### PR TITLE
Slice 11: Add subtask via UI

### DIFF
--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml
@@ -163,6 +163,16 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
+            <!-- Add subtask: inline editor (Enter to commit, button as alternative) -->
+            <Grid ColumnDefinitions="*,Auto" Margin="0,4,0,0">
+                <TextBox x:Name="AddSubtaskBox" Grid.Column="0"
+                         PlaceholderText="Add subtask..."
+                         KeyDown="AddSubtaskBox_KeyDown" />
+                <Button x:Name="AddSubtaskButton" Grid.Column="1"
+                        Content="Add" Margin="8,0,0,0"
+                        Click="AddSubtask_Click" />
+            </Grid>
+
             <!-- Completed / dropped subtasks: collapsed under an expander -->
             <Expander x:Name="CompletedExpander" HorizontalAlignment="Stretch"
                       Visibility="Collapsed">

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -178,6 +178,35 @@ public sealed partial class TaskDetailPage : Page
         }
     }
 
+    private void AddSubtaskBox_KeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
+    {
+        if (e.Key == Windows.System.VirtualKey.Enter)
+        {
+            CommitNewSubtask();
+            e.Handled = true;
+        }
+    }
+
+    private void AddSubtask_Click(object sender, RoutedEventArgs e) => CommitNewSubtask();
+
+    private void CommitNewSubtask()
+    {
+        if (_isLoading) return;
+        var title = AddSubtaskBox.Text?.Trim();
+        if (string.IsNullOrEmpty(title)) return;
+
+        App.Vault.AddSubtask(Task.Id, title);
+        AddSubtaskBox.Text = string.Empty;
+
+        var reloaded = App.Vault.Load(Task.Id);
+        if (reloaded is not null)
+        {
+            Task = reloaded;
+            BindSubtasks(reloaded.Subtasks);
+        }
+        try { App.Index.Refresh(); } catch { /* best-effort */ }
+    }
+
     private void ToggleSubtaskMyDay_Click(object sender, RoutedEventArgs e)
     {
         if (_isLoading) return;

--- a/src/Glasswork.Core/Services/VaultService.cs
+++ b/src/Glasswork.Core/Services/VaultService.cs
@@ -158,6 +158,129 @@ public class VaultService
     }
 
     /// <summary>
+    /// Targeted edit: append a new <c>### [ ] {title}</c> subtask under the <c>## Subtasks</c>
+    /// section. Creates the section at end of file if missing. New subtask is placed at the
+    /// bottom of the active group — immediately before the first "completed" subtask
+    /// (header marked <c>[x]</c>, or whose metadata block sets <c>status: done</c> /
+    /// <c>status: dropped</c>). Preserves line endings, surrounding prose, and metadata
+    /// blocks of other subtasks. No-op when the title is whitespace or the file is missing.
+    /// </summary>
+    public void AddSubtask(string taskId, string title)
+    {
+        if (string.IsNullOrWhiteSpace(title)) return;
+
+        var path = GetFilePath(taskId);
+        if (!File.Exists(path)) return;
+
+        var trimmed = title.Trim();
+        var content = File.ReadAllText(path);
+        var newline = content.Contains("\r\n") ? "\r\n" : "\n";
+        var lines = content.Split('\n').Select(l => l.TrimEnd('\r')).ToList();
+        var hadTrailingNewline = content.EndsWith('\n');
+
+        var subtasksHeaderIdx = -1;
+        for (int i = 0; i < lines.Count; i++)
+        {
+            if (lines[i].Trim() == "## Subtasks")
+            {
+                subtasksHeaderIdx = i;
+                break;
+            }
+        }
+
+        var headerPattern = new System.Text.RegularExpressions.Regex(@"^### \[([ xX])\] (.+?)\s*$");
+        var metaPattern = new System.Text.RegularExpressions.Regex(@"^- ([a-z_][a-z0-9_]*): (.*)$");
+        var newSubtaskLine = $"### [ ] {trimmed}";
+
+        if (subtasksHeaderIdx < 0)
+        {
+            // No section — append it (with a blank-line separator) at end of file.
+            // Strip trailing blanks first to avoid stacking blank lines.
+            while (lines.Count > 0 && string.IsNullOrEmpty(lines[^1])) lines.RemoveAt(lines.Count - 1);
+            lines.Add("");
+            lines.Add("## Subtasks");
+            lines.Add("");
+            lines.Add(newSubtaskLine);
+        }
+        else
+        {
+            // Find section bounds: from header to next `## ` heading or EOF.
+            int sectionEnd = lines.Count;
+            for (int i = subtasksHeaderIdx + 1; i < lines.Count; i++)
+            {
+                if (lines[i].StartsWith("## ") && !lines[i].StartsWith("### "))
+                {
+                    sectionEnd = i;
+                    break;
+                }
+            }
+
+            // Walk subtasks and find the first "completed" header within the section.
+            int insertAt = -1;
+            int lastActiveBlockEnd = -1; // last line index that belongs to an active subtask
+            int i2 = subtasksHeaderIdx + 1;
+            while (i2 < sectionEnd)
+            {
+                var hm = headerPattern.Match(lines[i2]);
+                if (!hm.Success) { i2++; continue; }
+
+                var checkChar = hm.Groups[1].Value;
+
+                // Walk this subtask's metadata block.
+                int blockEnd = i2;
+                string? statusValue = null;
+                for (int j = i2 + 1; j < sectionEnd; j++)
+                {
+                    var mm = metaPattern.Match(lines[j]);
+                    if (!mm.Success) break;
+                    blockEnd = j;
+                    if (mm.Groups[1].Value == "status") statusValue = mm.Groups[2].Value.Trim();
+                }
+
+                bool isDone = checkChar is "x" or "X"
+                    || statusValue is "done" or "dropped";
+
+                if (isDone)
+                {
+                    insertAt = i2;
+                    break;
+                }
+                lastActiveBlockEnd = blockEnd;
+                i2 = blockEnd + 1;
+            }
+
+            if (insertAt < 0)
+            {
+                // No completed subtask — insert after last active block, or after the section
+                // header (skipping any blank line) if there are no subtasks at all.
+                if (lastActiveBlockEnd >= 0)
+                {
+                    lines.Insert(lastActiveBlockEnd + 1, newSubtaskLine);
+                }
+                else
+                {
+                    // Empty section: insert after `## Subtasks` and its conventional blank line.
+                    int insertPoint = subtasksHeaderIdx + 1;
+                    if (insertPoint < lines.Count && string.IsNullOrEmpty(lines[insertPoint]))
+                        insertPoint++;
+                    lines.Insert(insertPoint, newSubtaskLine);
+                }
+            }
+            else
+            {
+                lines.Insert(insertAt, newSubtaskLine);
+            }
+        }
+
+        var rebuilt = string.Join(newline, lines);
+        if (hadTrailingNewline && !rebuilt.EndsWith(newline))
+            rebuilt += newline;
+
+        _selfWrites?.RegisterWrite(path);
+        File.WriteAllText(path, rebuilt);
+    }
+
+    /// <summary>
     /// Save a task to disk. Creates or overwrites the file.
     /// </summary>
     public void Save(GlassworkTask task)

--- a/tests/Glasswork.Tests/VaultAddSubtaskTests.cs
+++ b/tests/Glasswork.Tests/VaultAddSubtaskTests.cs
@@ -1,0 +1,363 @@
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class VaultAddSubtaskTests
+{
+    private string _tempDir = null!;
+    private VaultService _vault = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-addsub-" + Guid.NewGuid().ToString("N")[..8]);
+        _vault = new VaultService(_tempDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private string Write(string id, string body)
+    {
+        var path = Path.Combine(_tempDir, $"{id}.md");
+        File.WriteAllText(path, body);
+        return path;
+    }
+
+    [TestMethod]
+    public void AddSubtask_AppendsUnderExistingSubtasksSection_PreservesEverythingElse()
+    {
+        var id = "add-existing";
+        var original =
+            "---\n" +
+            "id: add-existing\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] First sub\n" +
+            "### [ ] Second sub\n";
+        var path = Write(id, original);
+
+        _vault.AddSubtask(id, "Third sub");
+
+        var actual = File.ReadAllText(path);
+        var expected =
+            "---\n" +
+            "id: add-existing\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] First sub\n" +
+            "### [ ] Second sub\n" +
+            "### [ ] Third sub\n";
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void AddSubtask_CreatesSubtasksSection_WhenAbsent()
+    {
+        var id = "add-no-section";
+        var original =
+            "---\n" +
+            "id: add-no-section\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "Some notes here.\n";
+        var path = Write(id, original);
+
+        _vault.AddSubtask(id, "First sub");
+
+        var actual = File.ReadAllText(path);
+        var expected =
+            "---\n" +
+            "id: add-no-section\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "Some notes here.\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] First sub\n";
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void AddSubtask_InsertsAboveCompletedGroup_WhenCompletedSubtasksExist()
+    {
+        var id = "add-above-completed";
+        var original =
+            "---\n" +
+            "id: add-above-completed\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] Active one\n" +
+            "### [ ] Active two\n" +
+            "### [x] Completed one\n" +
+            "### [x] Completed two\n";
+        var path = Write(id, original);
+
+        _vault.AddSubtask(id, "New active");
+
+        var actual = File.ReadAllText(path);
+        var expected =
+            "---\n" +
+            "id: add-above-completed\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] Active one\n" +
+            "### [ ] Active two\n" +
+            "### [ ] New active\n" +
+            "### [x] Completed one\n" +
+            "### [x] Completed two\n";
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void AddSubtask_InsertsAboveDoneByStatusSubtask()
+    {
+        var id = "add-above-done-status";
+        var original =
+            "---\n" +
+            "id: add-above-done-status\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] Active one\n" +
+            "### [ ] Already done\n" +
+            "- status: done\n";
+        var path = Write(id, original);
+
+        _vault.AddSubtask(id, "Brand new");
+
+        var actual = File.ReadAllText(path);
+        var expected =
+            "---\n" +
+            "id: add-above-done-status\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] Active one\n" +
+            "### [ ] Brand new\n" +
+            "### [ ] Already done\n" +
+            "- status: done\n";
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void AddSubtask_InsertsBeforeNextH2Section_WhenSubtasksSectionIsNotLast()
+    {
+        var id = "add-before-h2";
+        var original =
+            "---\n" +
+            "id: add-before-h2\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] Existing\n" +
+            "\n" +
+            "## Notes\n" +
+            "\n" +
+            "Some prose.\n";
+        var path = Write(id, original);
+
+        _vault.AddSubtask(id, "Added");
+
+        var actual = File.ReadAllText(path);
+        var expected =
+            "---\n" +
+            "id: add-before-h2\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] Existing\n" +
+            "### [ ] Added\n" +
+            "\n" +
+            "## Notes\n" +
+            "\n" +
+            "Some prose.\n";
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void AddSubtask_RoundTripsThroughParser_NewSubtaskHasDefaultState()
+    {
+        var id = "add-roundtrip";
+        var original =
+            "---\n" +
+            "id: add-roundtrip\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] Pre-existing\n";
+        Write(id, original);
+
+        _vault.AddSubtask(id, "Fresh subtask");
+
+        var loaded = _vault.Load(id);
+        Assert.IsNotNull(loaded);
+        Assert.AreEqual(2, loaded!.Subtasks.Count);
+        var fresh = loaded.Subtasks.Last();
+        Assert.AreEqual("Fresh subtask", fresh.Text);
+        Assert.IsFalse(fresh.IsCompleted);
+        Assert.IsNull(fresh.Status);
+        Assert.IsFalse(fresh.IsEffectivelyDone);
+    }
+
+    [TestMethod]
+    public void AddSubtask_RegistersSelfWrite_ToSuppressFalseExternalChangeBanner()
+    {
+        var id = "add-selfwrite";
+        var coordinator = new SelfWriteCoordinator();
+        var vault = new VaultService(_tempDir, coordinator);
+        var original =
+            "---\n" +
+            "id: add-selfwrite\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] Existing\n";
+        var path = Write(id, original);
+
+        vault.AddSubtask(id, "New one");
+
+        Assert.IsTrue(coordinator.IsSuppressed(path),
+            "AddSubtask must register the path with SelfWriteCoordinator before writing.");
+    }
+
+    [TestMethod]
+    public void AddSubtask_TitleWithWhitespace_IsTrimmed()
+    {
+        var id = "add-trim";
+        var original =
+            "---\n" +
+            "id: add-trim\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n";
+        var path = Write(id, original);
+
+        _vault.AddSubtask(id, "  Padded  ");
+
+        var actual = File.ReadAllText(path);
+        StringAssert.Contains(actual, "### [ ] Padded\n");
+        Assert.IsFalse(actual.Contains("### [ ]   Padded"));
+    }
+
+    [TestMethod]
+    public void AddSubtask_EmptyOrWhitespaceTitle_IsNoOp()
+    {
+        var id = "add-empty";
+        var original =
+            "---\n" +
+            "id: add-empty\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] Existing\n";
+        var path = Write(id, original);
+
+        _vault.AddSubtask(id, "   ");
+
+        Assert.AreEqual(original, File.ReadAllText(path));
+    }
+
+    [TestMethod]
+    public void AddSubtask_FileMissing_IsNoOp()
+    {
+        // Should not throw.
+        _vault.AddSubtask("does-not-exist", "Whatever");
+    }
+
+    [TestMethod]
+    public void AddSubtask_PreservesCrlfLineEndings()
+    {
+        var id = "add-crlf";
+        var original =
+            "---\r\n" +
+            "id: add-crlf\r\n" +
+            "title: T\r\n" +
+            "---\r\n" +
+            "\r\n" +
+            "## Subtasks\r\n" +
+            "\r\n" +
+            "### [ ] Existing\r\n";
+        var path = Write(id, original);
+
+        _vault.AddSubtask(id, "Added");
+
+        var actual = File.ReadAllText(path);
+        Assert.IsFalse(actual.Replace("\r\n", "").Contains('\n'),
+            "File should contain only CRLF line endings, no bare LF.");
+        StringAssert.Contains(actual, "### [ ] Added\r\n");
+    }
+
+    // ===== TDD step 4: ViewModel/orchestration test =====
+    // Mirrors what TaskDetailPage.CommitNewSubtask does: AddSubtask → Load → expect new
+    // subtask in the active list of the freshly-loaded task.
+
+    [TestMethod]
+    public void AddSubtask_ThenReload_SurfacesNewSubtaskInActiveList()
+    {
+        var id = "ui-orchestration";
+        var original =
+            "---\n" +
+            "id: ui-orchestration\n" +
+            "title: T\n" +
+            "---\n" +
+            "\n" +
+            "## Subtasks\n" +
+            "\n" +
+            "### [ ] Existing active\n" +
+            "### [x] Existing done\n";
+        Write(id, original);
+
+        // Simulate the click: vault write + reload.
+        _vault.AddSubtask(id, "Typed in UI");
+        var reloaded = _vault.Load(id);
+
+        Assert.IsNotNull(reloaded);
+        var active = reloaded!.Subtasks.Where(s => !s.IsEffectivelyDone).Select(s => s.Text).ToList();
+        var completed = reloaded.Subtasks.Where(s => s.IsEffectivelyDone).Select(s => s.Text).ToList();
+
+        CollectionAssert.AreEqual(
+            new[] { "Existing active", "Typed in UI" },
+            active,
+            "New subtask should appear in active list, after existing active items.");
+        CollectionAssert.AreEqual(
+            new[] { "Existing done" },
+            completed);
+    }
+}


### PR DESCRIPTION
Closes #16.

## What

Adds an inline `TextBox` + `Add` affordance to `TaskDetailPage` so users can create subtasks without editing markdown directly. New subtasks land at the bottom of the active group, immediately above any completed subtasks.

## How

- `VaultService.AddSubtask(taskId, title)` — targeted writer that appends `### [ ] Title` under `## Subtasks` (creates section if absent). Detects `completed` group via either `[x]` marker OR `- status: done|dropped` metadata. Preserves line endings, prose, and other subtasks' metadata blocks. Registers self-writes with `SelfWriteCoordinator`.
- `TaskDetailPage` — inline editor placed between the active subtask list and the completed expander. Enter key or button click commits; orchestration mirrors `ToggleSubtaskMyDay_Click` (write → reload → refresh index).

## TDD

- ✅ Step 1 — append under `## Subtasks`, create section if absent
- ✅ Step 2 — placed at bottom of active group, above `[x]` and `status: done` subtasks
- ✅ Step 3 — round-trips through parser with default state (`IsCompleted=false`, `Status=null`)
- ✅ Step 4 — orchestration test (write → reload → new subtask in active list)
- ⏭ Step 5 (rich form) — out of scope per task brief

12 new tests in `VaultAddSubtaskTests`. Total now 117 (one pre-existing flaky timing-based `DebouncerTests.Trigger_FiresAgainAfterQuietPeriodElapses` — passes on isolated re-run, unrelated to this slice).

## Notes

Kept `TaskDetailPage.xaml` changes localized to a 10-line additive block (no reorders) since slices 5 and 12 are editing the same file in parallel.