### PR TITLE
Slice 8: Wrap-up completion flow

### DIFF
--- a/skills/glasswork-wrap-up/SKILL.md
+++ b/skills/glasswork-wrap-up/SKILL.md
@@ -11,17 +11,72 @@ The task lives at `wiki/todo/<task-id>.md` in the user's wiki vault (typically `
 
 > Full design context lives in the PRD: `~/Wiki/wiki/decisions/glasswork-v2-prd.md` (see decisions **D4** routing, **D6** completion flow, **D8** guardrails, **D9** notes format). Read it if anything below is ambiguous.
 
-## Process
+## Process (D6 — seven steps)
 
-1. **Read the task file** at `wiki/todo/<task-id>.md` end-to-end. Parse the YAML frontmatter and the body.
+1. **Read the task file** at `wiki/todo/<task-id>.md` end-to-end. Parse the YAML frontmatter and the body. Skim any pages referenced in `## Related` so the summary reflects the wider context.
 2. **Read recent `## Notes` entries** (especially the last few `### YYYY-MM-DD` blocks) to understand what actually happened during the work.
-3. **Append a wrap-up entry** to `## Notes` using the timestamped log format (see below). 2–4 lines: what was accomplished, what's left, any follow-ups.
-4. **Propose a status change** to the user:
-   - If the work is genuinely complete → propose `status: done`.
-   - If it's being parked / handed off → propose another status (e.g. `blocked`, or leaving it as-is) and explain why.
+3. **Write/refresh the `### Summary` block** at the **top** of `## Notes` (see "Summary block" below). 3–6 lines compressing what shipped, what's left, and any follow-ups.
+4. **Append today's wrap-up entry** to the timestamped log at the bottom of `## Notes` using the D9 format (see below). 2–4 lines.
+5. **Verify subtask accounting** (see "Subtask accounting gate" below). Every `### [ ]` subtask must be done, dropped, or carried over. If anything is unaccounted for, **refuse to mark `status: done`** and surface the unresolved items so the user can resolve them.
+6. **Propose a status change** to the user:
+   - If the work is genuinely complete → propose `status: done` **and** `completed: <today>`.
+   - If it's being parked / handed off → propose another status (e.g. `blocked`, or leaving it as-is) and explain why. Do not stamp `completed:` in this case.
    - **You must get explicit confirmation before changing `status` to `done`.** Never set it silently. The wrap-up itself is also a CONFIRM action — don't finalize until the user says so.
-5. **Ask whether to mark substantial work as an accomplishment.** If the work feels meaningful (not a routine fix), propose creating `wiki/accomplishments/<title>-<date>.md` — this is the **only skill** that creates accomplishment pages — and ask the user to confirm before creating it.
-6. **Summarise what you did** at the end of the session: which fields you changed, which files you touched, any open follow-ups the user might want to capture as new tasks.
+7. **Ask whether to mark substantial work as an accomplishment** (see "Substantial-ness heuristic" below). If yes, propose creating `wiki/accomplishments/<title>-<date>.md` — this is the **only skill** that creates accomplishment pages — and ask the user to confirm before creating it.
+8. **On confirmation, finalize:** stamp `status: done` and `completed: YYYY-MM-DD` in the frontmatter, then **move the file** from `wiki/todo/<task-id>.md` to `wiki/todo/done/<task-id>.md` (create `done/` if missing). The Glasswork app's FileWatcherService picks up the move and regenerates `_index.md` / `_today.md` automatically — completed tasks disappear from the active index because the index only scans the top-level `wiki/todo/` directory.
+9. **Summarise what you did** at the end of the session: which fields you changed, which files you touched, the new path of the file, any open follow-ups the user might want to capture as new tasks.
+
+## Summary block (top of `## Notes`)
+
+The `### Summary` subsection lives at the **very top** of `## Notes`, immediately under the `## Notes` header and above the timestamped `### YYYY-MM-DD` log. It's the wrap-up's headline: a future reader (or future-you) should be able to read just the summary and understand the outcome without scrolling the log.
+
+```markdown
+## Notes
+
+### Summary
+Shipped the new BatchOptions defaults in PR #1234. Default `batch_size` is now
+100 across `appsettings.json` and the `[[batch-tuning]]` runbook. Two follow-ups
+captured as new tasks: deprecate the legacy `MaxBatch` knob, and add a metrics
+dashboard for batch latency.
+
+### 2026-04-18
+Started work. Plan: read PartitionedBatchProcessor, then trace batch_size config.
+…
+```
+
+**Rules:**
+- The `### Summary` header is fixed — always exactly that, always at the top of `## Notes`.
+- **Regenerate or update** the summary on each wrap-up (it's not appended to). If a previous wrap-up wrote one, replace it with the current view. The timestamped log below is **never** rewritten.
+- 3–6 lines, prose. Mention the concrete artifacts (PRs, decisions, wiki pages created) and any explicit follow-ups.
+- If you do not have enough material to write a meaningful summary, say so and ask the user before fabricating one.
+- This is a **targeted edit**: insert/replace just the `### Summary` block. Do not touch the `### YYYY-MM-DD` entries below it.
+
+## Subtask accounting gate
+
+Before you can propose `status: done`, every subtask under `## Subtasks` must be in one of these terminal states:
+
+| State | How it looks | Meaning |
+|---|---|---|
+| **Done** | `### [x] Title` **or** subtask metadata block contains `- status: done` | Completed in this task. |
+| **Dropped** | Subtask metadata block contains `- status: dropped` | Decided not to do — note **why** in the summary or notes. |
+| **Carried over** | A new task exists in `wiki/todo/` that picks up the work, **and** the wrap-up summary or today's notes entry mentions it by ID (e.g. `Carried over to [[follow-up-task]]`) | Work continues elsewhere. |
+
+If any subtask is `### [ ]` and isn't carried over, **refuse to mark the parent done**. List the offending subtasks back to the user and ask them to either (a) check them off, (b) mark `status: dropped`, or (c) confirm a follow-up task they want you to create. After they resolve them, re-run the gate.
+
+This is the only place the wrap-up skill walks the subtask tree — keep it shallow (one level, the existing flat `### [ ]` headers under `## Subtasks`).
+
+## Substantial-ness heuristic (accomplishment proposal)
+
+Propose `wiki/accomplishments/<title>-<date>.md` when **two or more** of these apply:
+
+- **Visible artifact:** shipped a PR, a published doc, an outage mitigation, a deployed config, a deck — something with a URL.
+- **Multi-day effort:** the timestamped log spans more than two distinct days, or the task has 3+ checked-off subtasks.
+- **Cross-cutting:** the work touched multiple services/teams or required pulling in someone outside the immediate team.
+- **Reusable knowledge:** the wrap-up created a `decisions/`, `concepts/`, or `incidents/` page (i.e. there's something worth pointing back to).
+
+**Skip** the proposal — don't even ask — for routine fixes: a typo PR, a one-line config tweak, a single-day investigation that didn't change anything, or a task that was abandoned (`status: dropped`).
+
+When in doubt, ask the user with one short sentence ("This felt substantial — want me to draft an accomplishment page?") rather than creating one silently. The CONFIRM gate still applies.
 
 ## Notes log format (D9 — Option B, timestamped)
 
@@ -75,8 +130,10 @@ These are **baked into this skill** and override any user request that conflicts
 
 ### CONFIRM — allowed only with explicit user confirmation in this session
 - **Transition the task's `status` to `done`** — the headline wrap-up action. Always confirm. One Enter-press is fine, but the checkpoint is mandatory.
-- **Finalize the wrap-up itself** (any frontmatter mutation, the `completed: <date>` stamp, etc.). Don't run the whole sequence unattended.
-- Move, rename, or delete any wiki page (the "move task to `done/`" step is out of scope this slice anyway).
+- **Stamp `completed: YYYY-MM-DD`** in the frontmatter (only when flipping to `done`).
+- **Move the task file** from `wiki/todo/<id>.md` to `wiki/todo/done/<id>.md`. This is the final mechanical step of wrap-up and only runs after the user confirms `done`.
+- **Finalize the wrap-up itself** (any frontmatter mutation, the `completed:` stamp, the move). Don't run the whole sequence unattended.
+- Move, rename, or delete any **other** wiki page.
 - Create a `wiki/accomplishments/` page — propose first, then wait.
 - Run any command that mutates external state (git push, ADO comments).
 - Write source code. (You may **read** code freely; write only when the user explicitly says so.)
@@ -94,8 +151,8 @@ If a request would require breaking a HARD NO rule, refuse and name which guardr
 
 ## Scope notes
 
-- The current task format is **flat** — there are no nested subtasks to verify yet. Don't try to walk a subtask tree or enforce "every subtask must be done/dropped."
-- **Do not move the file** out of `wiki/todo/` in this slice. The "move to `done/`" step is a later slice.
-- **Do not rewrite or compress the existing `## Notes` log.** Just append the wrap-up entry. Summarising the log is a later slice.
+- Subtask accounting is **shallow** — walk only the flat `### [ ]` headers under `## Subtasks` (and their immediate metadata blocks for `status: done` / `status: dropped`). Don't recurse — the format is flat.
+- **Move the file** to `wiki/todo/done/<id>.md` after the user confirms `done`. Create the `done/` directory if it doesn't exist. Do not delete the file — moving preserves history.
+- **Do not rewrite or compress the existing timestamped `### YYYY-MM-DD` log.** The `### Summary` block at the top is the only part of `## Notes` you may rewrite; everything below it is append-only.
 - Don't touch the `## Related` section. A later slice owns that maintenance.
-- All edits to the task file are **targeted** (append a line, insert a header, change one frontmatter field). Never rewrite the whole file.
+- All edits to the task file are **targeted** (append a line, insert/replace the `### Summary` block, change one frontmatter field). Never rewrite the whole file.

--- a/tests/Glasswork.Tests/IndexServiceTests.cs
+++ b/tests/Glasswork.Tests/IndexServiceTests.cs
@@ -83,4 +83,31 @@ public class IndexServiceTests
         var content = File.ReadAllText(Path.Combine(_tempDir, "_today.md"));
         Assert.IsTrue(content.Contains("No tasks picked for today yet"));
     }
+
+    [TestMethod]
+    public void Refresh_TaskMovedToDoneSubdir_NotListedInIndex()
+    {
+        // Wrap-up flow moves completed task files from wiki/todo/<id>.md to
+        // wiki/todo/done/<id>.md. The index should only reflect ACTIVE tasks
+        // (top-level vault). Files under done/ must not appear.
+        _vault.Save(new GlassworkTask { Id = "active-task", Title = "Active Task", Status = "todo" });
+        _vault.Save(new GlassworkTask { Id = "wrapped-task", Title = "Wrapped Task", Status = "done" });
+
+        _index.Refresh();
+        var before = File.ReadAllText(Path.Combine(_tempDir, "_index.md"));
+        Assert.IsTrue(before.Contains("Wrapped Task"), "Pre-move sanity: completed task should appear in Done (Recent).");
+
+        // Simulate the wrap-up move: relocate wrapped-task.md into done/ subfolder.
+        var doneDir = Path.Combine(_tempDir, "done");
+        Directory.CreateDirectory(doneDir);
+        File.Move(
+            Path.Combine(_tempDir, "wrapped-task.md"),
+            Path.Combine(doneDir, "wrapped-task.md"));
+
+        _index.Refresh();
+
+        var after = File.ReadAllText(Path.Combine(_tempDir, "_index.md"));
+        Assert.IsFalse(after.Contains("Wrapped Task"), "Tasks moved to done/ subfolder must not appear in _index.md.");
+        Assert.IsTrue(after.Contains("Active Task"), "Active task should still appear after the move.");
+    }
 }


### PR DESCRIPTION
Closes #9.

Extends `skills/glasswork-wrap-up/SKILL.md` to cover the full seven-step D6 completion flow, plus a small app-side regression test.

## Skill changes

- **Summary block** — new `### Summary` subsection at the top of `## Notes`, regenerated/updated on each wrap-up. The timestamped `### YYYY-MM-DD` log below it stays intact and append-only.
- **Subtask accounting gate** — wrap-up refuses to mark a parent `status: done` until every `### [ ]` subtask is `[x]`, marked `status: dropped`, or explicitly carried over to a follow-up task. Lists offending items back to the user.
- **`completed: YYYY-MM-DD`** — stamped in frontmatter alongside the `status: done` flip.
- **Substantial-ness heuristic** — clarified the accomplishment proposal: propose when 2+ of {visible artifact, multi-day, cross-cutting, reusable knowledge}; skip silently for routine fixes.
- **Move to `wiki/todo/done/`** — final mechanical step after the user confirms `done`. Old `Do not move the file` scope note flipped; CONFIRM list updated.
- **Confirmation gate** — language preserved; one Enter is fine, gate is mandatory before stamping/moving.

## App-side changes

- `VaultService.LoadAll` already uses non-recursive `Directory.GetFiles(_vaultPath, ""*.md"")` and `FileWatcherService` uses `IncludeSubdirectories = false` — so files in `wiki/todo/done/` are naturally excluded from the index and the move triggers a `Deleted` event on the top-level path that fires regen. No code change needed.
- Added `IndexServiceTests.Refresh_TaskMovedToDoneSubdir_NotListedInIndex` to lock that invariant in: a task present in the top-level vault is rendered, then after `File.Move` into `done/` and a `Refresh()`, it disappears from `_index.md`.

## Verification

- `dotnet build src\Glasswork.App -p:Platform=x64` — succeeded, 0 warnings, 0 errors.
- `dotnet test` (excluding the known-flaky `DebouncerTests.Trigger_FiresAgainAfterQuietPeriodElapses`) — **142 passed**, 0 failed (was 141 on main; +1 new regression test).

## Notes / design

- Subtask accounting is shallow by design — the format is flat (`### [ ]` headers under `## Subtasks`), and the skill walks one level only.
- The `### Summary` is the only part of `## Notes` the skill may rewrite; everything below it is append-only.
- No new file writers were introduced, so no new `SelfWriteCoordinator` registrations needed.
