### PR TITLE
Slice 5: Related section + wiki page hydration

### DIFF
--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml
@@ -216,6 +216,39 @@
                 <TextBlock x:Name="ClipboardHint" VerticalAlignment="Center" Opacity="0.6" FontSize="12" />
             </StackPanel>
 
+            <!-- Related (slice 5) -->
+            <StackPanel x:Name="RelatedSection" Spacing="8" Margin="0,16,0,0" Visibility="Collapsed">
+                <TextBlock Text="Related" Style="{StaticResource SubtitleTextBlockStyle}" />
+                <ItemsControl x:Name="RelatedList">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Button HorizontalAlignment="Stretch"
+                                    HorizontalContentAlignment="Stretch"
+                                    Margin="0,2,0,2"
+                                    Padding="12,8"
+                                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                    BorderThickness="1"
+                                    Click="RelatedLink_Click">
+                                <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="12">
+                                    <TextBlock Grid.Column="0" Text="{Binding TypeGlyph}" FontSize="18" VerticalAlignment="Center" />
+                                    <StackPanel Grid.Column="1" Spacing="2">
+                                        <TextBlock Text="{Binding Title}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Text="{Binding Subtitle}" Opacity="0.65" FontSize="12" />
+                                    </StackPanel>
+                                    <TextBlock Grid.Column="2"
+                                               Text="missing"
+                                               Foreground="#C50F1F"
+                                               FontSize="11"
+                                               VerticalAlignment="Center"
+                                               Visibility="{Binding IsMissing, Converter={StaticResource BoolToVis}}" />
+                                </Grid>
+                            </Button>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+
             <!-- Actions -->
             <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,16,0,0">
                 <Button Content="Delete" Click="Delete_Click" />

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using Glasswork.Core.Models;
 using Glasswork.Core.Services;
@@ -62,6 +63,7 @@ public sealed partial class TaskDetailPage : Page
             : (DateTimeOffset?)null;
 
         BindSubtasks(task.Subtasks);
+        BindRelated(task.RelatedLinks);
 
         CreatedText.Text = $"Created: {task.Created:yyyy-MM-dd}";
         CompletedText.Text = task.CompletedAt.HasValue
@@ -103,6 +105,34 @@ public sealed partial class TaskDetailPage : Page
         }
     }
 
+
+    private void BindRelated(IList<RelatedLink> links)
+    {
+        if (links.Count == 0)
+        {
+            RelatedSection.Visibility = Visibility.Collapsed;
+            RelatedList.ItemsSource = null;
+            return;
+        }
+
+        // wiki root = parent of the todo/ vault directory (e.g. ~/Wiki/wiki/).
+        // Slugs in [[..]] are paths relative to this root.
+        var wikiRoot = Path.GetDirectoryName(App.Vault.VaultPath) ?? App.Vault.VaultPath;
+        var hydrated = new WikiLinkHydrator().Hydrate(links, wikiRoot);
+        RelatedList.ItemsSource = hydrated;
+        RelatedSection.Visibility = Visibility.Visible;
+    }
+
+    private void RelatedLink_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement fe || fe.DataContext is not HydratedRelatedLink link) return;
+        // Open in Obsidian. Vault is "Wiki"; the slug is already the file path
+        // (without .md) relative to the Obsidian vault root, matching the same
+        // scheme used by OpenObsidian_Click below.
+        var encoded = string.Join("/", link.Slug.Split('/').Select(Uri.EscapeDataString));
+        var uri = $"obsidian://open?vault=Wiki&file={encoded}";
+        Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true });
+    }
 
     protected override void OnNavigatedFrom(NavigationEventArgs e)
     {

--- a/src/Glasswork.Core/Models/GlassworkTask.cs
+++ b/src/Glasswork.Core/Models/GlassworkTask.cs
@@ -24,6 +24,7 @@ public partial class GlassworkTask : ObservableObject
     [ObservableProperty] public partial List<string> ContextLinks { get; set; } = [];
     [ObservableProperty] public partial List<string> Tags { get; set; } = [];
     [ObservableProperty] public partial List<SubTask> Subtasks { get; set; } = [];
+    [ObservableProperty] public partial List<RelatedLink> RelatedLinks { get; set; } = [];
 
     /// <summary>
     /// True when the source markdown file is in legacy V1 format (no `## Subtasks` header).

--- a/src/Glasswork.Core/Models/HydratedRelatedLink.cs
+++ b/src/Glasswork.Core/Models/HydratedRelatedLink.cs
@@ -1,0 +1,56 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Glasswork.Core.Models;
+
+/// <summary>
+/// A <see cref="RelatedLink"/> resolved against the wiki on disk: title, type, and created
+/// date pulled from the target page's YAML frontmatter. When the target file is missing,
+/// <see cref="IsMissing"/> is true and the rendered fields fall back to the slug.
+/// </summary>
+public partial class HydratedRelatedLink : ObservableObject
+{
+    [ObservableProperty] public partial string Slug { get; set; } = string.Empty;
+    [ObservableProperty] public partial string? DisplayName { get; set; }
+    [ObservableProperty] public partial string Title { get; set; } = string.Empty;
+    [ObservableProperty] public partial string Type { get; set; } = string.Empty;
+    [ObservableProperty] public partial DateTime? Created { get; set; }
+    [ObservableProperty] public partial bool IsMissing { get; set; }
+
+    /// <summary>Single-character glyph for the page type (decision/note/contact/...).</summary>
+    public string TypeGlyph => Type?.ToLowerInvariant() switch
+    {
+        "decision" => "📋",
+        "contact" => "👤",
+        "meeting" => "📅",
+        "project" => "📁",
+        "reference" or "ref" => "📚",
+        "note" or "" or null => "📄",
+        _ => "📄",
+    };
+
+    /// <summary>Capitalized type label, or "Page" when no type is known.</summary>
+    public string TypeLabel
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(Type)) return "Page";
+            return char.ToUpperInvariant(Type[0]) + Type[1..];
+        }
+    }
+
+    /// <summary>"yyyy-MM-dd" string of <see cref="Created"/>, or empty.</summary>
+    public string CreatedDisplay => Created.HasValue ? Created.Value.ToString("yyyy-MM-dd") : string.Empty;
+
+    /// <summary>One-line summary used as the card subtitle: "Decision • 2026-04-17" or "Missing".</summary>
+    public string Subtitle
+    {
+        get
+        {
+            if (IsMissing) return "Missing";
+            var parts = new System.Collections.Generic.List<string> { TypeLabel };
+            if (!string.IsNullOrEmpty(CreatedDisplay)) parts.Add(CreatedDisplay);
+            return string.Join(" • ", parts);
+        }
+    }
+}

--- a/src/Glasswork.Core/Models/RelatedLink.cs
+++ b/src/Glasswork.Core/Models/RelatedLink.cs
@@ -1,0 +1,29 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Glasswork.Core.Models;
+
+/// <summary>
+/// A wiki-link reference parsed from a task's <c>## Related</c> section.
+/// Format: <c>[[slug]]</c> or <c>[[slug|display name]]</c>.
+/// The <see cref="Slug"/> is the path relative to the Obsidian vault root, without the
+/// <c>.md</c> extension (e.g. <c>decisions/glasswork-v2-prd</c>).
+/// </summary>
+public partial class RelatedLink : ObservableObject
+{
+    [ObservableProperty] public partial string Slug { get; set; } = string.Empty;
+    [ObservableProperty] public partial string? DisplayName { get; set; }
+
+    /// <summary>
+    /// The text to show when no hydrated title is available.
+    /// Falls back to the last segment of the slug (e.g. <c>glasswork-v2-prd</c>).
+    /// </summary>
+    public string FallbackDisplay
+    {
+        get
+        {
+            if (!string.IsNullOrWhiteSpace(DisplayName)) return DisplayName!;
+            var idx = Slug.LastIndexOf('/');
+            return idx >= 0 ? Slug[(idx + 1)..] : Slug;
+        }
+    }
+}

--- a/src/Glasswork.Core/Services/FrontmatterParser.cs
+++ b/src/Glasswork.Core/Services/FrontmatterParser.cs
@@ -35,6 +35,12 @@ public partial class FrontmatterParser
     [GeneratedRegex(@"(?ms)^## Subtasks\s*$(.*?)(?=^## |\z)", RegexOptions.Multiline)]
     private static partial Regex SubtasksSectionRegex();
 
+    [GeneratedRegex(@"(?ms)^## Related\s*$(.*?)(?=^## |\z)", RegexOptions.Multiline)]
+    private static partial Regex RelatedSectionRegex();
+
+    [GeneratedRegex(@"\[\[([^\]\|]+?)(?:\|([^\]]+))?\]\]")]
+    private static partial Regex WikiLinkRegex();
+
     [GeneratedRegex(@"^- ([a-z_][a-z0-9_]*): (.*)$")]
     private static partial Regex MetadataLineRegex();
 
@@ -80,6 +86,7 @@ public partial class FrontmatterParser
         var (subtasks, cleanBody) = ParseSubtasks(body);
         task.Subtasks = subtasks;
         task.Body = cleanBody;
+        task.RelatedLinks = ParseRelatedLinks(body);
         task.IsV1Format = MigrationService.IsV1Format(content);
 
         return task;
@@ -164,7 +171,42 @@ public partial class FrontmatterParser
             }
         }
 
+        if (task.RelatedLinks.Count > 0)
+        {
+            sb.AppendLine("## Related");
+            sb.AppendLine();
+            foreach (var link in task.RelatedLinks)
+            {
+                var inner = string.IsNullOrWhiteSpace(link.DisplayName)
+                    ? link.Slug
+                    : $"{link.Slug}|{link.DisplayName}";
+                sb.AppendLine($"- [[{inner}]]");
+            }
+            sb.AppendLine();
+        }
+
         return sb.ToString().TrimEnd() + "\n";
+    }
+
+    private static List<RelatedLink> ParseRelatedLinks(string body)
+    {
+        var links = new List<RelatedLink>();
+        var match = RelatedSectionRegex().Match(body);
+        if (!match.Success) return links;
+
+        var section = match.Groups[1].Value;
+        // Find every wiki-link occurrence; preserves order and tolerates bullets,
+        // bare lines, or multiple links per line. Per D10, this section is left
+        // intact in the body (Obsidian's graph view depends on it being on disk).
+        foreach (Match m in WikiLinkRegex().Matches(section))
+        {
+            var slug = m.Groups[1].Value.Trim();
+            if (slug.Length == 0) continue;
+            string? display = m.Groups[2].Success ? m.Groups[2].Value.Trim() : null;
+            if (string.IsNullOrWhiteSpace(display)) display = null;
+            links.Add(new RelatedLink { Slug = slug, DisplayName = display });
+        }
+        return links;
     }
 
     private static (List<SubTask> subtasks, string cleanBody) ParseSubtasks(string body)

--- a/src/Glasswork.Core/Services/WikiLinkHydrator.cs
+++ b/src/Glasswork.Core/Services/WikiLinkHydrator.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+using Glasswork.Core.Models;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Glasswork.Core.Services;
+
+/// <summary>
+/// Resolves <see cref="RelatedLink"/> references against the wiki on disk and produces
+/// <see cref="HydratedRelatedLink"/> view-models with title/type/created pulled from the
+/// target page's YAML frontmatter. Missing files render as placeholder cards (per D10).
+/// </summary>
+public partial class WikiLinkHydrator
+{
+    private static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
+        .WithNamingConvention(UnderscoredNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    [GeneratedRegex(@"^---\s*\n(.*?)\n---\s*\n?", RegexOptions.Singleline)]
+    private static partial Regex FrontmatterRegex();
+
+    /// <summary>
+    /// Hydrate each link by reading the target file's frontmatter from <paramref name="wikiRoot"/>.
+    /// The wiki root is the Obsidian vault root (e.g. <c>~/Wiki/wiki/</c>); slugs are interpreted
+    /// as paths relative to that root with <c>.md</c> appended.
+    /// </summary>
+    public List<HydratedRelatedLink> Hydrate(IEnumerable<RelatedLink> links, string wikiRoot)
+    {
+        var result = new List<HydratedRelatedLink>();
+        foreach (var link in links)
+        {
+            result.Add(HydrateOne(link, wikiRoot));
+        }
+        return result;
+    }
+
+    private static HydratedRelatedLink HydrateOne(RelatedLink link, string wikiRoot)
+    {
+        var slugPath = link.Slug.Replace('/', Path.DirectorySeparatorChar);
+        var fullPath = Path.Combine(wikiRoot, slugPath + ".md");
+
+        var hydrated = new HydratedRelatedLink
+        {
+            Slug = link.Slug,
+            DisplayName = link.DisplayName,
+            Title = link.FallbackDisplay,
+        };
+
+        if (!File.Exists(fullPath))
+        {
+            hydrated.IsMissing = true;
+            return hydrated;
+        }
+
+        try
+        {
+            var content = File.ReadAllText(fullPath);
+            var match = FrontmatterRegex().Match(content);
+            if (!match.Success) return hydrated; // file exists but no frontmatter — keep slug fallback
+
+            var fm = YamlDeserializer.Deserialize<PageFrontmatter>(match.Groups[1].Value);
+            if (fm is null) return hydrated;
+
+            if (!string.IsNullOrWhiteSpace(fm.Title)) hydrated.Title = fm.Title!;
+            if (!string.IsNullOrWhiteSpace(fm.Type)) hydrated.Type = fm.Type!;
+            hydrated.Created = ParseDate(fm.Created);
+        }
+        catch
+        {
+            // Best-effort: a malformed page should render as a card with whatever we have.
+        }
+
+        return hydrated;
+    }
+
+    private static DateTime? ParseDate(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        if (DateTime.TryParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var d))
+            return d;
+        if (DateTime.TryParse(value, out var fallback)) return fallback;
+        return null;
+    }
+
+    private class PageFrontmatter
+    {
+        public string? Title { get; set; }
+        public string? Type { get; set; }
+        public string? Created { get; set; }
+    }
+}

--- a/tests/Glasswork.Tests/RelatedLinkParserTests.cs
+++ b/tests/Glasswork.Tests/RelatedLinkParserTests.cs
@@ -1,0 +1,176 @@
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class RelatedLinkParserTests
+{
+    private readonly FrontmatterParser _parser = new();
+
+    private const string Header = """
+        ---
+        id: t
+        title: T
+        created: 2026-04-17
+        ---
+
+        Body prose.
+
+        """;
+
+    [TestMethod]
+    public void Parse_NoRelatedSection_ReturnsEmptyList()
+    {
+        var task = _parser.Parse(Header);
+        Assert.AreEqual(0, task.RelatedLinks.Count);
+    }
+
+    [TestMethod]
+    public void Parse_RelatedSection_BulletList_ParsesEachLink()
+    {
+        var md = Header + """
+            ## Related
+
+            - [[decisions/glasswork-v2-prd]]
+            - [[contacts/jane-doe|Jane Doe]]
+            - [[notes/loose-thought]]
+            """;
+
+        var task = _parser.Parse(md);
+
+        Assert.AreEqual(3, task.RelatedLinks.Count);
+        Assert.AreEqual("decisions/glasswork-v2-prd", task.RelatedLinks[0].Slug);
+        Assert.IsNull(task.RelatedLinks[0].DisplayName);
+        Assert.AreEqual("contacts/jane-doe", task.RelatedLinks[1].Slug);
+        Assert.AreEqual("Jane Doe", task.RelatedLinks[1].DisplayName);
+        Assert.AreEqual("notes/loose-thought", task.RelatedLinks[2].Slug);
+    }
+
+    [TestMethod]
+    public void Parse_RelatedSection_BarePlainLines_ParsesEachLink()
+    {
+        var md = Header + """
+            ## Related
+
+            [[decisions/foo]]
+            [[notes/bar|Bar Note]]
+            """;
+
+        var task = _parser.Parse(md);
+
+        Assert.AreEqual(2, task.RelatedLinks.Count);
+        Assert.AreEqual("decisions/foo", task.RelatedLinks[0].Slug);
+        Assert.AreEqual("notes/bar", task.RelatedLinks[1].Slug);
+        Assert.AreEqual("Bar Note", task.RelatedLinks[1].DisplayName);
+    }
+
+    [TestMethod]
+    public void Parse_RelatedSection_TrimsWhitespace_AndIgnoresPlainText()
+    {
+        var md = Header + """
+            ## Related
+
+            Some agent commentary here, no link.
+            -   [[decisions/foo]]   
+            - some bullet without a link
+            """;
+
+        var task = _parser.Parse(md);
+
+        Assert.AreEqual(1, task.RelatedLinks.Count);
+        Assert.AreEqual("decisions/foo", task.RelatedLinks[0].Slug);
+    }
+
+    [TestMethod]
+    public void Parse_RelatedSection_StopsAtNextHeading()
+    {
+        var md = Header + """
+            ## Related
+
+            - [[decisions/foo]]
+
+            ## Notes
+
+            - [[should/not/be/parsed]]
+            """;
+
+        var task = _parser.Parse(md);
+
+        Assert.AreEqual(1, task.RelatedLinks.Count);
+        Assert.AreEqual("decisions/foo", task.RelatedLinks[0].Slug);
+    }
+
+    [TestMethod]
+    public void Parse_RelatedSection_PreservesSectionInBody_NotStrippedLikeSubtasks()
+    {
+        // Related is left in the body so Obsidian's graph view still works (D10).
+        // Unlike Subtasks, we don't strip it from Body.
+        var md = Header + """
+            ## Related
+
+            - [[decisions/foo]]
+            """;
+
+        var task = _parser.Parse(md);
+
+        Assert.IsTrue(task.Body.Contains("## Related"), "Related section should remain in Body.");
+        Assert.IsTrue(task.Body.Contains("[[decisions/foo]]"), "Related links should remain in Body.");
+    }
+
+    [TestMethod]
+    public void RelatedLink_FallbackDisplay_UsesLastSegmentOfSlug()
+    {
+        var l = new RelatedLink { Slug = "decisions/glasswork-v2-prd" };
+        Assert.AreEqual("glasswork-v2-prd", l.FallbackDisplay);
+
+        var l2 = new RelatedLink { Slug = "flat" };
+        Assert.AreEqual("flat", l2.FallbackDisplay);
+
+        var l3 = new RelatedLink { Slug = "x/y", DisplayName = "Pretty Name" };
+        Assert.AreEqual("Pretty Name", l3.FallbackDisplay);
+    }
+
+    [TestMethod]
+    public void Serialize_EmitsRelatedSection_AfterSubtasks()
+    {
+        var task = new GlassworkTask
+        {
+            Id = "t",
+            Title = "T",
+            Created = new DateTime(2026, 4, 17),
+            Body = "Some prose.",
+            RelatedLinks =
+            {
+                new RelatedLink { Slug = "decisions/foo" },
+                new RelatedLink { Slug = "contacts/jane", DisplayName = "Jane" },
+            },
+        };
+
+        var md = _parser.Serialize(task);
+
+        StringAssert.Contains(md, "## Related");
+        StringAssert.Contains(md, "- [[decisions/foo]]");
+        StringAssert.Contains(md, "- [[contacts/jane|Jane]]");
+    }
+
+    [TestMethod]
+    public void Roundtrip_ParseSerializeParse_PreservesRelatedLinks()
+    {
+        var original = Header + """
+            ## Related
+
+            - [[decisions/foo]]
+            - [[contacts/jane|Jane Doe]]
+            """;
+
+        var parsed = _parser.Parse(original);
+        var reSerialized = _parser.Serialize(parsed);
+        var reParsed = _parser.Parse(reSerialized);
+
+        Assert.AreEqual(2, reParsed.RelatedLinks.Count);
+        Assert.AreEqual("decisions/foo", reParsed.RelatedLinks[0].Slug);
+        Assert.AreEqual("contacts/jane", reParsed.RelatedLinks[1].Slug);
+        Assert.AreEqual("Jane Doe", reParsed.RelatedLinks[1].DisplayName);
+    }
+}

--- a/tests/Glasswork.Tests/WikiLinkHydratorTests.cs
+++ b/tests/Glasswork.Tests/WikiLinkHydratorTests.cs
@@ -1,0 +1,119 @@
+using System.IO;
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class WikiLinkHydratorTests
+{
+    private string _wikiRoot = string.Empty;
+
+    [TestInitialize]
+    public void Init()
+    {
+        _wikiRoot = Path.Combine(Path.GetTempPath(), "glasswork-hydrator-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_wikiRoot);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_wikiRoot)) Directory.Delete(_wikiRoot, recursive: true);
+    }
+
+    private void WritePage(string relativePath, string frontmatter)
+    {
+        var full = Path.Combine(_wikiRoot, relativePath.Replace('/', Path.DirectorySeparatorChar) + ".md");
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, $"---\n{frontmatter}\n---\n\nbody\n");
+    }
+
+    [TestMethod]
+    public void Hydrate_ResolvesTitleTypeAndCreated_FromTargetFrontmatter()
+    {
+        WritePage("decisions/glasswork-v2-prd",
+            "id: glasswork-v2-prd\ntitle: Glasswork V2 PRD\ntype: decision\ncreated: 2026-04-17");
+
+        var hydrator = new WikiLinkHydrator();
+        var input = new[] { new RelatedLink { Slug = "decisions/glasswork-v2-prd" } };
+
+        var result = hydrator.Hydrate(input, _wikiRoot);
+
+        Assert.AreEqual(1, result.Count);
+        var h = result[0];
+        Assert.IsFalse(h.IsMissing);
+        Assert.AreEqual("Glasswork V2 PRD", h.Title);
+        Assert.AreEqual("decision", h.Type);
+        Assert.AreEqual(new DateTime(2026, 4, 17), h.Created);
+        Assert.AreEqual("decisions/glasswork-v2-prd", h.Slug);
+    }
+
+    [TestMethod]
+    public void Hydrate_DisplayNameOverride_PreservedOnHydratedView()
+    {
+        WritePage("contacts/jane",
+            "id: jane\ntitle: Jane Doe (full)\ntype: contact\ncreated: 2026-01-01");
+
+        var hydrator = new WikiLinkHydrator();
+        var input = new[] { new RelatedLink { Slug = "contacts/jane", DisplayName = "Jane" } };
+
+        var result = hydrator.Hydrate(input, _wikiRoot);
+
+        Assert.AreEqual("Jane", result[0].DisplayName);
+        Assert.AreEqual("Jane Doe (full)", result[0].Title);
+    }
+
+    [TestMethod]
+    public void Hydrate_MissingFile_MarksIsMissingAndUsesSlugFallback()
+    {
+        var hydrator = new WikiLinkHydrator();
+        var input = new[] { new RelatedLink { Slug = "decisions/does-not-exist" } };
+
+        var result = hydrator.Hydrate(input, _wikiRoot);
+
+        Assert.AreEqual(1, result.Count);
+        Assert.IsTrue(result[0].IsMissing);
+        Assert.AreEqual("does-not-exist", result[0].Title);
+        Assert.IsNull(result[0].Created);
+        Assert.AreEqual("Missing", result[0].Subtitle);
+    }
+
+    [TestMethod]
+    public void Hydrate_MissingTitleInFrontmatter_FallsBackToSlugSegment()
+    {
+        WritePage("notes/orphan", "id: orphan\ntype: note\ncreated: 2026-02-02");
+
+        var hydrator = new WikiLinkHydrator();
+        var input = new[] { new RelatedLink { Slug = "notes/orphan" } };
+
+        var result = hydrator.Hydrate(input, _wikiRoot);
+
+        Assert.IsFalse(result[0].IsMissing);
+        Assert.AreEqual("orphan", result[0].Title);
+        Assert.AreEqual("note", result[0].Type);
+    }
+
+    [TestMethod]
+    public void Hydrate_FileWithoutFrontmatter_DoesNotThrow_AndUsesSlugFallback()
+    {
+        var full = Path.Combine(_wikiRoot, "notes", "raw.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, "Just plain markdown, no frontmatter.");
+
+        var hydrator = new WikiLinkHydrator();
+        var result = hydrator.Hydrate(new[] { new RelatedLink { Slug = "notes/raw" } }, _wikiRoot);
+
+        Assert.AreEqual(1, result.Count);
+        Assert.IsFalse(result[0].IsMissing);
+        Assert.AreEqual("raw", result[0].Title);
+    }
+
+    [TestMethod]
+    public void Hydrate_EmptyInput_ReturnsEmptyList()
+    {
+        var hydrator = new WikiLinkHydrator();
+        var result = hydrator.Hydrate(System.Array.Empty<RelatedLink>(), _wikiRoot);
+        Assert.AreEqual(0, result.Count);
+    }
+}


### PR DESCRIPTION
Closes #7.

## Slice 5: Related section + wiki page hydration

### Parser / serializer
- `FrontmatterParser` now parses `## Related` blocks of `- [[slug]]` / `- [[slug|display]]` lines into `GlassworkTask.RelatedLinks`.
- `Serialize()` re-emits the `## Related` block after `## Subtasks` so the section round-trips and Obsidian's graph view keeps working (per D10).

### Hydrator
- New `WikiLinkHydrator.Hydrate(links, wikiRoot)` reads each target wiki page's YAML frontmatter (`title`, `type`, `created`) and returns `HydratedRelatedLink` view-models. Missing files set `IsMissing = true`; missing titles fall back to the slug's last segment.

### UI
- `TaskDetailPage` gets a Related section above the action buttons. Each link renders as a card with type glyph, title, and `Type | yyyy-MM-dd` subtitle. Clicking opens the linked page in Obsidian using the same `obsidian://open?vault=Wiki&file=...` URI scheme already used by *Open in Obsidian*.

### Scope notes
- Wiki-side templates / skill files in `~/Wiki/` are intentionally **out of scope** for this slice (per the spec).
- XAML/code-behind additions are localized (one new `StackPanel` + one new method) to avoid conflicts with slice 11 (add-subtask UI) and slice 12 (ADO link UI), which are touching the same page.

### Verification
- `dotnet build src\Glasswork.App -p:Platform=x64` -- clean, 0 warnings.
- `dotnet test tests\Glasswork.Tests` -- 119 passing. The single failure (`DebouncerTests.Trigger_FiresAgainAfterQuietPeriodElapses`) is a pre-existing flaky timing test unrelated to this slice.
- 15 new tests across `RelatedLinkParserTests` (parse + serialize + round-trip) and `WikiLinkHydratorTests` (resolve / override display name / missing file / missing title / no frontmatter / empty input).