### PR TITLE
Slice 2: Subtask basics

### DIFF
--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -84,7 +84,14 @@ public sealed partial class TaskDetailPage : Page
         Save();
     }
 
-    private void Subtask_Click(object sender, RoutedEventArgs e) => Save();
+    private void Subtask_Click(object sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        if (sender is CheckBox cb && cb.DataContext is SubTask sub)
+        {
+            App.Vault.UpdateSubtaskCheckbox(Task.Id, sub.Text, cb.IsChecked == true);
+        }
+    }
 
     private void Delete_Click(object sender, RoutedEventArgs e)
     {

--- a/src/Glasswork.Core/Services/FrontmatterParser.cs
+++ b/src/Glasswork.Core/Services/FrontmatterParser.cs
@@ -29,8 +29,11 @@ public partial class FrontmatterParser
     [GeneratedRegex(@"^---\s*\n(.*?)\n---\s*\n?(.*)", RegexOptions.Singleline)]
     private static partial Regex FrontmatterRegex();
 
-    [GeneratedRegex(@"^- \[([ xX])\] (.+)$", RegexOptions.Multiline)]
-    private static partial Regex CheckboxRegex();
+    [GeneratedRegex(@"^### \[([ xX])\] (.+?)\s*$", RegexOptions.Multiline)]
+    private static partial Regex SubtaskHeadingRegex();
+
+    [GeneratedRegex(@"(?ms)^## Subtasks\s*$(.*?)(?=^## |\z)", RegexOptions.Multiline)]
+    private static partial Regex SubtasksSectionRegex();
 
     /// <summary>
     /// Parse a markdown file's content into a GlassworkTask.
@@ -109,10 +112,13 @@ public partial class FrontmatterParser
 
         if (task.Subtasks.Count > 0)
         {
+            sb.AppendLine("## Subtasks");
+            sb.AppendLine();
             foreach (var sub in task.Subtasks)
             {
                 var check = sub.IsCompleted ? "x" : " ";
-                sb.AppendLine($"- [{check}] {sub.Text}");
+                sb.AppendLine($"### [{check}] {sub.Text}");
+                sb.AppendLine();
             }
         }
 
@@ -122,9 +128,13 @@ public partial class FrontmatterParser
     private static (List<SubTask> subtasks, string cleanBody) ParseSubtasks(string body)
     {
         var subtasks = new List<SubTask>();
-        var matches = CheckboxRegex().Matches(body);
+        var sectionMatch = SubtasksSectionRegex().Match(body);
 
-        foreach (Match m in matches)
+        if (!sectionMatch.Success)
+            return (subtasks, body.Trim());
+
+        var sectionContent = sectionMatch.Groups[1].Value;
+        foreach (Match m in SubtaskHeadingRegex().Matches(sectionContent))
         {
             subtasks.Add(new SubTask
             {
@@ -133,8 +143,8 @@ public partial class FrontmatterParser
             });
         }
 
-        // Remove checkbox lines from body to get clean prose
-        var cleanBody = CheckboxRegex().Replace(body, "").Trim();
+        // Body is everything before the ## Subtasks heading.
+        var cleanBody = body[..sectionMatch.Index].Trim();
         return (subtasks, cleanBody);
     }
 

--- a/src/Glasswork.Core/Services/VaultService.cs
+++ b/src/Glasswork.Core/Services/VaultService.cs
@@ -66,6 +66,29 @@ public class VaultService
     }
 
     /// <summary>
+    /// Targeted edit: toggle a single subtask checkbox on disk by replacing only the
+    /// `### [ ]` / `### [x]` character on the matching line. The rest of the file is left
+    /// byte-for-byte untouched. No-op if the title is not found.
+    /// </summary>
+    public void UpdateSubtaskCheckbox(string taskId, string subtaskTitle, bool isCompleted)
+    {
+        var path = GetFilePath(taskId);
+        if (!File.Exists(path)) return;
+
+        var content = File.ReadAllText(path);
+        var newCheck = isCompleted ? "x" : " ";
+        var pattern = @"^### \[[ xX]\] " + System.Text.RegularExpressions.Regex.Escape(subtaskTitle) + @"\s*$";
+        var regex = new System.Text.RegularExpressions.Regex(pattern, System.Text.RegularExpressions.RegexOptions.Multiline);
+
+        var match = regex.Match(content);
+        if (!match.Success) return;
+
+        var updated = content[..match.Index] + $"### [{newCheck}] {subtaskTitle}" + content[(match.Index + match.Length)..];
+        if (updated != content)
+            File.WriteAllText(path, updated);
+    }
+
+    /// <summary>
     /// Save a task to disk. Creates or overwrites the file.
     /// </summary>
     public void Save(GlassworkTask task)

--- a/tests/Glasswork.Tests/FrontmatterParserTests.cs
+++ b/tests/Glasswork.Tests/FrontmatterParserTests.cs
@@ -33,8 +33,10 @@ public class FrontmatterParserTests
 
             Some notes about this task.
 
-            - [x] Step one done
-            - [ ] Step two pending
+            ## Subtasks
+
+            ### [x] Step one done
+            ### [ ] Step two pending
             """;
 
         var task = _parser.Parse(markdown);
@@ -111,6 +113,134 @@ public class FrontmatterParserTests
         Assert.AreEqual(original.Subtasks.Count, parsed.Subtasks.Count);
         Assert.AreEqual(original.Subtasks[0].Text, parsed.Subtasks[0].Text);
         Assert.AreEqual(original.Subtasks[0].IsCompleted, parsed.Subtasks[0].IsCompleted);
+    }
+
+    [TestMethod]
+    public void Parse_SingleUncheckedH3Subtask_ReturnsOneIncompleteSubtask()
+    {
+        var markdown = """
+            ---
+            id: t
+            title: T
+            ---
+
+            ## Subtasks
+
+            ### [ ] Plain title
+            """;
+
+        var task = _parser.Parse(markdown);
+
+        Assert.AreEqual(1, task.Subtasks.Count);
+        Assert.AreEqual("Plain title", task.Subtasks[0].Text);
+        Assert.IsFalse(task.Subtasks[0].IsCompleted);
+    }
+
+    [TestMethod]
+    public void Parse_SingleCheckedH3Subtask_ReturnsCompletedSubtask()
+    {
+        var markdown = """
+            ---
+            id: t
+            title: T
+            ---
+
+            ## Subtasks
+
+            ### [x] Done thing
+            """;
+
+        var task = _parser.Parse(markdown);
+
+        Assert.AreEqual(1, task.Subtasks.Count);
+        Assert.AreEqual("Done thing", task.Subtasks[0].Text);
+        Assert.IsTrue(task.Subtasks[0].IsCompleted);
+    }
+
+    [TestMethod]
+    public void Parse_MultipleH3Subtasks_PreservesOrderAndStates()
+    {
+        var markdown = """
+            ---
+            id: t
+            title: T
+            ---
+
+            Some prose body.
+
+            ## Subtasks
+
+            ### [ ] First
+            ### [x] Second
+            ### [ ] Third
+            """;
+
+        var task = _parser.Parse(markdown);
+
+        Assert.AreEqual(3, task.Subtasks.Count);
+        Assert.AreEqual("First", task.Subtasks[0].Text);
+        Assert.IsFalse(task.Subtasks[0].IsCompleted);
+        Assert.AreEqual("Second", task.Subtasks[1].Text);
+        Assert.IsTrue(task.Subtasks[1].IsCompleted);
+        Assert.AreEqual("Third", task.Subtasks[2].Text);
+        Assert.IsFalse(task.Subtasks[2].IsCompleted);
+        Assert.AreEqual("Some prose body.", task.Body);
+    }
+
+    [TestMethod]
+    public void Parse_V1TaskWithoutSubtasksSection_ReturnsEmptySubtaskList()
+    {
+        var markdown = """
+            ---
+            id: legacy-v1
+            title: Legacy V1 task
+            status: todo
+            priority: medium
+            created: 2026-01-01
+            ---
+
+            Just a body of plain notes, no subtasks heading at all.
+            """;
+
+        var task = _parser.Parse(markdown);
+
+        Assert.AreEqual("legacy-v1", task.Id);
+        Assert.AreEqual(0, task.Subtasks.Count);
+        Assert.AreEqual("Just a body of plain notes, no subtasks heading at all.", task.Body);
+    }
+
+    [TestMethod]
+    public void Parse_ToggleSerialize_Reparse_PreservesSubtaskState()
+    {
+        var markdown = """
+            ---
+            id: round-trip-sub
+            title: Round trip
+            ---
+
+            ## Subtasks
+
+            ### [ ] Alpha
+            ### [ ] Beta
+            ### [x] Gamma
+            """;
+
+        var task = _parser.Parse(markdown);
+        Assert.AreEqual(3, task.Subtasks.Count);
+
+        // Toggle: complete Beta, uncomplete Gamma
+        task.Subtasks[1].IsCompleted = true;
+        task.Subtasks[2].IsCompleted = false;
+
+        var roundTripped = _parser.Parse(_parser.Serialize(task));
+
+        Assert.AreEqual(3, roundTripped.Subtasks.Count);
+        Assert.AreEqual("Alpha", roundTripped.Subtasks[0].Text);
+        Assert.IsFalse(roundTripped.Subtasks[0].IsCompleted);
+        Assert.AreEqual("Beta", roundTripped.Subtasks[1].Text);
+        Assert.IsTrue(roundTripped.Subtasks[1].IsCompleted);
+        Assert.AreEqual("Gamma", roundTripped.Subtasks[2].Text);
+        Assert.IsFalse(roundTripped.Subtasks[2].IsCompleted);
     }
 
     [TestMethod]

--- a/tests/Glasswork.Tests/VaultServiceTests.cs
+++ b/tests/Glasswork.Tests/VaultServiceTests.cs
@@ -109,4 +109,66 @@ public class VaultServiceTests
         var id = VaultService.GenerateId(longTitle);
         Assert.IsTrue(id.Length <= 60);
     }
+
+    [TestMethod]
+    public void UpdateSubtaskCheckbox_TogglesSingleCharacter_LeavesRestOfFileByteForByteUntouched()
+    {
+        var taskId = "targeted-edit";
+        var original =
+            "---\n" +
+            "id: targeted-edit\n" +
+            "title: Targeted edit task\n" +
+            "---\n" +
+            "\n" +
+            "Body line that must not change.\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] First sub\n" +
+            "### [ ] Second sub\n" +
+            "### [x] Third sub\n";
+
+        var path = Path.Combine(_tempDir, $"{taskId}.md");
+        File.WriteAllText(path, original);
+
+        _vault.UpdateSubtaskCheckbox(taskId, "Second sub", isCompleted: true);
+
+        var actual = File.ReadAllText(path);
+        var expected =
+            "---\n" +
+            "id: targeted-edit\n" +
+            "title: Targeted edit task\n" +
+            "---\n" +
+            "\n" +
+            "Body line that must not change.\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] First sub\n" +
+            "### [x] Second sub\n" +
+            "### [x] Third sub\n";
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void UpdateSubtaskCheckbox_TitleNotFound_LeavesFileUnchanged()
+    {
+        var taskId = "no-such-sub";
+        var original =
+            "---\n" +
+            "id: no-such-sub\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] Only one\n";
+        var path = Path.Combine(_tempDir, $"{taskId}.md");
+        File.WriteAllText(path, original);
+
+        _vault.UpdateSubtaskCheckbox(taskId, "Missing title", isCompleted: true);
+
+        Assert.AreEqual(original, File.ReadAllText(path));
+    }
 }


### PR DESCRIPTION
Closes #2

## Summary
Implements minimal subtask system for Glasswork V2 (slice 2 only).

- Parser recognizes `### [ ] Title` / `### [x] Title` lines under a `## Subtasks` heading and populates `GlassworkTask.Subtasks`.
- Serializer emits the same format. Body is preserved separately from the subtasks section.
- V1 task files (no `## Subtasks` section) load with `Subtasks = []`.
- New `VaultService.UpdateSubtaskCheckbox(taskId, subtaskTitle, isCompleted)` performs a **targeted single-line edit** (regex replace + write) instead of rewriting the whole file. No-op if the title is not found.
- `TaskDetailPage` checkbox click handler now calls `UpdateSubtaskCheckbox` instead of `Save` to honor the targeted-edit contract from PRD decision D12.

## Tests
- 33 baseline -> **40 passing** (7 new). Updated one existing parser fixture from `- [x]` to `### [x]` format.
- New tests: single unchecked, single checked, multiple, V1 backcompat, toggle round-trip, targeted-edit byte-for-byte assertion, missing-title no-op.

## Files changed
- `src/Glasswork.Core/Services/FrontmatterParser.cs`
- `src/Glasswork.Core/Services/VaultService.cs`
- `src/Glasswork.App/Pages/TaskDetailPage.xaml.cs`
- `tests/Glasswork.Tests/FrontmatterParserTests.cs`
- `tests/Glasswork.Tests/VaultServiceTests.cs`

## TODO (out of scope for this slice)
- User must update `C:\Users\toegbeji\Wiki\wiki\todo\_schema.md` manually with the new `## Subtasks` section spec (wiki is outside repo scope).
- Existing `SubTask` class kept (not renamed to `Subtask`) to avoid touching unrelated call sites; class lives at `src/Glasswork.Core/Models/GlassworkTask.cs`.
- `GlassworkTask.Subtasks` model property already existed and is wired through `FrontmatterParser.Parse` via `ParseSubtasks`.