### PR TITLE
Slice 1: Skills MVP

### DIFF
--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -75,5 +75,25 @@ Write-Host ""
 Write-Host "=== Publish Complete ===" -ForegroundColor Cyan
 Write-Host "Install dir: $InstallDir"
 Write-Host "Launch from: Start Menu, Desktop, or $exe"
+
+# 6. Install Copilot CLI skills (skills/ -> ~/.copilot/skills/)
+$skillsSrc = Join-Path $RepoRoot "skills"
+if (Test-Path $skillsSrc) {
+    $skillsDest = Join-Path $env:USERPROFILE ".copilot\skills"
+    Write-Host ""
+    Write-Host "Installing Copilot CLI skills to $skillsDest ..." -ForegroundColor Cyan
+    New-Item -ItemType Directory -Force -Path $skillsDest | Out-Null
+
+    $skillDirs = Get-ChildItem -Path $skillsSrc -Directory
+    foreach ($skill in $skillDirs) {
+        $destSkillDir = Join-Path $skillsDest $skill.Name
+        if (Test-Path $destSkillDir) {
+            Remove-Item -Recurse -Force $destSkillDir
+        }
+        Copy-Item -Recurse -Force -Path $skill.FullName -Destination $destSkillDir
+        Write-Host "  [OK] $($skill.Name)" -ForegroundColor Green
+    }
+}
+
 Write-Host ""
 Write-Host "To update after code changes, run this script again." -ForegroundColor Yellow

--- a/skills/glasswork-resume/SKILL.md
+++ b/skills/glasswork-resume/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: glasswork-resume
+description: Resume an in-flight Glasswork task. Use when the user pastes "Resume Glasswork task: <task-id>", asks to pick a Glasswork task back up, or hits the Glasswork app's "Resume" button.
+---
+
+# Glasswork — Resume
+
+You are picking a Glasswork task back up after a break. The user pasted a one-liner like `Resume Glasswork task: <task-id>` from the Glasswork app's **Resume** button. There is prior context in the task file you need to reload before doing anything.
+
+The task lives at `wiki/todo/<task-id>.md` in the user's wiki vault (typically `C:\Users\toegbeji\Wiki\`).
+
+## Process
+
+1. **Read the task file** at `wiki/todo/<task-id>.md` end-to-end. Parse the YAML frontmatter and the body.
+2. **Find where work left off**: look at the `## Notes` section. The **last `###` dated entry tells you where the user left off.** That entry is the most recent ground truth — read it carefully.
+3. **Reload context** by reading any `[[wiki-link]]` references mentioned in recent notes (decisions, concepts, etc.) so you have the same mental model the user had last time.
+4. **Re-orient out loud**: in 2–4 sentences, summarise:
+   - What this task is about.
+   - What was done last (per the most recent `###` note).
+   - What looks like the obvious next step.
+5. **Ask the user** whether your read of "where we left off" matches theirs and what they want to tackle now. Don't dive into work until they confirm.
+6. **Append a resume entry to `## Notes`** when you actually start doing something:
+   ```markdown
+   ### <YYYY-MM-DD>
+   Resumed. <one-line summary of what we agreed to tackle next>.
+   ```
+   New entries go at the bottom. Date-only is fine unless there are already multiple entries today.
+
+## Scope notes (V2 Slice 1)
+
+- The current task format is **flat** — no nested subtasks yet. Just read what the file contains.
+- Don't rewrite the existing `## Notes` log — append only.
+- Don't touch the `## Related` section. A later slice owns that.
+
+---
+
+## D8 Guardrails (apply to every action you take)
+
+These are **baked into this skill** and override any user request that conflicts.
+
+### ALLOWED freely
+- Read from any source: code, wiki vault, ADO, ICM, EngHub, EV2, the web.
+- Write to the wiki vault — the task's `## Notes` section, and other wiki pages (`decisions/`, `concepts/`, etc.) when the user asks.
+- **Suggest** task status changes, code changes, or next actions.
+
+### ALLOWED only with explicit confirmation
+- Set `status: done` on a task. (Always confirm — even when the user clearly said "done".)
+- Move a task file out of `wiki/todo/`.
+- Create a `wiki/accomplishments/` page.
+- Write source code. (You may **read** code freely; write only when the user explicitly says so.)
+- Run any command that mutates external state (git push, ADO comments, file deletes).
+
+### NEVER (hard rules — no override, even if the user asks)
+- **Do not send Teams messages, emails, or calendar invites.** Ever. No tool call, no draft, no "here's what to send" that you then offer to send. If the user wants to communicate with another human, they do it themselves.
+- Do not close or modify ADO work items beyond adding comments (and only with confirmation).
+- Do not approve or merge pull requests.
+- Do not delete files in the wiki vault.
+- Do not modify these task frontmatter fields: `id`, `created`, `ado`.
+- Do not commit or push code without an explicit user instruction in this session.
+
+If a request would require breaking a NEVER rule, refuse and explain which guardrail blocked it.

--- a/skills/glasswork-start-work/SKILL.md
+++ b/skills/glasswork-start-work/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: glasswork-start-work
+description: Start fresh work on a Glasswork task. Use when the user pastes "Start work on Glasswork task: <task-id>", asks to begin a Glasswork task, or kicks off a new task from the Glasswork app's "Start work" button.
+---
+
+# Glasswork — Start Work
+
+You are picking up a Glasswork task for the first time in this session. The user pasted a one-liner like `Start work on Glasswork task: <task-id>` from the Glasswork app's **Start work** button.
+
+The task lives as a markdown file in the user's wiki vault under `wiki/todo/<task-id>.md`. The vault root is typically `C:\Users\toegbeji\Wiki\` (confirm via the user's environment if unsure).
+
+## Process
+
+1. **Read the task file** at `wiki/todo/<task-id>.md`. Parse the YAML frontmatter and the body.
+2. **Orient**: state the title, status, priority, due date, and any ADO link out loud so the user can confirm you grabbed the right task.
+3. **Skim the description** (the body before any `## Notes` / `## Subtasks` section). Identify what's being asked.
+4. **Plan**: propose a short, ordered list of next steps. Keep it lightweight — this is the kickoff, not the whole project plan.
+5. **Confirm** with the user before doing any work: which step do they want you to start on?
+6. **Append a kickoff entry to `## Notes`** (if the section exists; otherwise create it at the bottom of the file). Format:
+   ```markdown
+   ## Notes
+
+   ### <YYYY-MM-DD>
+   Started work. <one-line summary of the plan you and the user agreed on>.
+   ```
+   Date-only is fine. Add new entries at the bottom of the section.
+
+## Scope notes (V2 Slice 1)
+
+- The current task format is **flat** — there are no nested subtasks yet, just whatever the file contains. Don't try to traverse a subtask tree.
+- Don't touch the `## Related` section. A later slice will own that maintenance.
+- Don't try to do tiered context routing yet. Keep notes inline in the task file.
+
+---
+
+## D8 Guardrails (apply to every action you take)
+
+These are **baked into this skill** and override any user request that conflicts.
+
+### ALLOWED freely
+- Read from any source: code, wiki vault, ADO, ICM, EngHub, EV2, the web.
+- Write to the wiki vault — the task's `## Notes` section, and other wiki pages (`decisions/`, `concepts/`, etc.) when the user asks.
+- **Suggest** task status changes, code changes, or next actions.
+
+### ALLOWED only with explicit confirmation
+- Set `status: done` on a task. (Always confirm — even when the user clearly said "done".)
+- Move a task file out of `wiki/todo/`.
+- Create a `wiki/accomplishments/` page.
+- Write source code. (You may **read** code freely; write only when the user explicitly says so.)
+- Run any command that mutates external state (git push, ADO comments, file deletes).
+
+### NEVER (hard rules — no override, even if the user asks)
+- **Do not send Teams messages, emails, or calendar invites.** Ever. No tool call, no draft, no "here's what to send" that you then offer to send. If the user wants to communicate with another human, they do it themselves.
+- Do not close or modify ADO work items beyond adding comments (and only with confirmation).
+- Do not approve or merge pull requests.
+- Do not delete files in the wiki vault.
+- Do not modify these task frontmatter fields: `id`, `created`, `ado`.
+- Do not commit or push code without an explicit user instruction in this session.
+
+If a request would require breaking a NEVER rule, refuse and explain which guardrail blocked it.

--- a/skills/glasswork-wrap-up/SKILL.md
+++ b/skills/glasswork-wrap-up/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: glasswork-wrap-up
+description: Wrap up a Glasswork task that's done or being parked. Use when the user pastes "Wrap up Glasswork task: <task-id>", asks to finish/close a Glasswork task, or hits the Glasswork app's "Wrap up" button.
+---
+
+# Glasswork — Wrap Up
+
+The user is finishing (or parking) a Glasswork task. They pasted a one-liner like `Wrap up Glasswork task: <task-id>` from the Glasswork app's **Wrap up** button. Your job is to close the loop cleanly: leave behind a task file that future-you can understand at a glance.
+
+The task lives at `wiki/todo/<task-id>.md` in the user's wiki vault (typically `C:\Users\toegbeji\Wiki\`).
+
+## Process
+
+1. **Read the task file** at `wiki/todo/<task-id>.md` end-to-end. Parse the YAML frontmatter and the body.
+2. **Read recent `## Notes` entries** to understand what actually happened during the work.
+3. **Append a wrap-up entry to `## Notes`** capturing what was done and any loose ends:
+   ```markdown
+   ### <YYYY-MM-DD>
+   Wrapping up. <2–4 lines: what was accomplished, what's left, any follow-ups.>
+   ```
+4. **Propose a status change** to the user:
+   - If the work is genuinely complete → propose `status: done`.
+   - If it's being parked / handed off → propose another status (e.g. `blocked`, or leaving it as-is) and explain why.
+   - **You must get explicit confirmation before changing `status` to `done`.** Never set it silently.
+5. **Ask whether to mark substantial work as an accomplishment.** If the work feels meaningful (not a routine fix), propose creating `wiki/accomplishments/<title>-<date>.md` and ask the user to confirm before creating it.
+6. **Summarise what you did** at the end of the session: which fields you changed, which files you touched, any open follow-ups the user might want to capture as new tasks.
+
+## Scope notes (V2 Slice 1)
+
+- The current task format is **flat** — there are no nested subtasks to verify yet. Don't try to walk a subtask tree or enforce "every subtask must be done/dropped."
+- **Do not move the file** out of `wiki/todo/` in this slice. The "move to `done/`" step is a later slice.
+- **Do not rewrite or compress the existing `## Notes` log.** Just append the wrap-up entry. Summarising the log is a later slice.
+- Don't touch the `## Related` section. A later slice owns that maintenance.
+
+---
+
+## D8 Guardrails (apply to every action you take)
+
+These are **baked into this skill** and override any user request that conflicts.
+
+### ALLOWED freely
+- Read from any source: code, wiki vault, ADO, ICM, EngHub, EV2, the web.
+- Write to the wiki vault — the task's `## Notes` section, and other wiki pages (`decisions/`, `concepts/`, etc.) when the user asks.
+- **Suggest** task status changes, code changes, or next actions.
+
+### ALLOWED only with explicit confirmation
+- Set `status: done` on a task. **Always confirm — even in wrap-up. This is the most common case where the rule matters.**
+- Move a task file out of `wiki/todo/` (out of scope this slice anyway).
+- Create a `wiki/accomplishments/` page.
+- Write source code. (You may **read** code freely; write only when the user explicitly says so.)
+- Run any command that mutates external state (git push, ADO comments, file deletes).
+
+### NEVER (hard rules — no override, even if the user asks)
+- **Do not send Teams messages, emails, or calendar invites.** Ever. No tool call, no draft, no "here's what to send" that you then offer to send. Even at wrap-up, even if the user says "let people know I'm done" — they do that themselves.
+- Do not close or modify ADO work items beyond adding comments (and only with confirmation).
+- Do not approve or merge pull requests.
+- Do not delete files in the wiki vault.
+- Do not modify these task frontmatter fields: `id`, `created`, `ado`.
+- Do not commit or push code without an explicit user instruction in this session.
+
+If a request would require breaking a NEVER rule, refuse and explain which guardrail blocked it.

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml
@@ -67,6 +67,14 @@
                 <TextBlock x:Name="IdText" FontSize="12" />
             </StackPanel>
 
+            <!-- Agent invocation buttons (copy one-liner to clipboard, paste into Copilot CLI) -->
+            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
+                <Button x:Name="StartWorkButton" Content="Start work" Click="StartWork_Click" />
+                <Button x:Name="ResumeButton" Content="Resume" Click="Resume_Click" />
+                <Button x:Name="WrapUpButton" Content="Wrap up" Click="WrapUp_Click" />
+                <TextBlock x:Name="ClipboardHint" VerticalAlignment="Center" Opacity="0.6" FontSize="12" />
+            </StackPanel>
+
             <!-- Actions -->
             <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,16,0,0">
                 <Button Content="Delete" Click="Delete_Click" />

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -108,6 +108,23 @@ public sealed partial class TaskDetailPage : Page
         }
     }
 
+    private void StartWork_Click(object sender, RoutedEventArgs e)
+        => CopyInvocation(TaskInvocationFormatter.FormatStartWork(Task.Id));
+
+    private void Resume_Click(object sender, RoutedEventArgs e)
+        => CopyInvocation(TaskInvocationFormatter.FormatResume(Task.Id));
+
+    private void WrapUp_Click(object sender, RoutedEventArgs e)
+        => CopyInvocation(TaskInvocationFormatter.FormatWrapUp(Task.Id));
+
+    private void CopyInvocation(string line)
+    {
+        var pkg = new Windows.ApplicationModel.DataTransfer.DataPackage();
+        pkg.SetText(line);
+        Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(pkg);
+        ClipboardHint.Text = "Copied — paste into your Copilot CLI session.";
+    }
+
     private void Save() => App.Vault.Save(Task);
 
     private static void SetComboByTag(ComboBox combo, string tag)

--- a/src/Glasswork.Core/Services/TaskInvocationFormatter.cs
+++ b/src/Glasswork.Core/Services/TaskInvocationFormatter.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Glasswork.Core.Services;
+
+/// <summary>
+/// Formats the one-liner invocations that the TaskDetailPage buttons copy to the clipboard.
+/// The user pastes these into a Copilot CLI session, where the matching glasswork-* skill activates.
+/// </summary>
+public static class TaskInvocationFormatter
+{
+    public static string FormatStartWork(string taskId) =>
+        $"Start work on Glasswork task: {Require(taskId)}";
+
+    public static string FormatResume(string taskId) =>
+        $"Resume Glasswork task: {Require(taskId)}";
+
+    public static string FormatWrapUp(string taskId) =>
+        $"Wrap up Glasswork task: {Require(taskId)}";
+
+    private static string Require(string taskId)
+    {
+        if (string.IsNullOrWhiteSpace(taskId))
+            throw new ArgumentException("Task id must not be null or whitespace.", nameof(taskId));
+        return taskId;
+    }
+}

--- a/tests/Glasswork.Tests/TaskInvocationFormatterTests.cs
+++ b/tests/Glasswork.Tests/TaskInvocationFormatterTests.cs
@@ -1,0 +1,37 @@
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class TaskInvocationFormatterTests
+{
+    [TestMethod]
+    public void FormatStartWork_IncludesTaskId()
+    {
+        var line = TaskInvocationFormatter.FormatStartWork("2026-04-18-fix-login");
+        Assert.AreEqual("Start work on Glasswork task: 2026-04-18-fix-login", line);
+    }
+
+    [TestMethod]
+    public void FormatResume_IncludesTaskId()
+    {
+        var line = TaskInvocationFormatter.FormatResume("2026-04-18-fix-login");
+        Assert.AreEqual("Resume Glasswork task: 2026-04-18-fix-login", line);
+    }
+
+    [TestMethod]
+    public void FormatWrapUp_IncludesTaskId()
+    {
+        var line = TaskInvocationFormatter.FormatWrapUp("2026-04-18-fix-login");
+        Assert.AreEqual("Wrap up Glasswork task: 2026-04-18-fix-login", line);
+    }
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   ")]
+    public void FormatStartWork_RejectsMissingTaskId(string? taskId)
+    {
+        Assert.ThrowsExactly<ArgumentException>(() => TaskInvocationFormatter.FormatStartWork(taskId!));
+    }
+}


### PR DESCRIPTION
Closes #1

## What's in this slice

The tracer-bullet for V2's agent loop. Three Copilot CLI skills + three buttons in TaskDetailPage that copy a one-liner to the clipboard. The user pastes that into their Copilot CLI session and the matching skill activates.

## Files

- `skills/glasswork-start-work/SKILL.md`
- `skills/glasswork-resume/SKILL.md`
- `skills/glasswork-wrap-up/SKILL.md`
- `src/Glasswork.Core/Services/TaskInvocationFormatter.cs` (new)
- `tests/Glasswork.Tests/TaskInvocationFormatterTests.cs` (new, 6 tests)
- `src/Glasswork.App/Pages/TaskDetailPage.xaml` + `.xaml.cs` — three buttons
- `scripts/publish.ps1` — copies `skills/*` to `~/.copilot/skills/`

## D8 guardrails

Every skill has the full D8 block: `ALLOWED freely` / `ALLOWED with confirmation` / `NEVER`. The `NEVER` list leads with the hard rule: no Teams, email, or calendar comms — no override, no drafts, no tool calls.

## Tests

- Baseline: 33 passing
- After this slice: **39 passing** (added 6 for `TaskInvocationFormatter`)
- Build: `dotnet build src\Glasswork.App -p:Platform=x64` succeeds

## Smoke test (manual, post-merge)

The skills aren't installed by this PR — the user runs `scripts\publish.ps1` to install them.

**Setup**
1. Pull main, run `.\scripts\publish.ps1`.
2. Confirm `~/.copilot/skills/glasswork-start-work/SKILL.md` (and `-resume`, `-wrap-up`) exist.
3. Launch Glasswork from the Start Menu shortcut.
4. Open any existing task in the wiki vault.

**glasswork-start-work**
1. Click **Start work**. Confirm the hint reads `Copied — paste into your Copilot CLI session.`
2. Open a fresh Copilot CLI session in the wiki vault directory and paste. The pasted line should look like `Start work on Glasswork task: <task-id>`.
3. Verify the `glasswork-start-work` skill activates (Copilot will mention it).
4. Verify the agent reads `wiki/todo/<task-id>.md`, states the title/status/priority back, proposes a plan, and **waits for your go-ahead** before doing anything.
5. Tell it to start step 1. Confirm it appends a `### <today>` entry under `## Notes`.

**glasswork-resume**
1. With the same task (now with prior notes), click **Resume**.
2. Paste into a new Copilot CLI session.
3. Verify the agent re-reads the file, finds the **last `###` entry** in `## Notes`, and summarises `what we did last`.
4. Verify it asks before tackling the next step.
5. Confirm a new `### <today>` entry is appended (`Resumed. ...`) when work begins.

**glasswork-wrap-up**
1. Click **Wrap up**, paste into Copilot CLI.
2. Verify the agent reads the task, proposes a wrap-up summary, and appends a `### <today>` `Wrapping up.` entry to `## Notes`.
3. Verify it **asks for explicit confirmation** before changing `status` to `done` (D8: even in wrap-up, always confirm).
4. Verify it does **not** move the file out of `wiki/todo/` (out of scope this slice).
5. Verify it does **not** rewrite or compress the existing notes log.

**Guardrail check (any skill)**
1. Ask the agent to `message <coworker> on Teams that this is done` (or send an email / make a calendar invite).
2. Verify it refuses and cites the D8 NEVER rule. No drafts, no tool calls, no offers to send.

## Out of scope (later slices)

- Subtask awareness (slice 3)
- Tiered context routing — decisions/concepts/etc. (slice 4)
- Timestamped notes log compression on wrap-up (slice 5)
- `## Related` section maintenance (slice 5)
- Moving wrapped-up tasks to `wiki/todo/done/`