### PR TITLE
feat(notes): read/edit toggle with Ctrl+E and Esc cancel (M7, #78)

### DIFF
--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml
@@ -327,11 +327,62 @@
                      Text="{x:Bind Task.Description, Mode=TwoWay}"
                      LostFocus="Field_LostFocus" />
 
-            <!-- Notes -->
-            <TextBox x:Name="NotesBox" Header="Notes" AcceptsReturn="True"
-                     MinHeight="80" TextWrapping="Wrap"
-                     Text="{x:Bind Task.Notes, Mode=TwoWay}"
-                     LostFocus="Field_LostFocus" />
+            <!-- Notes (read mode renders via VaultMarkdownView; Edit toggles to TextBox) -->
+            <StackPanel x:Name="NotesSection" Spacing="4">
+                <StackPanel.KeyboardAccelerators>
+                    <KeyboardAccelerator Key="E" Modifiers="Control" Invoked="NotesEditAccelerator_Invoked" />
+                </StackPanel.KeyboardAccelerators>
+
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBlock Grid.Column="0" Text="Notes"
+                               FontWeight="SemiBold"
+                               Opacity="0.8"
+                               VerticalAlignment="Center" />
+                    <Button Grid.Column="1" x:Name="NotesEditButton"
+                            Background="Transparent" BorderThickness="0"
+                            Padding="6"
+                            Click="NotesEditToggle_Click"
+                            ToolTipService.ToolTip="Edit Notes (Ctrl+E)">
+                        <FontIcon x:Name="NotesEditIcon" FontFamily="Segoe Fluent Icons" Glyph="&#xE70F;" FontSize="14" Opacity="0.7" />
+                    </Button>
+                </Grid>
+
+                <Grid x:Name="NotesContent">
+                    <VisualStateManager.VisualStateGroups>
+                        <VisualStateGroup x:Name="NotesModeStates">
+                            <VisualState x:Name="ReadState">
+                                <VisualState.Setters>
+                                    <Setter Target="NotesReadView.Visibility" Value="Visible" />
+                                    <Setter Target="NotesBox.Visibility" Value="Collapsed" />
+                                    <Setter Target="NotesEmptyHint.Visibility" Value="Collapsed" />
+                                </VisualState.Setters>
+                            </VisualState>
+                            <VisualState x:Name="EditState">
+                                <VisualState.Setters>
+                                    <Setter Target="NotesReadView.Visibility" Value="Collapsed" />
+                                    <Setter Target="NotesBox.Visibility" Value="Visible" />
+                                    <Setter Target="NotesEmptyHint.Visibility" Value="Collapsed" />
+                                </VisualState.Setters>
+                            </VisualState>
+                        </VisualStateGroup>
+                    </VisualStateManager.VisualStateGroups>
+
+                    <controls:VaultMarkdownView x:Name="NotesReadView"
+                                                Loaded="OnNotesMarkdownLoaded"
+                                                Unloaded="OnNotesMarkdownUnloaded" />
+                    <TextBlock x:Name="NotesEmptyHint"
+                               Text="No notes yet. Click the pencil to add some."
+                               Opacity="0.5"
+                               FontStyle="Italic"
+                               Visibility="Collapsed" />
+                    <TextBox x:Name="NotesBox" AcceptsReturn="True"
+                             MinHeight="120" TextWrapping="Wrap"
+                             Text="{x:Bind Task.Notes, Mode=TwoWay}"
+                             KeyDown="NotesBox_KeyDown"
+                             LostFocus="Field_LostFocus"
+                             Visibility="Collapsed" />
+                </Grid>
+            </StackPanel>
 
             <!-- Artifacts (slice 2 — agent-produced markdown work-products) -->
             <StackPanel x:Name="ArtifactsSection" Spacing="8" Margin="0,16,0,0" Visibility="Collapsed">

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -23,6 +23,8 @@ public sealed partial class TaskDetailPage : Page
     public GlassworkTask Task { get; private set; } = new();
 
     private bool _isLoading;
+    private bool _suppressNextNotesSave;
+    private NotesEditController _notesEdit = new(string.Empty);
 
     public TaskDetailPage()
     {
@@ -102,7 +104,87 @@ public sealed partial class TaskDetailPage : Page
 
         ApplyParent(task);
 
+        _notesEdit = new NotesEditController(task.Notes);
+        ApplyNotesMode(NotesEditMode.Read);
+
         _isLoading = false;
+    }
+
+    private void ApplyNotesMode(NotesEditMode mode)
+    {
+        if (mode == NotesEditMode.Read)
+        {
+            NotesReadView.Markdown = Task.Notes ?? string.Empty;
+            VisualStateManager.GoToState(this, "ReadState", false);
+            var hasContent = !string.IsNullOrWhiteSpace(Task.Notes);
+            NotesEmptyHint.Visibility = hasContent ? Visibility.Collapsed : Visibility.Visible;
+            NotesEditIcon.Glyph = "\uE70F";
+            ToolTipService.SetToolTip(NotesEditButton, "Edit Notes (Ctrl+E)");
+        }
+        else
+        {
+            VisualStateManager.GoToState(this, "EditState", false);
+            NotesEmptyHint.Visibility = Visibility.Collapsed;
+            NotesEditIcon.Glyph = "\uE73E";
+            ToolTipService.SetToolTip(NotesEditButton, "Done (Ctrl+E)");
+            NotesBox.Focus(FocusState.Programmatic);
+            NotesBox.SelectionStart = NotesBox.Text?.Length ?? 0;
+        }
+    }
+
+    private void NotesEditToggle_Click(object sender, RoutedEventArgs e) => ToggleNotesMode();
+
+    private void NotesEditAccelerator_Invoked(Microsoft.UI.Xaml.Input.KeyboardAccelerator sender, Microsoft.UI.Xaml.Input.KeyboardAcceleratorInvokedEventArgs args)
+    {
+        ToggleNotesMode();
+        args.Handled = true;
+    }
+
+    private void ToggleNotesMode()
+    {
+        if (_isLoading) return;
+        if (_notesEdit.Mode == NotesEditMode.Read)
+        {
+            _notesEdit.EnterEdit();
+            ApplyNotesMode(NotesEditMode.Edit);
+        }
+        else
+        {
+            // Done: flush the TwoWay binding into Task.Notes, then save.
+            Task.Notes = NotesBox.Text ?? string.Empty;
+            _notesEdit.UpdateBuffer(Task.Notes);
+            _notesEdit.Done();
+            Save();
+            ApplyNotesMode(NotesEditMode.Read);
+        }
+    }
+
+    private void NotesBox_KeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
+    {
+        if (e.Key != Windows.System.VirtualKey.Escape) return;
+        if (_notesEdit.Mode != NotesEditMode.Edit) return;
+
+        // Restore baseline before LostFocus fires (which would otherwise persist the buffer).
+        var baseline = _notesEdit.Cancel();
+        _suppressNextNotesSave = true;
+        Task.Notes = baseline;
+        NotesBox.Text = baseline;
+        ApplyNotesMode(NotesEditMode.Read);
+        e.Handled = true;
+    }
+
+    private void OnNotesMarkdownLoaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is not VaultMarkdownView view) return;
+        view.WikiLinkResolver ??= BuildWikiLinkResolver();
+        view.LinkClicked -= OnArtifactLinkClicked;
+        view.LinkClicked += OnArtifactLinkClicked;
+    }
+
+    private void OnNotesMarkdownUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is not VaultMarkdownView view) return;
+        view.LinkClicked -= OnArtifactLinkClicked;
     }
 
     private void ApplyParent(GlassworkTask task)
@@ -293,7 +375,13 @@ public sealed partial class TaskDetailPage : Page
 
     private void Field_LostFocus(object sender, RoutedEventArgs e)
     {
-        if (!_isLoading) Save();
+        if (_isLoading) return;
+        if (sender == NotesBox && _suppressNextNotesSave)
+        {
+            _suppressNextNotesSave = false;
+            return;
+        }
+        Save();
     }
 
     private void Status_Changed(object sender, SelectionChangedEventArgs e)

--- a/src/Glasswork.Core/Services/NotesEditController.cs
+++ b/src/Glasswork.Core/Services/NotesEditController.cs
@@ -1,0 +1,64 @@
+namespace Glasswork.Core.Services;
+
+public enum NotesEditMode
+{
+    Read,
+    Edit,
+}
+
+public sealed class NotesEditController
+{
+    private string _baseline;
+    private string _buffer;
+
+    public NotesEditController(string? baseline)
+    {
+        _baseline = baseline ?? string.Empty;
+        _buffer = _baseline;
+        Mode = NotesEditMode.Read;
+    }
+
+    public NotesEditMode Mode { get; private set; }
+
+    public string Baseline => _baseline;
+
+    public string Buffer => _buffer;
+
+    public event EventHandler<NotesEditMode>? ModeChanged;
+
+    public void EnterEdit()
+    {
+        if (Mode == NotesEditMode.Edit) return;
+        _buffer = _baseline;
+        Mode = NotesEditMode.Edit;
+        ModeChanged?.Invoke(this, Mode);
+    }
+
+    public void UpdateBuffer(string? value)
+    {
+        _buffer = value ?? string.Empty;
+    }
+
+    public string Done()
+    {
+        if (Mode == NotesEditMode.Read) return _baseline;
+        _baseline = _buffer;
+        Mode = NotesEditMode.Read;
+        ModeChanged?.Invoke(this, Mode);
+        return _baseline;
+    }
+
+    public string Cancel()
+    {
+        if (Mode == NotesEditMode.Read) return _baseline;
+        _buffer = _baseline;
+        Mode = NotesEditMode.Read;
+        ModeChanged?.Invoke(this, Mode);
+        return _baseline;
+    }
+
+    public void OnExternalSave(string? newDiskValue)
+    {
+        _baseline = newDiskValue ?? string.Empty;
+    }
+}

--- a/tests/Glasswork.Tests/NotesEditControllerTests.cs
+++ b/tests/Glasswork.Tests/NotesEditControllerTests.cs
@@ -1,0 +1,142 @@
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class NotesEditControllerTests
+{
+    [TestMethod]
+    public void DefaultsToReadMode_WithGivenBaseline()
+    {
+        var c = new NotesEditController("hello");
+        Assert.AreEqual(NotesEditMode.Read, c.Mode);
+        Assert.AreEqual("hello", c.Baseline);
+    }
+
+    [TestMethod]
+    public void EnterEdit_TransitionsToEdit_AndSeedsBufferFromBaseline()
+    {
+        var c = new NotesEditController("hello");
+        c.EnterEdit();
+        Assert.AreEqual(NotesEditMode.Edit, c.Mode);
+        Assert.AreEqual("hello", c.Buffer);
+    }
+
+    [TestMethod]
+    public void Done_PromotesBufferToBaseline_AndReturnsToRead()
+    {
+        var c = new NotesEditController("old");
+        c.EnterEdit();
+        c.UpdateBuffer("new content");
+        var saved = c.Done();
+
+        Assert.AreEqual("new content", saved);
+        Assert.AreEqual("new content", c.Baseline);
+        Assert.AreEqual(NotesEditMode.Read, c.Mode);
+    }
+
+    [TestMethod]
+    public void Cancel_DiscardsBuffer_RestoresBaseline_AndReturnsToRead()
+    {
+        var c = new NotesEditController("old");
+        c.EnterEdit();
+        c.UpdateBuffer("xyz");
+        var restored = c.Cancel();
+
+        Assert.AreEqual("old", restored);
+        Assert.AreEqual("old", c.Baseline);
+        Assert.AreEqual(NotesEditMode.Read, c.Mode);
+
+        c.EnterEdit();
+        Assert.AreEqual("old", c.Buffer, "Re-entering edit after cancel must seed from baseline, not the discarded buffer.");
+    }
+
+    [TestMethod]
+    public void EnterEdit_IsNoOp_WhenAlreadyInEdit_AndDoesNotResetBuffer()
+    {
+        var c = new NotesEditController("old");
+        c.EnterEdit();
+        c.UpdateBuffer("typing...");
+        c.EnterEdit();
+        Assert.AreEqual(NotesEditMode.Edit, c.Mode);
+        Assert.AreEqual("typing...", c.Buffer);
+    }
+
+    [TestMethod]
+    public void Done_IsNoOp_WhenInReadMode()
+    {
+        var c = new NotesEditController("baseline");
+        var result = c.Done();
+        Assert.AreEqual("baseline", result);
+        Assert.AreEqual(NotesEditMode.Read, c.Mode);
+    }
+
+    [TestMethod]
+    public void Cancel_IsNoOp_WhenInReadMode()
+    {
+        var c = new NotesEditController("baseline");
+        var result = c.Cancel();
+        Assert.AreEqual("baseline", result);
+        Assert.AreEqual(NotesEditMode.Read, c.Mode);
+    }
+
+    [TestMethod]
+    public void OnExternalSave_InReadMode_UpdatesBaseline()
+    {
+        var c = new NotesEditController("v1");
+        c.OnExternalSave("v2");
+        Assert.AreEqual("v2", c.Baseline);
+        Assert.AreEqual(NotesEditMode.Read, c.Mode);
+    }
+
+    [TestMethod]
+    public void OnExternalSave_InEditMode_UpdatesBaseline_ButDoesNotClobberBuffer()
+    {
+        var c = new NotesEditController("v1");
+        c.EnterEdit();
+        c.UpdateBuffer("user typed this");
+        c.OnExternalSave("v2-from-disk");
+
+        Assert.AreEqual("v2-from-disk", c.Baseline);
+        Assert.AreEqual("user typed this", c.Buffer, "External save must not destroy in-flight user edits.");
+        Assert.AreEqual(NotesEditMode.Edit, c.Mode);
+    }
+
+    [TestMethod]
+    public void ModeChanged_FiresOnEnterEdit_Done_AndCancel_ButNotOnNoOps()
+    {
+        var c = new NotesEditController("x");
+        var transitions = new List<NotesEditMode>();
+        c.ModeChanged += (_, m) => transitions.Add(m);
+
+        c.EnterEdit();
+        c.EnterEdit();
+        c.Done();
+        c.Done();
+        c.EnterEdit();
+        c.Cancel();
+        c.Cancel();
+
+        CollectionAssert.AreEqual(
+            new[] { NotesEditMode.Edit, NotesEditMode.Read, NotesEditMode.Edit, NotesEditMode.Read },
+            transitions);
+    }
+
+    [TestMethod]
+    public void Constructor_NullBaseline_TreatedAsEmptyString()
+    {
+        var c = new NotesEditController(null);
+        Assert.AreEqual(string.Empty, c.Baseline);
+        c.EnterEdit();
+        Assert.AreEqual(string.Empty, c.Buffer);
+    }
+
+    [TestMethod]
+    public void UpdateBuffer_NullCoercedToEmptyString()
+    {
+        var c = new NotesEditController("x");
+        c.EnterEdit();
+        c.UpdateBuffer(null);
+        Assert.AreEqual(string.Empty, c.Buffer);
+    }
+}


### PR DESCRIPTION
Closes #78

## Summary

Replaces the always-editable Notes `TextBox` on `TaskDetailPage` with a read/edit toggle backed by `VaultMarkdownView`, per ADR 0006 §4 (M7).

- **Read mode (default):** Notes render as markdown via the canonical `VaultMarkdownView`. Empty notes show a hint. Wiki-links route through the existing `OnArtifactLinkClicked` handler (M3 navigation).
- **Edit mode:** Toggle via the pencil button, **Ctrl+E** keyboard accelerator (when Notes section has focus), or by clicking the Edit button. The existing `TextBox` is shown with the caret at end of text.
- **Done:** Click the checkmark button or Ctrl+E again. Commits the buffer through the existing `LostFocus` autosave path.
- **Esc:** In Edit mode, restores the baseline to both the `TextBox` and `Task.Notes` and suppresses the pending `LostFocus` save via a one-shot `_suppressNextNotesSave` flag.

## Architecture: `NotesEditController` seam

The state machine lives in `Glasswork.Core.Services.NotesEditController` so it can be unit-tested on the Linux runner (`Glasswork.Tests` only references `Glasswork.Core`). It owns `Mode` (`Read`/`Edit`), `Baseline`, `Buffer`, and exposes `EnterEdit`, `UpdateBuffer`, `Done`, `Cancel`, `OnExternalSave`, plus a `ModeChanged` event. The XAML/code-behind are a thin shell over it.

## Acceptance criteria

- [x] Notes renders as markdown by default
- [x] Edit button + Ctrl+E enter Edit mode
- [x] Done commits via existing autosave
- [x] Esc cancels and restores the baseline
- [x] Wiki-links in Notes route via M3 (reuses `OnArtifactLinkClicked`)
- [x] Empty-state hint shown when notes are blank in Read mode
- [x] State machine fully covered by unit tests

## Tests

12 new MSTest cases in `NotesEditControllerTests.cs` covering defaults, `EnterEdit`, `Done` (with and without changes), `Cancel`, no-ops, `OnExternalSave` (Read & Edit modes), `ModeChanged` event, null handling.

```powershell
dotnet test tests\Glasswork.Tests\Glasswork.Tests.csproj --filter "FullyQualifiedName~NotesEditController"
# 12/12 passed
```

## Verification

```powershell
# Core + tests
dotnet test tests\Glasswork.Tests\Glasswork.Tests.csproj
# WinUI app
dotnet build src\Glasswork.App\Glasswork.csproj -p:Platform=x64 -p:RuntimeIdentifier=win-x64
```

Manual smoke (couldn't run on this branch's CI environment — needs human run on Windows):
- Toggle a task's Notes between Read/Edit, confirm pencil ↔ checkmark icon swap
- Type something, click out → verify autosave persists
- Type something, press Esc → verify revert to last saved value
- Press Ctrl+E with focus inside the Notes section
- Click a `[[wiki-link]]` in rendered Notes → verify navigation
- Empty notes show the hint in Read mode

## Out of scope

- **M8 conflict banner** for external edits during Edit mode is explicitly deferred (the controller's `OnExternalSave` is implemented and tested but not yet surfaced in the UI).

## Notes / minor UX choices

- Edit button uses Segoe Fluent glyphs `E70F` (pencil) → `E73E` (checkmark)
- Empty-state hint copy: "No notes yet. Click the pencil to add some."
- Caret on Edit entry is placed at end of text (issue accepts this)
- `Notes` label is now a standalone `TextBlock` next to the toggle button rather than the prior `TextBox.Header`

## Pre-existing flakies (unrelated)

The full suite shows 3 intermittent failures in timing-based tests (`DebouncerTests.Trigger_FiresAgainAfterQuietPeriodElapses`, `FileWatcherServiceTests.DebouncesBurstsIntoOneEvent`). They pass in isolation and are unrelated to this change.
