### PR TITLE
Capture page/task/version context in feedback dialog (closes #86)

### DIFF
--- a/src/Glasswork.App/MainWindow.xaml.cs
+++ b/src/Glasswork.App/MainWindow.xaml.cs
@@ -1,8 +1,11 @@
 using System;
 using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Glasswork.Core.Feedback;
 using Glasswork.Pages;
 
 // To learn more about WinUI, the WinUI project structure,
@@ -180,7 +183,7 @@ public sealed partial class MainWindow : Window
 
     private async void ShowFeedbackDialog()
     {
-        var dialog = new FeedbackDialog
+        var dialog = new FeedbackDialog(CaptureFeedbackContext())
         {
             XamlRoot = Content.XamlRoot
         };
@@ -188,5 +191,44 @@ public sealed partial class MainWindow : Window
         // Dialog files the issue directly via `gh issue create` and shows the result
         // (filed URL, or actionable error — gh missing, not authenticated, etc.) inline.
         await dialog.ShowAsync();
+    }
+
+    private FeedbackContext CaptureFeedbackContext()
+    {
+        // Page name is just the type name (e.g. "MyDayPage"); the full namespace is noise
+        // in a triage table.
+        string? pageName = null;
+        try
+        {
+            pageName = NavFrame.CurrentSourcePageType?.Name;
+        }
+        catch
+        {
+            // Defensive: never let context capture fail the feedback flow.
+        }
+
+        return new FeedbackContext(
+            PageName: pageName,
+            ActiveTaskId: App.ActiveTask.ActiveTaskId,
+            AppVersion: ResolveAppVersion(),
+            OsDescription: RuntimeInformation.OSDescription,
+            RuntimeVersion: RuntimeInformation.FrameworkDescription,
+            CapturedAtUtc: DateTimeOffset.UtcNow);
+    }
+
+    private static string ResolveAppVersion()
+    {
+        try
+        {
+            var asm = Assembly.GetExecutingAssembly();
+            // InformationalVersion includes any +commit suffix; fall back to assembly version.
+            var info = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+            if (!string.IsNullOrWhiteSpace(info)) return info;
+            return asm.GetName().Version?.ToString() ?? "unknown";
+        }
+        catch
+        {
+            return "unknown";
+        }
     }
 }

--- a/src/Glasswork.App/Pages/FeedbackDialog.xaml
+++ b/src/Glasswork.App/Pages/FeedbackDialog.xaml
@@ -21,6 +21,10 @@
         <TextBox x:Name="BodyBox" Header="Details" PlaceholderText="Describe the issue or idea..."
                  AcceptsReturn="True" TextWrapping="Wrap" Height="120" />
 
+        <CheckBox x:Name="IncludeContextBox" IsChecked="True"
+                  Content="Include page, active task, app version, OS, and runtime"
+                  ToolTipService.ToolTip="When checked, attaches a context table with the current page, active task ID, app version, OS, and runtime to the issue body. Uncheck if your task ID contains anything you'd rather not publish." />
+
         <InfoBar x:Name="StatusBar" IsOpen="False" />
     </StackPanel>
 </ContentDialog>

--- a/src/Glasswork.App/Pages/FeedbackDialog.xaml.cs
+++ b/src/Glasswork.App/Pages/FeedbackDialog.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Glasswork.Core.Feedback;
 using Glasswork.Services;
 using Microsoft.UI.Xaml.Controls;
 
@@ -8,14 +9,20 @@ namespace Glasswork.Pages;
 public sealed partial class FeedbackDialog : ContentDialog
 {
     private readonly GhCliIssueFiler _filer;
+    private readonly FeedbackContext? _context;
 
-    public FeedbackDialog() : this(new GhCliIssueFiler())
+    public FeedbackDialog() : this(new GhCliIssueFiler(), context: null)
     {
     }
 
-    internal FeedbackDialog(GhCliIssueFiler filer)
+    public FeedbackDialog(FeedbackContext? context) : this(new GhCliIssueFiler(), context)
+    {
+    }
+
+    internal FeedbackDialog(GhCliIssueFiler filer, FeedbackContext? context)
     {
         _filer = filer;
+        _context = context;
         InitializeComponent();
     }
 
@@ -45,7 +52,7 @@ public sealed partial class FeedbackDialog : ContentDialog
             StatusBar.Severity = InfoBarSeverity.Informational;
             StatusBar.IsOpen = true;
 
-            var issueBody = BuildIssueBody(category, body);
+            var issueBody = FeedbackBodyFormatter.Build(category, body, _context);
             var result = await _filer.TryFileIssueAsync(title, issueBody, labels);
 
             if (result.Succeeded)
@@ -79,11 +86,4 @@ public sealed partial class FeedbackDialog : ContentDialog
         _ => new[] { "user-report" },
     };
 
-    private static string BuildIssueBody(string category, string body)
-    {
-        // Tag provenance so triage can tell real bugs from feature requests without
-        // re-reading the title, and preserve the user's body verbatim below.
-        var header = $"_Filed from Glasswork feedback dialog — category: **{category}**_";
-        return string.IsNullOrEmpty(body) ? header : $"{header}\n\n{body}";
-    }
 }

--- a/src/Glasswork.App/Pages/FeedbackDialog.xaml.cs
+++ b/src/Glasswork.App/Pages/FeedbackDialog.xaml.cs
@@ -52,7 +52,8 @@ public sealed partial class FeedbackDialog : ContentDialog
             StatusBar.Severity = InfoBarSeverity.Informational;
             StatusBar.IsOpen = true;
 
-            var issueBody = FeedbackBodyFormatter.Build(category, body, _context);
+            var includeContext = IncludeContextBox.IsChecked == true;
+            var issueBody = FeedbackBodyFormatter.Build(category, body, includeContext ? _context : null);
             var result = await _filer.TryFileIssueAsync(title, issueBody, labels);
 
             if (result.Succeeded)

--- a/src/Glasswork.Core/Feedback/FeedbackBodyFormatter.cs
+++ b/src/Glasswork.Core/Feedback/FeedbackBodyFormatter.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Text;
+
+namespace Glasswork.Core.Feedback;
+
+/// <summary>
+/// Builds the GitHub issue body submitted from the in-app feedback dialog.
+/// Lives in Core so it can be unit-tested without spinning up WinUI.
+/// </summary>
+public static class FeedbackBodyFormatter
+{
+    /// <summary>
+    /// Render the issue body. Layout is:
+    /// <code>
+    /// _Filed from Glasswork feedback dialog — category: **Bug**_
+    ///
+    /// ## Context
+    /// | Field | Value |
+    /// | --- | --- |
+    /// | Page | MyDayPage |
+    /// | Active task | task-... |
+    /// | ...
+    ///
+    /// &lt;user body&gt;
+    /// </code>
+    /// When <paramref name="context"/> is null the Context section is omitted entirely
+    /// (so the formatter degrades gracefully if the App can't capture context for some reason).
+    /// </summary>
+    public static string Build(string category, string? body, FeedbackContext? context)
+    {
+        var sb = new StringBuilder();
+        sb.Append("_Filed from Glasswork feedback dialog — category: **")
+          .Append(category)
+          .Append("**_");
+
+        if (context is not null)
+        {
+            sb.Append("\n\n## Context\n\n");
+            sb.Append("| Field | Value |\n");
+            sb.Append("| --- | --- |\n");
+            AppendRow(sb, "Page", context.PageName);
+            AppendRow(sb, "Active task", context.ActiveTaskId);
+            AppendRow(sb, "App version", context.AppVersion);
+            AppendRow(sb, "OS", context.OsDescription);
+            AppendRow(sb, "Runtime", context.RuntimeVersion);
+            AppendRow(sb, "Captured", context.CapturedAtUtc.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"));
+        }
+
+        var trimmedBody = body?.Trim() ?? string.Empty;
+        if (trimmedBody.Length > 0)
+        {
+            sb.Append("\n\n");
+            sb.Append(trimmedBody);
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendRow(StringBuilder sb, string field, string? value)
+    {
+        // Empty/null values render as "(none)" so a reviewer can tell the difference between
+        // "we didn't capture this" and "the user wasn't on a task page" — the field is always present.
+        var display = string.IsNullOrWhiteSpace(value) ? "(none)" : EscapeCell(value);
+        sb.Append("| ").Append(field).Append(" | ").Append(display).Append(" |\n");
+    }
+
+    private static string EscapeCell(string s)
+    {
+        // Pipe and newline are the only chars that break GFM table rendering; escape pipes,
+        // collapse newlines to spaces. Everything else (including underscores) is fine inline.
+        return s.Replace("|", "\\|").Replace("\r", " ").Replace("\n", " ");
+    }
+}

--- a/src/Glasswork.Core/Feedback/FeedbackContext.cs
+++ b/src/Glasswork.Core/Feedback/FeedbackContext.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Glasswork.Core.Feedback;
+
+/// <summary>
+/// Snapshot of UI state at the moment the user opened the feedback dialog.
+/// Captured by the App layer (page name, active task) and the runtime (versions, OS)
+/// and rendered into the issue body by <see cref="FeedbackBodyFormatter"/> so triage
+/// has the context the user forgot to mention.
+/// </summary>
+public sealed record FeedbackContext(
+    string? PageName,
+    string? ActiveTaskId,
+    string AppVersion,
+    string OsDescription,
+    string RuntimeVersion,
+    DateTimeOffset CapturedAtUtc);

--- a/tests/Glasswork.Tests/FeedbackBodyFormatterTests.cs
+++ b/tests/Glasswork.Tests/FeedbackBodyFormatterTests.cs
@@ -1,0 +1,139 @@
+using System;
+using Glasswork.Core.Feedback;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class FeedbackBodyFormatterTests
+{
+    private static FeedbackContext SampleContext(
+        string? pageName = "MyDayPage",
+        string? activeTaskId = "task-2026-04-24-fix-thing",
+        string appVersion = "0.5.0",
+        string osDescription = "Microsoft Windows 10.0.26100",
+        string runtimeVersion = ".NET 10.0.0") =>
+        new(
+            PageName: pageName,
+            ActiveTaskId: activeTaskId,
+            AppVersion: appVersion,
+            OsDescription: osDescription,
+            RuntimeVersion: runtimeVersion,
+            CapturedAtUtc: new DateTimeOffset(2026, 4, 24, 22, 30, 15, TimeSpan.Zero));
+
+    [TestMethod]
+    public void Build_PreservesCategoryHeader()
+    {
+        var body = FeedbackBodyFormatter.Build("Bug", "Something broke", SampleContext());
+
+        StringAssert.Contains(body, "_Filed from Glasswork feedback dialog — category: **Bug**_");
+    }
+
+    [TestMethod]
+    public void Build_PreservesUserBodyVerbatim()
+    {
+        const string userBody = "Steps:\n1. Open My Day\n2. Click reload\n\nExpected: refresh\nActual: crash";
+
+        var body = FeedbackBodyFormatter.Build("Bug", userBody, SampleContext());
+
+        StringAssert.Contains(body, userBody);
+    }
+
+    [TestMethod]
+    public void Build_IncludesContextSection()
+    {
+        var body = FeedbackBodyFormatter.Build("Bug", "broke", SampleContext());
+
+        StringAssert.Contains(body, "## Context");
+    }
+
+    [TestMethod]
+    public void Build_RendersAllContextFieldsWhenPresent()
+    {
+        var body = FeedbackBodyFormatter.Build("Bug", "broke", SampleContext());
+
+        StringAssert.Contains(body, "MyDayPage");
+        StringAssert.Contains(body, "task-2026-04-24-fix-thing");
+        StringAssert.Contains(body, "0.5.0");
+        StringAssert.Contains(body, "Microsoft Windows 10.0.26100");
+        StringAssert.Contains(body, ".NET 10.0.0");
+        StringAssert.Contains(body, "2026-04-24T22:30:15");
+    }
+
+    [TestMethod]
+    public void Build_ShowsNoneForMissingPage()
+    {
+        var body = FeedbackBodyFormatter.Build("Bug", "broke",
+            SampleContext(pageName: null));
+
+        // Page row must still appear (so reviewer knows we tried to capture it),
+        // but its value reads "(none)" rather than blank.
+        StringAssert.Contains(body, "Page");
+        StringAssert.Contains(body, "(none)");
+    }
+
+    [TestMethod]
+    public void Build_ShowsNoneForMissingActiveTask()
+    {
+        var body = FeedbackBodyFormatter.Build("Feature Request", "idea",
+            SampleContext(activeTaskId: null));
+
+        StringAssert.Contains(body, "Active task");
+        StringAssert.Contains(body, "(none)");
+    }
+
+    [TestMethod]
+    public void Build_NullContext_OmitsContextSection()
+    {
+        var body = FeedbackBodyFormatter.Build("General Feedback", "thoughts", context: null);
+
+        StringAssert.Contains(body, "_Filed from Glasswork feedback dialog");
+        StringAssert.Contains(body, "thoughts");
+        Assert.IsFalse(body.Contains("## Context"),
+            "Context section should be omitted when context is null.");
+    }
+
+    [TestMethod]
+    public void Build_EmptyBody_StillIncludesHeaderAndContext()
+    {
+        var body = FeedbackBodyFormatter.Build("Bug", "", SampleContext());
+
+        StringAssert.Contains(body, "_Filed from Glasswork feedback dialog");
+        StringAssert.Contains(body, "## Context");
+        StringAssert.Contains(body, "MyDayPage");
+        // No trailing whitespace garbage at the very end.
+        Assert.AreEqual(body, body.TrimEnd() + (body.EndsWith('\n') ? "\n" : ""),
+            "Should not have stray trailing whitespace beyond a single optional newline.");
+    }
+
+    [TestMethod]
+    public void Build_NullBody_TreatedAsEmpty()
+    {
+        var body = FeedbackBodyFormatter.Build("Bug", body: null, SampleContext());
+
+        StringAssert.Contains(body, "_Filed from Glasswork feedback dialog");
+        StringAssert.Contains(body, "## Context");
+    }
+
+    [TestMethod]
+    public void Build_TimestampIsIso8601Utc()
+    {
+        var body = FeedbackBodyFormatter.Build("Bug", "x", SampleContext());
+
+        // We render captured time as an ISO-8601 instant ending in 'Z' so triage doesn't have
+        // to guess the timezone.
+        StringAssert.Contains(body, "2026-04-24T22:30:15Z");
+    }
+
+    [TestMethod]
+    public void Build_HeaderAppearsBeforeContextBeforeUserBody()
+    {
+        var body = FeedbackBodyFormatter.Build("Bug", "USER_BODY_MARKER", SampleContext());
+
+        var headerIdx = body.IndexOf("_Filed from Glasswork feedback dialog", StringComparison.Ordinal);
+        var contextIdx = body.IndexOf("## Context", StringComparison.Ordinal);
+        var userIdx = body.IndexOf("USER_BODY_MARKER", StringComparison.Ordinal);
+
+        Assert.IsTrue(headerIdx >= 0 && contextIdx > headerIdx && userIdx > contextIdx,
+            $"Expected header < context < user body. Got header={headerIdx} context={contextIdx} user={userIdx}.\nBody:\n{body}");
+    }
+}

--- a/tests/Glasswork.Tests/FeedbackBodyFormatterTests.cs
+++ b/tests/Glasswork.Tests/FeedbackBodyFormatterTests.cs
@@ -125,6 +125,54 @@ public class FeedbackBodyFormatterTests
     }
 
     [TestMethod]
+    public void Build_EscapesPipesInCellValues()
+    {
+        // Auto-triage and humans both read the table; an unescaped pipe would split the
+        // cell and corrupt every following row.
+        var body = FeedbackBodyFormatter.Build("Bug", "x",
+            SampleContext(activeTaskId: "task-foo|bar|baz"));
+
+        StringAssert.Contains(body, "task-foo\\|bar\\|baz");
+        Assert.IsFalse(body.Contains("task-foo|bar"),
+            "Raw unescaped pipe leaked into table cell.");
+    }
+
+    [TestMethod]
+    public void Build_CollapsesNewlinesInCellValues()
+    {
+        // A literal newline in a cell breaks the GFM table; the formatter must flatten them.
+        var body = FeedbackBodyFormatter.Build("Bug", "x",
+            SampleContext(osDescription: "Line one\r\nLine two\nLine three"));
+
+        StringAssert.Contains(body, "Line one  Line two Line three");
+        // No raw \n inside the OS row — find the row and check it's a single line.
+        var osLineStart = body.IndexOf("| OS |", StringComparison.Ordinal);
+        var osLineEnd = body.IndexOf('\n', osLineStart);
+        var osRow = body.Substring(osLineStart, osLineEnd - osLineStart);
+        Assert.IsFalse(osRow.Contains('\r') || osRow.Contains('\n'),
+            $"OS row still contains raw newlines: '{osRow}'");
+    }
+
+    [TestMethod]
+    public void Build_NormalizesNonUtcTimestampToUtc()
+    {
+        // 10:30:15 in -07:00 == 17:30:15 UTC. The Captured row must reflect UTC, not local.
+        var ctx = new FeedbackContext(
+            PageName: "MyDayPage",
+            ActiveTaskId: "task-x",
+            AppVersion: "1.0.0",
+            OsDescription: "Windows",
+            RuntimeVersion: ".NET 10",
+            CapturedAtUtc: new DateTimeOffset(2026, 4, 24, 10, 30, 15, TimeSpan.FromHours(-7)));
+
+        var body = FeedbackBodyFormatter.Build("Bug", "x", ctx);
+
+        StringAssert.Contains(body, "2026-04-24T17:30:15Z");
+        Assert.IsFalse(body.Contains("2026-04-24T10:30:15Z"),
+            "Timestamp was not converted to UTC before rendering.");
+    }
+
+    [TestMethod]
     public void Build_HeaderAppearsBeforeContextBeforeUserBody()
     {
         var body = FeedbackBodyFormatter.Build("Bug", "USER_BODY_MARKER", SampleContext());


### PR DESCRIPTION
Closes #86.

## What changed

- New `Glasswork.Core.Feedback.FeedbackBodyFormatter` renders a GFM Context table (Page / Active task / App version / OS / Runtime / Captured) in front of the user's body. Pure, no Windows deps, testable on Linux.
- `MainWindow.ShowFeedbackDialog` now snapshots a `FeedbackContext` (page from `NavFrame.CurrentSourcePageType`, active task from `App.ActiveTask`, version via `AssemblyInformationalVersion`, OS + runtime via `RuntimeInformation`, ISO-8601 UTC timestamp) and passes it to the dialog.
- `FeedbackDialog` accepts an optional `FeedbackContext` and routes through the formatter; null context is safe (table is omitted).

## Tests

11 new tests in `FeedbackBodyFormatterTests` lock down: header preserved, body verbatim, all 6 fields rendered, header < context < body ordering, null-context omits table, null/empty cells render as `(none)`, ISO-8601 timestamp.