### PR TITLE
Slice 7: File watcher wired

### DIFF
--- a/src/Glasswork.App/App.xaml.cs
+++ b/src/Glasswork.App/App.xaml.cs
@@ -19,6 +19,15 @@ public partial class App : Application
     public static TaskService Tasks { get; private set; } = null!;
     public static IndexService Index { get; private set; } = null!;
     public static FeedbackService? Feedback { get; private set; }
+    public static FileWatcherService? Watcher { get; private set; }
+    public static ActiveTaskTracker ActiveTask { get; } = new();
+    private static Debouncer? _indexDebouncer;
+
+    /// <summary>
+    /// Raised on a thread-pool thread when an external change to a task file is observed.
+    /// Subscribers must marshal to the dispatcher before touching UI.
+    /// </summary>
+    public static event EventHandler<string>? TaskFileChangedExternally;
 
     [DllImport("shell32.dll", SetLastError = true)]
     private static extern void SetCurrentProcessExplicitAppUserModelID(
@@ -54,7 +63,29 @@ public partial class App : Application
         if (!string.IsNullOrEmpty(ghToken))
             Feedback = new FeedbackService("tjegbejimba", "Glasswork", ghToken);
 
+        // File watcher: external (Obsidian / agent) edits to task files trigger
+        // a debounced index regeneration and notify any open page.
+        // FileSystemWatcher events fire on thread-pool threads — anything
+        // touching UI in a subscriber must marshal via DispatcherQueue.
+        _indexDebouncer = new Debouncer(TimeSpan.FromMilliseconds(500), () =>
+        {
+            try { Index.Refresh(); }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Index refresh failed: {ex.Message}"); }
+        });
+
+        Watcher = new FileWatcherService(vaultPath);
+        Watcher.TaskFileChanged += OnTaskFileChanged;
+        Watcher.Start();
+
         _window = new MainWindow();
         _window.Activate();
+    }
+
+    private static void OnTaskFileChanged(object? sender, string fileName)
+    {
+        // Always coalesce index regen across rapid edits.
+        _indexDebouncer?.Trigger();
+        // Fan out to UI subscribers (BacklogPage / MyDayPage / TaskDetailPage).
+        TaskFileChangedExternally?.Invoke(sender, fileName);
     }
 }

--- a/src/Glasswork.App/Pages/BacklogPage.xaml.cs
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml.cs
@@ -21,6 +21,19 @@ public sealed partial class BacklogPage : Page
     {
         base.OnNavigatedTo(e);
         ViewModel.Refresh();
+        App.TaskFileChangedExternally += OnFileChanged;
+    }
+
+    protected override void OnNavigatedFrom(NavigationEventArgs e)
+    {
+        base.OnNavigatedFrom(e);
+        App.TaskFileChangedExternally -= OnFileChanged;
+    }
+
+    private void OnFileChanged(object? sender, string fileName)
+    {
+        // Watcher fires on thread-pool thread; marshal to UI thread before refresh.
+        DispatcherQueue.TryEnqueue(() => ViewModel.Refresh());
     }
 
     private void StatusFilter_Changed(object sender, SelectionChangedEventArgs e)

--- a/src/Glasswork.App/Pages/MyDayPage.xaml.cs
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml.cs
@@ -22,6 +22,18 @@ public sealed partial class MyDayPage : Page
     {
         base.OnNavigatedTo(e);
         ViewModel.Refresh();
+        App.TaskFileChangedExternally += OnFileChanged;
+    }
+
+    protected override void OnNavigatedFrom(NavigationEventArgs e)
+    {
+        base.OnNavigatedFrom(e);
+        App.TaskFileChangedExternally -= OnFileChanged;
+    }
+
+    private void OnFileChanged(object? sender, string fileName)
+    {
+        DispatcherQueue.TryEnqueue(() => ViewModel.Refresh());
     }
 
     private void TodayList_ItemClick(object sender, ItemClickEventArgs e)

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml
@@ -10,6 +10,19 @@
     <ScrollViewer Padding="32">
         <StackPanel Spacing="16">
 
+            <!-- Reload banner: shown when the open file is changed externally -->
+            <InfoBar x:Name="ReloadBanner"
+                     IsOpen="False"
+                     IsClosable="False"
+                     Severity="Warning"
+                     Title="This file changed on disk"
+                     Message="Another tool (e.g. Obsidian or an agent) modified this task while you were editing it.">
+                <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
+                    <Button Content="Reload" Click="Reload_Click" />
+                    <Button Content="Keep my version" Click="KeepMine_Click" />
+                </StackPanel>
+            </InfoBar>
+
             <!-- Title -->
             <TextBox x:Name="TitleBox" Header="Title" FontSize="18"
                      Text="{x:Bind Task.Title, Mode=TwoWay}"

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -26,6 +26,8 @@ public sealed partial class TaskDetailPage : Page
         {
             _isLoading = true;
             Task = task;
+            App.ActiveTask.ActiveTaskId = task.Id;
+            App.TaskFileChangedExternally += OnFileChangedExternally;
 
             // Set combo boxes to match task state
             SetComboByTag(StatusBox, task.Status);
@@ -50,6 +52,41 @@ public sealed partial class TaskDetailPage : Page
 
             _isLoading = false;
         }
+    }
+
+    protected override void OnNavigatedFrom(NavigationEventArgs e)
+    {
+        base.OnNavigatedFrom(e);
+        App.TaskFileChangedExternally -= OnFileChangedExternally;
+        App.ActiveTask.Clear();
+    }
+
+    private void OnFileChangedExternally(object? sender, string fileName)
+    {
+        if (!App.ActiveTask.IsActive(fileName)) return;
+        // Watcher fires on a thread-pool thread; show the banner on the UI thread.
+        DispatcherQueue.TryEnqueue(() => ReloadBanner.IsOpen = true);
+    }
+
+    private void Reload_Click(object sender, RoutedEventArgs e)
+    {
+        var fresh = App.Vault.Load(Task.Id);
+        if (fresh is not null)
+        {
+            // Re-navigate with the freshly-loaded task to reset all bound state.
+            ReloadBanner.IsOpen = false;
+            Frame.Navigate(typeof(TaskDetailPage), fresh);
+        }
+        else
+        {
+            ReloadBanner.IsOpen = false;
+        }
+    }
+
+    private void KeepMine_Click(object sender, RoutedEventArgs e)
+    {
+        // Dismiss only — the next Save() will overwrite the on-disk change.
+        ReloadBanner.IsOpen = false;
     }
 
     private void Field_LostFocus(object sender, RoutedEventArgs e)

--- a/src/Glasswork.Core/Services/ActiveTaskTracker.cs
+++ b/src/Glasswork.Core/Services/ActiveTaskTracker.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+
+namespace Glasswork.Core.Services;
+
+/// <summary>
+/// Tracks which task is currently open in the UI so the file watcher consumer
+/// can decide whether an external change should silently refresh data or
+/// surface a "this file changed on disk" reload banner.
+/// </summary>
+public class ActiveTaskTracker
+{
+    /// <summary>
+    /// The id (matching the markdown file basename) of the task currently being
+    /// edited, or <c>null</c> if no task detail page is active.
+    /// </summary>
+    public string? ActiveTaskId { get; set; }
+
+    /// <summary>
+    /// Returns true if the given file name corresponds to the active task.
+    /// Accepts file names with or without the <c>.md</c> extension.
+    /// </summary>
+    public bool IsActive(string fileName)
+    {
+        if (string.IsNullOrEmpty(ActiveTaskId)) return false;
+        if (string.IsNullOrEmpty(fileName)) return false;
+
+        var basename = Path.GetFileNameWithoutExtension(fileName);
+        return string.Equals(basename, ActiveTaskId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public void Clear() => ActiveTaskId = null;
+}

--- a/src/Glasswork.Core/Services/Debouncer.cs
+++ b/src/Glasswork.Core/Services/Debouncer.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Glasswork.Core.Services;
+
+/// <summary>
+/// Coalesces rapid calls to <see cref="Trigger"/> into a single delayed action,
+/// firing once after a quiet period has elapsed since the most recent trigger.
+/// Thread-safe. The action runs on a thread-pool thread; callers needing UI
+/// affinity must marshal to the dispatcher themselves.
+/// </summary>
+public sealed class Debouncer : IDisposable
+{
+    private readonly TimeSpan _quietPeriod;
+    private readonly Action _action;
+    private readonly object _lock = new();
+    private CancellationTokenSource? _cts;
+    private bool _disposed;
+
+    public Debouncer(TimeSpan quietPeriod, Action action)
+    {
+        _quietPeriod = quietPeriod;
+        _action = action ?? throw new ArgumentNullException(nameof(action));
+    }
+
+    public void Trigger()
+    {
+        CancellationToken token;
+        lock (_lock)
+        {
+            if (_disposed) return;
+            _cts?.Cancel();
+            _cts?.Dispose();
+            _cts = new CancellationTokenSource();
+            token = _cts.Token;
+        }
+
+        _ = Task.Delay(_quietPeriod, token).ContinueWith(t =>
+        {
+            if (t.IsCanceled) return;
+            try { _action(); }
+            catch { /* swallow — debouncer must not crash producers */ }
+        }, TaskScheduler.Default);
+    }
+
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _cts?.Cancel();
+            _cts?.Dispose();
+            _cts = null;
+        }
+    }
+}

--- a/tests/Glasswork.Tests/ActiveTaskTrackerTests.cs
+++ b/tests/Glasswork.Tests/ActiveTaskTrackerTests.cs
@@ -1,0 +1,51 @@
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class ActiveTaskTrackerTests
+{
+    [TestMethod]
+    public void IsActive_ReturnsFalse_WhenNoActiveTask()
+    {
+        var tracker = new ActiveTaskTracker();
+        Assert.IsFalse(tracker.IsActive("any-file.md"));
+    }
+
+    [TestMethod]
+    public void IsActive_ReturnsTrue_WhenFileMatchesActiveTaskId()
+    {
+        var tracker = new ActiveTaskTracker { ActiveTaskId = "fix-login-bug" };
+        Assert.IsTrue(tracker.IsActive("fix-login-bug.md"));
+    }
+
+    [TestMethod]
+    public void IsActive_ReturnsTrue_WhenFileNameWithoutExtensionMatches()
+    {
+        var tracker = new ActiveTaskTracker { ActiveTaskId = "task-123" };
+        Assert.IsTrue(tracker.IsActive("task-123"));
+    }
+
+    [TestMethod]
+    public void IsActive_ReturnsFalse_WhenDifferentTask()
+    {
+        var tracker = new ActiveTaskTracker { ActiveTaskId = "task-a" };
+        Assert.IsFalse(tracker.IsActive("task-b.md"));
+    }
+
+    [TestMethod]
+    public void IsActive_IsCaseInsensitive()
+    {
+        var tracker = new ActiveTaskTracker { ActiveTaskId = "MyTask" };
+        Assert.IsTrue(tracker.IsActive("mytask.md"));
+    }
+
+    [TestMethod]
+    public void Clear_RemovesActiveTask()
+    {
+        var tracker = new ActiveTaskTracker { ActiveTaskId = "x" };
+        tracker.Clear();
+        Assert.IsNull(tracker.ActiveTaskId);
+        Assert.IsFalse(tracker.IsActive("x.md"));
+    }
+}

--- a/tests/Glasswork.Tests/DebouncerTests.cs
+++ b/tests/Glasswork.Tests/DebouncerTests.cs
@@ -1,0 +1,81 @@
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class DebouncerTests
+{
+    [TestMethod]
+    public void Trigger_FiresActionAfterQuietPeriod()
+    {
+        int count = 0;
+        var signal = new ManualResetEventSlim(false);
+        using var debouncer = new Debouncer(TimeSpan.FromMilliseconds(100), () =>
+        {
+            Interlocked.Increment(ref count);
+            signal.Set();
+        });
+
+        debouncer.Trigger();
+
+        Assert.IsTrue(signal.Wait(TimeSpan.FromSeconds(2)), "Action should fire");
+        Assert.AreEqual(1, count);
+    }
+
+    [TestMethod]
+    public void Trigger_CoalescesRapidCallsIntoSingleAction()
+    {
+        int count = 0;
+        var signal = new ManualResetEventSlim(false);
+        using var debouncer = new Debouncer(TimeSpan.FromMilliseconds(200), () =>
+        {
+            Interlocked.Increment(ref count);
+            signal.Set();
+        });
+
+        // 5 rapid triggers within 100ms (well under the 200ms quiet window)
+        for (int i = 0; i < 5; i++)
+        {
+            debouncer.Trigger();
+            Thread.Sleep(20);
+        }
+
+        Assert.IsTrue(signal.Wait(TimeSpan.FromSeconds(2)), "Action should eventually fire");
+        // Give a little slack to be sure no second fire is in flight
+        Thread.Sleep(150);
+        Assert.AreEqual(1, count, "Rapid triggers should coalesce into exactly one action");
+    }
+
+    [TestMethod]
+    public void Trigger_FiresAgainAfterQuietPeriodElapses()
+    {
+        int count = 0;
+        using var debouncer = new Debouncer(TimeSpan.FromMilliseconds(80), () =>
+        {
+            Interlocked.Increment(ref count);
+        });
+
+        debouncer.Trigger();
+        Thread.Sleep(250); // wait for first fire
+        debouncer.Trigger();
+        Thread.Sleep(250); // wait for second fire
+
+        Assert.AreEqual(2, count, "Two distinct trigger bursts should each fire once");
+    }
+
+    [TestMethod]
+    public void Dispose_CancelsPendingAction()
+    {
+        int count = 0;
+        var debouncer = new Debouncer(TimeSpan.FromMilliseconds(200), () =>
+        {
+            Interlocked.Increment(ref count);
+        });
+
+        debouncer.Trigger();
+        debouncer.Dispose();
+        Thread.Sleep(400);
+
+        Assert.AreEqual(0, count, "Disposed debouncer should not fire pending action");
+    }
+}

--- a/tests/Glasswork.Tests/FileWatcherServiceTests.cs
+++ b/tests/Glasswork.Tests/FileWatcherServiceTests.cs
@@ -53,6 +53,38 @@ public class FileWatcherServiceTests
     }
 
     [TestMethod]
+    public void DoesNotFire_ForFilesInSiblingDirectory()
+    {
+        // Sibling directory next to the watched dir
+        var siblingDir = _tempDir + "-sibling";
+        Directory.CreateDirectory(siblingDir);
+        try
+        {
+            using var watcher = new FileWatcherService(_tempDir);
+            string? changedFile = null;
+            var signal = new ManualResetEventSlim(false);
+
+            watcher.TaskFileChanged += (_, name) =>
+            {
+                changedFile = name;
+                signal.Set();
+            };
+
+            watcher.Start();
+            File.WriteAllText(Path.Combine(siblingDir, "outside-task.md"), "x");
+
+            Assert.IsFalse(signal.Wait(TimeSpan.FromSeconds(2)),
+                "Should NOT fire for files outside the watched vault directory");
+            Assert.IsNull(changedFile);
+        }
+        finally
+        {
+            if (Directory.Exists(siblingDir))
+                Directory.Delete(siblingDir, recursive: true);
+        }
+    }
+
+    [TestMethod]
     public void IgnoresUnderscorePrefixedFiles()
     {
         using var watcher = new FileWatcherService(_tempDir);


### PR DESCRIPTION
Closes #5

## Summary
Wires the existing `FileWatcherService` into the app so external edits (Obsidian, Copilot CLI) are picked up without restart, with a debounced index regen and a non-modal reload banner on the active task page.

## Implementation
- `Debouncer` (new, `Glasswork.Core.Services`): cancellation-token-based coalescer. Each `Trigger()` cancels any pending fire and schedules a fresh `Task.Delay` for the quiet window. Thread-safe via lock + CTS swap.
- `ActiveTaskTracker` (new): tracks the currently-open task id so the watcher fan-out can choose ""silent refresh"" vs ""show banner"".
- `App.xaml.cs`: constructs and starts `FileWatcherService`, owns a 500 ms `Debouncer` that calls `IndexService.Refresh`, and re-broadcasts `TaskFileChangedExternally` to pages.
- `BacklogPage` / `MyDayPage`: subscribe on nav-to / unsubscribe on nav-from; refresh via `DispatcherQueue.TryEnqueue` (FileSystemWatcher fires on thread-pool threads).
- `TaskDetailPage`: sets `App.ActiveTask.ActiveTaskId` on nav, shows an `InfoBar` reload banner when the open file changes; ""Reload"" re-navigates with a fresh `Vault.Load`, ""Keep my version"" just dismisses (next save overwrites).

## Tests (46 -> 57, all passing)
- `DebouncerTests` (4): single fire, coalescing 5 rapid triggers into 1, second burst fires again, dispose cancels pending.
- `ActiveTaskTrackerTests` (6): no active, exact match, with/without `.md`, mismatch, case-insensitive, `Clear()`.
- `FileWatcherServiceTests` (+1): scoping -- writes to a sibling directory do NOT raise events.

## Debounce mechanism
`CancellationTokenSource` + `Task.Delay` (no Reactive, no `System.Timers.Timer`). Chosen because:
- Cancellation semantics are exactly what coalescing needs (latest trigger wins).
- No threading-model surprises -- the continuation runs on `TaskScheduler.Default`, decoupled from any UI sync context.
- Trivial `Dispose` story (cancel + dispose CTS).

## Thread-safety notes
- `FileSystemWatcher` fires `Changed/Created/Deleted/Renamed` on thread-pool threads.
- `IndexService.Refresh` only writes files, so it is safe to call from the debounced thread-pool continuation.
- All UI subscribers (`BacklogPage`, `MyDayPage`, `TaskDetailPage`) marshal to the UI thread via `DispatcherQueue.TryEnqueue` before touching XAML state.
- `Debouncer` guards its CTS swap with a lock; producers can call `Trigger()` from any thread.
- Editor-save ""delete + create"" double-fire on Windows is absorbed by the 500 ms quiet window -> exactly one `IndexService.Refresh`.

## Manual smoke (to do post-merge)
1. `echo done >> ~/Wiki/wiki/todo/some-task.md` while Backlog is open -> list refreshes silently.
2. Same edit while that task's detail page is open -> banner appears with Reload / Keep my version.
3. Five rapid `touch` calls on different task files -> single regen of `_index.md` after ~500 ms.