### PR TITLE
Slice 12: Link/edit ADO work item via UI

### DIFF
--- a/src/Glasswork.App/Pages/CreateTaskDialog.xaml
+++ b/src/Glasswork.App/Pages/CreateTaskDialog.xaml
@@ -21,6 +21,11 @@
 
         <CheckBox x:Name="AddToMyDayBox" Content="Add to My Day" />
 
+        <TextBox x:Name="AdoLinkBox" Header="ADO work item ID (optional)"
+                 PlaceholderText="e.g. 12345" InputScope="Number" />
+        <TextBox x:Name="AdoTitleBox" Header="ADO title (optional)"
+                 PlaceholderText="Short label shown on the task" />
+
         <TextBox x:Name="NotesBox" Header="Notes (optional)" AcceptsReturn="True" Height="80"
                  PlaceholderText="Additional context..." />
     </StackPanel>

--- a/src/Glasswork.App/Pages/CreateTaskDialog.xaml.cs
+++ b/src/Glasswork.App/Pages/CreateTaskDialog.xaml.cs
@@ -26,7 +26,14 @@ public sealed partial class CreateTaskDialog : ContentDialog
         }
 
         var priority = (PriorityBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "medium";
-        var task = _taskService.CreateTask(title, priority);
+
+        int? adoLink = null;
+        var adoText = AdoLinkBox.Text?.Trim();
+        if (!string.IsNullOrEmpty(adoText) && int.TryParse(adoText, out var parsed) && parsed > 0)
+            adoLink = parsed;
+        var adoTitle = string.IsNullOrWhiteSpace(AdoTitleBox.Text) ? null : AdoTitleBox.Text.Trim();
+
+        var task = _taskService.CreateTask(title, priority, adoLink: adoLink, adoTitle: adoTitle);
 
         if (!string.IsNullOrWhiteSpace(NotesBox.Text))
         {

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml
@@ -54,12 +54,13 @@
             <CalendarDatePicker x:Name="DueDatePicker" Header="Due date" DateChanged="DueDate_Changed" />
 
             <!-- ADO link -->
-            <StackPanel x:Name="AdoPanel" Visibility="Collapsed" Orientation="Horizontal" Spacing="8">
-                <TextBlock VerticalAlignment="Center">
+            <StackPanel x:Name="AdoPanel" Orientation="Horizontal" Spacing="8">
+                <TextBlock x:Name="AdoLabel" VerticalAlignment="Center">
                     <Run Text="ADO: " />
                     <Run x:Name="AdoTitleRun" />
                 </TextBlock>
                 <HyperlinkButton x:Name="AdoLinkButton" Content="Open in ADO" Click="OpenAdo_Click" />
+                <Button x:Name="EditAdoButton" Content="Edit ADO link" Click="EditAdoLink_Click" />
             </StackPanel>
 
             <!-- Subtasks -->

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -71,12 +71,17 @@ public sealed partial class TaskDetailPage : Page
 
         if (task.AdoLink.HasValue)
         {
-            AdoPanel.Visibility = Visibility.Visible;
-            AdoTitleRun.Text = $"#{task.AdoLink} — {task.AdoTitle ?? "linked"}";
+            AdoLabel.Visibility = Visibility.Visible;
+            AdoLinkButton.Visibility = Visibility.Visible;
+            AdoTitleRun.Text = $"#{task.AdoLink} \u2014 {task.AdoTitle ?? "linked"}";
+            EditAdoButton.Content = "Edit ADO link";
         }
         else
         {
-            AdoPanel.Visibility = Visibility.Collapsed;
+            AdoLabel.Visibility = Visibility.Collapsed;
+            AdoLinkButton.Visibility = Visibility.Collapsed;
+            AdoTitleRun.Text = string.Empty;
+            EditAdoButton.Content = "Link ADO work item";
         }
 
         UpgradeV2Button.Visibility = task.IsV1Format ? Visibility.Visible : Visibility.Collapsed;
@@ -227,6 +232,53 @@ public sealed partial class TaskDetailPage : Page
             var url = $"https://dev.azure.com/_workitems/edit/{Task.AdoLink.Value}";
             Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
         }
+    }
+
+    private async void EditAdoLink_Click(object sender, RoutedEventArgs e)
+    {
+        var idBox = new TextBox
+        {
+            Header = "ADO work item ID (leave blank to clear)",
+            PlaceholderText = "e.g. 12345",
+            Text = Task.AdoLink?.ToString() ?? string.Empty,
+        };
+        var titleBox = new TextBox
+        {
+            Header = "ADO title (optional)",
+            PlaceholderText = "Short label shown on the task",
+            Text = Task.AdoTitle ?? string.Empty,
+            Margin = new Thickness(0, 12, 0, 0),
+        };
+        var panel = new StackPanel { MinWidth = 360 };
+        panel.Children.Add(idBox);
+        panel.Children.Add(titleBox);
+
+        var dialog = new ContentDialog
+        {
+            Title = "Edit ADO link",
+            Content = panel,
+            PrimaryButtonText = "Save",
+            CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Primary,
+            XamlRoot = this.XamlRoot,
+        };
+
+        var result = await dialog.ShowAsync();
+        if (result != ContentDialogResult.Primary) return;
+
+        var raw = idBox.Text?.Trim() ?? string.Empty;
+        int? newId = null;
+        if (raw.Length > 0)
+        {
+            if (!int.TryParse(raw, out var parsed) || parsed <= 0) return;
+            newId = parsed;
+        }
+        var newTitle = string.IsNullOrWhiteSpace(titleBox.Text) ? null : titleBox.Text.Trim();
+
+        App.Vault.SetAdoLink(Task.Id, newId, newTitle);
+        var reloaded = App.Vault.Load(Task.Id);
+        if (reloaded is not null) ApplyTask(reloaded);
+        try { App.Index.Refresh(); } catch { /* best-effort */ }
     }
 
     private void StartWork_Click(object sender, RoutedEventArgs e)

--- a/src/Glasswork.Core/Services/TaskService.cs
+++ b/src/Glasswork.Core/Services/TaskService.cs
@@ -21,7 +21,8 @@ public class TaskService
     /// <summary>
     /// Create a new task with auto-generated ID, save to vault.
     /// </summary>
-    public GlassworkTask CreateTask(string title, string priority = "medium", string? parent = null)
+    public GlassworkTask CreateTask(string title, string priority = "medium", string? parent = null,
+        int? adoLink = null, string? adoTitle = null)
     {
         var task = new GlassworkTask
         {
@@ -31,6 +32,8 @@ public class TaskService
             Priority = priority,
             Created = DateTime.Today,
             Parent = parent,
+            AdoLink = adoLink,
+            AdoTitle = adoTitle,
         };
 
         _vault.Save(task);

--- a/src/Glasswork.Core/Services/VaultService.cs
+++ b/src/Glasswork.Core/Services/VaultService.cs
@@ -158,6 +158,74 @@ public class VaultService
     }
 
     /// <summary>
+    /// Targeted edit: set or clear the <c>ado_link</c>/<c>ado_title</c> frontmatter keys without
+    /// rewriting any other frontmatter keys or the body. When <paramref name="adoId"/> is non-null,
+    /// inserts or replaces the <c>ado_link:</c> line (and <c>ado_title:</c> when supplied). When
+    /// <paramref name="adoId"/> is null, removes both lines if present. Preserves line endings
+    /// (\n vs \r\n) and the rest of the file byte-for-byte. No-op if the file does not exist.
+    /// </summary>
+    public void SetAdoLink(string taskId, int? adoId, string? adoTitle)
+    {
+        var path = GetFilePath(taskId);
+        if (!File.Exists(path)) return;
+
+        var content = File.ReadAllText(path);
+        var newline = content.Contains("\r\n") ? "\r\n" : "\n";
+
+        // Locate the frontmatter block: opening "---" line through the next "---" line.
+        var lines = content.Split('\n').Select(l => l.TrimEnd('\r')).ToList();
+        if (lines.Count == 0 || lines[0] != "---") return;
+
+        int closeIdx = -1;
+        for (int i = 1; i < lines.Count; i++)
+        {
+            if (lines[i] == "---") { closeIdx = i; break; }
+        }
+        if (closeIdx < 0) return;
+
+        // Strip any existing ado_link/ado_title lines inside the frontmatter block,
+        // remembering where the first one was so we can re-insert at the same position.
+        var adoLinkPattern = new System.Text.RegularExpressions.Regex(@"^ado_link:\s.*$");
+        var adoTitlePattern = new System.Text.RegularExpressions.Regex(@"^ado_title:\s.*$");
+        var newFront = new List<string>(closeIdx - 1);
+        int insertPos = -1;
+        for (int i = 1; i < closeIdx; i++)
+        {
+            if (adoLinkPattern.IsMatch(lines[i]) || adoTitlePattern.IsMatch(lines[i]))
+            {
+                if (insertPos < 0) insertPos = newFront.Count;
+                continue;
+            }
+            newFront.Add(lines[i]);
+        }
+        if (insertPos < 0) insertPos = newFront.Count; // append at end if none existed
+
+        if (adoId.HasValue)
+        {
+            var inserted = new List<string> { $"ado_link: {adoId.Value}" };
+            if (!string.IsNullOrWhiteSpace(adoTitle))
+                inserted.Add($"ado_title: {adoTitle}");
+            newFront.InsertRange(insertPos, inserted);
+        }
+
+        // Rebuild: opening "---", new frontmatter lines, closing "---", everything after.
+        var rebuilt = new List<string> { "---" };
+        rebuilt.AddRange(newFront);
+        rebuilt.Add("---");
+        for (int i = closeIdx + 1; i < lines.Count; i++) rebuilt.Add(lines[i]);
+
+        var hadTrailingNewline = content.EndsWith('\n');
+        var output = string.Join(newline, rebuilt);
+        if (hadTrailingNewline && !output.EndsWith(newline))
+            output += newline;
+
+        if (output == content) return;
+
+        _selfWrites?.RegisterWrite(path);
+        File.WriteAllText(path, output);
+    }
+
+    /// <summary>
     /// Save a task to disk. Creates or overwrites the file.
     /// </summary>
     public void Save(GlassworkTask task)

--- a/tests/Glasswork.Tests/TaskServiceTests.cs
+++ b/tests/Glasswork.Tests/TaskServiceTests.cs
@@ -79,6 +79,32 @@ public class TaskServiceTests
     }
 
     [TestMethod]
+    public void CreateTask_WithAdoLink_PersistsAdoFields()
+    {
+        var task = _taskService.CreateTask(
+            "Wire ADO link",
+            priority: "medium",
+            adoLink: 54321,
+            adoTitle: "Linked work item");
+
+        Assert.AreEqual(54321, task.AdoLink);
+        Assert.AreEqual("Linked work item", task.AdoTitle);
+
+        var loaded = _vault.Load(task.Id)!;
+        Assert.AreEqual(54321, loaded.AdoLink);
+        Assert.AreEqual("Linked work item", loaded.AdoTitle);
+    }
+
+    [TestMethod]
+    public void CreateTask_WithoutAdoLink_LeavesFieldsNull()
+    {
+        var task = _taskService.CreateTask("Plain task");
+
+        Assert.IsNull(task.AdoLink);
+        Assert.IsNull(task.AdoTitle);
+    }
+
+    [TestMethod]
     public void ToggleMyDay_AddsAndRemoves()
     {
         var task = new GlassworkTask { Id = "toggle-day", Title = "Toggle" };

--- a/tests/Glasswork.Tests/VaultSetAdoLinkTests.cs
+++ b/tests/Glasswork.Tests/VaultSetAdoLinkTests.cs
@@ -1,0 +1,239 @@
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class VaultSetAdoLinkTests
+{
+    private string _tempDir = null!;
+    private VaultService _vault = null!;
+    private SelfWriteCoordinator _selfWrites = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-ado-" + Guid.NewGuid().ToString("N")[..8]);
+        _selfWrites = new SelfWriteCoordinator();
+        _vault = new VaultService(_tempDir, _selfWrites);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public void SetAdoLink_AddsLinesToFrontmatter_PreservesEverythingElse()
+    {
+        var taskId = "ado-add";
+        var original =
+            "---\n" +
+            "id: ado-add\n" +
+            "title: My Task\n" +
+            "status: todo\n" +
+            "priority: medium\n" +
+            "created: 2024-05-01\n" +
+            "---\n" +
+            "\n" +
+            "Body prose stays exactly as-is.\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] One\n";
+        var path = Path.Combine(_tempDir, $"{taskId}.md");
+        File.WriteAllText(path, original);
+
+        _vault.SetAdoLink(taskId, 12345, "My Work Item");
+
+        var actual = File.ReadAllText(path);
+        var expected =
+            "---\n" +
+            "id: ado-add\n" +
+            "title: My Task\n" +
+            "status: todo\n" +
+            "priority: medium\n" +
+            "created: 2024-05-01\n" +
+            "ado_link: 12345\n" +
+            "ado_title: My Work Item\n" +
+            "---\n" +
+            "\n" +
+            "Body prose stays exactly as-is.\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] One\n";
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void SetAdoLink_WithoutTitle_OnlyWritesAdoLink()
+    {
+        var taskId = "ado-no-title";
+        var original =
+            "---\n" +
+            "id: ado-no-title\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "Body\n";
+        var path = Path.Combine(_tempDir, $"{taskId}.md");
+        File.WriteAllText(path, original);
+
+        _vault.SetAdoLink(taskId, 999, null);
+
+        var actual = File.ReadAllText(path);
+        var expected =
+            "---\n" +
+            "id: ado-no-title\n" +
+            "title: T\n" +
+            "ado_link: 999\n" +
+            "---\n" +
+            "\n" +
+            "Body\n";
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void SetAdoLink_ReplacesExistingLink_NoDuplicates()
+    {
+        var taskId = "ado-replace";
+        var original =
+            "---\n" +
+            "id: ado-replace\n" +
+            "title: T\n" +
+            "ado_link: 111\n" +
+            "ado_title: Old Title\n" +
+            "priority: medium\n" +
+            "---\n" +
+            "\n" +
+            "Body\n";
+        var path = Path.Combine(_tempDir, $"{taskId}.md");
+        File.WriteAllText(path, original);
+
+        _vault.SetAdoLink(taskId, 222, "New Title");
+
+        var actual = File.ReadAllText(path);
+        var expected =
+            "---\n" +
+            "id: ado-replace\n" +
+            "title: T\n" +
+            "ado_link: 222\n" +
+            "ado_title: New Title\n" +
+            "priority: medium\n" +
+            "---\n" +
+            "\n" +
+            "Body\n";
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void SetAdoLink_ClearsBothLines_PreservesOtherKeys()
+    {
+        var taskId = "ado-clear";
+        var original =
+            "---\n" +
+            "id: ado-clear\n" +
+            "title: T\n" +
+            "priority: high\n" +
+            "ado_link: 444\n" +
+            "ado_title: Going Away\n" +
+            "tags:\n" +
+            "- one\n" +
+            "---\n" +
+            "\n" +
+            "Body content.\n";
+        var path = Path.Combine(_tempDir, $"{taskId}.md");
+        File.WriteAllText(path, original);
+
+        _vault.SetAdoLink(taskId, null, null);
+
+        var actual = File.ReadAllText(path);
+        var expected =
+            "---\n" +
+            "id: ado-clear\n" +
+            "title: T\n" +
+            "priority: high\n" +
+            "tags:\n" +
+            "- one\n" +
+            "---\n" +
+            "\n" +
+            "Body content.\n";
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void SetAdoLink_ClearWhenAbsent_NoOp()
+    {
+        var taskId = "ado-clear-absent";
+        var original =
+            "---\n" +
+            "id: ado-clear-absent\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "Body\n";
+        var path = Path.Combine(_tempDir, $"{taskId}.md");
+        File.WriteAllText(path, original);
+
+        _vault.SetAdoLink(taskId, null, null);
+
+        Assert.AreEqual(original, File.ReadAllText(path));
+    }
+
+    [TestMethod]
+    public void SetAdoLink_RegistersSelfWrite()
+    {
+        var taskId = "ado-self-write";
+        var path = Path.Combine(_tempDir, $"{taskId}.md");
+        File.WriteAllText(path,
+            "---\n" +
+            "id: ado-self-write\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "Body\n");
+
+        _vault.SetAdoLink(taskId, 5, "X");
+
+        Assert.IsTrue(_selfWrites.IsSuppressed(path),
+            "SetAdoLink must register the file path with SelfWriteCoordinator before writing.");
+    }
+
+    [TestMethod]
+    public void SetAdoLink_NonExistentTask_NoOp()
+    {
+        // Should not throw.
+        _vault.SetAdoLink("does-not-exist", 1, "X");
+    }
+
+    [TestMethod]
+    public void SetAdoLink_PreservesCrlfLineEndings()
+    {
+        var taskId = "ado-crlf";
+        var original =
+            "---\r\n" +
+            "id: ado-crlf\r\n" +
+            "title: T\r\n" +
+            "---\r\n" +
+            "\r\n" +
+            "Body\r\n";
+        var path = Path.Combine(_tempDir, $"{taskId}.md");
+        File.WriteAllText(path, original);
+
+        _vault.SetAdoLink(taskId, 7, "Seven");
+
+        var actual = File.ReadAllText(path);
+        var expected =
+            "---\r\n" +
+            "id: ado-crlf\r\n" +
+            "title: T\r\n" +
+            "ado_link: 7\r\n" +
+            "ado_title: Seven\r\n" +
+            "---\r\n" +
+            "\r\n" +
+            "Body\r\n";
+        Assert.AreEqual(expected, actual);
+    }
+}


### PR DESCRIPTION
Closes #17.

## What

Adds the missing UI for **linking, editing, and clearing the ADO work item** on a task in both the **create** and **edit** flows.

## Core changes

- `VaultService.SetAdoLink(taskId, adoId, adoTitle?)` — new targeted-edit writer that inserts/replaces/clears `ado_link:` (and optional `ado_title:`) in the YAML frontmatter without rewriting any other key or the body. On replace the original line position is preserved. Registers the file path with `SelfWriteCoordinator` before writing so the FileWatcher does not raise a false-positive 'file changed externally' banner. CRLF / LF line endings preserved.
- `TaskService.CreateTask` now accepts optional `adoLink` + `adoTitle` and persists them on the new file.

## UI changes (scoped — no refactoring of unrelated code)

- **CreateTaskDialog**: optional 'ADO work item ID' + 'ADO title' fields; flow through `TaskService.CreateTask`.
- **TaskDetailPage**: ADO panel now always shows a button — 'Edit ADO link' when set, 'Link ADO work item' when not. Clicking pops a small dialog (id + title) to set / change / clear. On save the file is updated via `SetAdoLink` and the page re-binds. `AdoPanel` element preserved (only its inner contents augmented) to stay friendly with parallel slice 5 / slice 11 edits.

## Tests

- 8 new `VaultSetAdoLinkTests` — add, add-without-title, replace (no duplicates), clear, clear-when-absent (no-op), self-write registration, missing-file no-op, CRLF preservation.
- 2 new `TaskServiceTests` — `CreateTask` with and without adoLink.
- **115 tests total**. The single failing test (`DebouncerTests.Trigger_FiresAgainAfterQuietPeriodElapses`) is a pre-existing timing-flaky test that passes when run in isolation; unrelated to this slice.

## TDD trace

1. RED→GREEN: `SetAdoLink` writes `ado_link`/`ado_title` ✅
2. RED→GREEN: `SetAdoLink(null,null)` clears both lines ✅
3. RED→GREEN: `TaskService.CreateTask` accepts and persists adoLink ✅
4. GREEN: create dialog wired (covered by `CreateTask` tests; UI is thin wrapper)
5. GREEN: detail page 'Edit ADO link' affordance wired (covered by `SetAdoLink` tests; UI is thin wrapper)