### PR TITLE
feat(my-day): MyDayRemovalPolicy + virtual promotion wiring (closes #97)

### DIFF
--- a/src/Glasswork.App/Pages/MyDayPage.xaml
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml
@@ -17,21 +17,35 @@
         <conv:DueUrgencyForegroundBrushConverter x:Key="DueFg" />
     </Page.Resources>
 
-    <Grid Padding="32" RowDefinitions="Auto,*,Auto,Auto,Auto,Auto,Auto">
+    <Grid Padding="32" RowDefinitions="Auto,Auto,*,Auto,Auto,Auto,Auto,Auto">
 
         <!-- Header -->
-        <StackPanel Grid.Row="0">
-            <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="My Day" />
-            <TextBlock Text="{x:Bind TodayDate}" Opacity="0.6" Margin="0,4,0,0" />
-        </StackPanel>
+        <Grid Grid.Row="0" ColumnDefinitions="*,Auto">
+            <StackPanel Grid.Column="0">
+                <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="My Day" />
+                <TextBlock Text="{x:Bind TodayDate}" Opacity="0.6" Margin="0,4,0,0" />
+            </StackPanel>
+            <Button Grid.Column="1" Click="RefreshButton_Click"
+                    VerticalAlignment="Top" Margin="0,4,0,0"
+                    ToolTipService.ToolTip="Refresh from vault">
+                <StackPanel Orientation="Horizontal" Spacing="6">
+                    <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE72C;" FontSize="14" />
+                    <TextBlock Text="Refresh" />
+                </StackPanel>
+            </Button>
+        </Grid>
 
-        <!-- Today's tasks -->
+        <!-- Today's tasks header -->
+        <TextBlock x:Name="TodayHeader" Grid.Row="1" Text="Today's tasks"
+                   Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,16,0,8" />
+
         <ListView
-            Grid.Row="1"
+            Grid.Row="2"
             x:Name="TodayList"
             ItemsSource="{x:Bind ViewModel.TodayTasks}"
             SelectionMode="Single"
             IsItemClickEnabled="False"
+            MinHeight="320"
             Margin="0,16,0,0">
             <ListView.ItemContainerStyle>
                 <Style TargetType="ListViewItem">
@@ -131,15 +145,38 @@
                                        TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
                                        Visibility="{Binding HasBlurb, Converter={StaticResource BoolVis}}" />
                         </StackPanel>
+
+                        <!-- Today's subtasks (ADR 0008): flagged or due-today subtasks rendered
+                             inline beneath the parent. Visible whenever any qualify, even when
+                             the parent's card details are collapsed, since these subtasks are
+                             the reason this parent appears in My Day. -->
+                        <ItemsControl Grid.Row="1" ItemsSource="{Binding TodaysSubtasks}"
+                                      Visibility="{Binding HasTodaysSubtasks, Converter={StaticResource BoolVis}}"
+                                      Margin="32,4,0,0">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid Padding="0,2" ColumnDefinitions="Auto,*">
+                                        <FontIcon Grid.Column="0" FontFamily="Segoe Fluent Icons"
+                                                  Glyph="&#xE73E;" FontSize="11"
+                                                  Margin="0,0,8,0" VerticalAlignment="Center"
+                                                  Opacity="0.55" />
+                                        <TextBlock Grid.Column="1" Text="{Binding Text}"
+                                                   FontSize="12" Opacity="0.75"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   VerticalAlignment="Center" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
 
-        <!-- Empty state: shown when My Day has no tasks and no flagged subtasks -->
+        <!-- Empty state: shown when My Day has no tasks. -->
         <controls:EmptyState
             x:Name="EmptyStateView"
-            Grid.Row="1"
+            Grid.Row="2"
             Margin="0,16,0,0"
             Glyph="&#xE706;"
             Headline="Today is open."
@@ -148,53 +185,17 @@
             CtaClicked="EmptyState_OpenBacklog"
             Visibility="Collapsed" />
 
-        <!-- Flagged subtasks (parents not in My Day, but with at least one subtask flagged today) -->
-        <StackPanel x:Name="SubtaskGroupsSection" Grid.Row="2" Margin="0,16,0,0" Visibility="Collapsed">
-            <TextBlock Text="Flagged subtasks" Style="{StaticResource SubtitleTextBlockStyle}" />
-            <ItemsControl ItemsSource="{x:Bind SubtaskGroups}" Margin="0,8,0,0">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                                BorderThickness="1" CornerRadius="6"
-                                Padding="12,8" Margin="0,0,0,8">
-                            <StackPanel Spacing="4">
-                                <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <TextBlock Text="{Binding ParentTitle}" FontWeight="SemiBold" />
-                                    <TextBlock Text="{Binding OtherSubtasksLabel}" Opacity="0.55" />
-                                </StackPanel>
-                                <ItemsControl ItemsSource="{Binding Anchors}">
-                                    <ItemsControl.ItemTemplate>
-                                        <DataTemplate>
-                                            <Grid ColumnDefinitions="*,Auto" Padding="8,4,0,4">
-                                                <HyperlinkButton Grid.Column="0" Content="{Binding DisplayText}"
-                                                                 Click="SubtaskAnchor_Click"
-                                                                 HorizontalAlignment="Left" Padding="0" />
-                                                <Button Grid.Column="1" Click="RemoveSubtaskFromDay_Click"
-                                                        Background="Transparent" BorderThickness="0"
-                                                        Padding="6" VerticalAlignment="Center"
-                                                        ToolTipService.ToolTip="Remove subtask from My Day">
-                                                    <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE711;" FontSize="12" />
-                                                </Button>
-                                            </Grid>
-                                        </DataTemplate>
-                                    </ItemsControl.ItemTemplate>
-                                </ItemsControl>
-                            </StackPanel>
-                        </Border>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-        </StackPanel>
+        <!-- ADR 0008: separate "Flagged subtasks" section removed; parents are now virtually
+             promoted into Today's tasks above with qualifying subtasks rendered inline. -->
 
         <!-- Recently Completed (today, was on My Day) -->
-        <StackPanel x:Name="RecentlyCompletedHeader" Grid.Row="3" Orientation="Horizontal" Spacing="8" Margin="0,24,0,8" Visibility="Collapsed">
+        <StackPanel x:Name="RecentlyCompletedHeader" Grid.Row="4" Orientation="Horizontal" Spacing="8" Margin="0,24,0,8" Visibility="Collapsed">
             <TextBlock Text="Recently completed" Style="{StaticResource SubtitleTextBlockStyle}" Opacity="0.75" />
             <TextBlock Text="{x:Bind ViewModel.RecentlyCompletedTasks.Count, Mode=OneWay}" Opacity="0.5" VerticalAlignment="Center" />
         </StackPanel>
 
-        <ListView x:Name="RecentlyCompletedList" Grid.Row="4" Visibility="Collapsed"
-                  ItemsSource="{x:Bind ViewModel.RecentlyCompletedTasks}" SelectionMode="None" MaxHeight="200">
+        <ListView x:Name="RecentlyCompletedList" Grid.Row="5" Visibility="Collapsed"
+                  ItemsSource="{x:Bind ViewModel.RecentlyCompletedTasks}" SelectionMode="None" MaxHeight="140">
             <ListView.ItemContainerStyle>
                 <Style TargetType="ListViewItem">
                     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -245,13 +246,13 @@
         </ListView>
 
         <!-- Suggestions header -->
-        <StackPanel Grid.Row="5" Orientation="Horizontal" Spacing="12" Margin="0,24,0,8">
+        <StackPanel Grid.Row="6" Orientation="Horizontal" Spacing="12" Margin="0,24,0,8">
             <TextBlock Text="Suggestions" Style="{StaticResource SubtitleTextBlockStyle}" />
             <Button Content="Carry all" Click="CarryAll_Click" />
         </StackPanel>
 
         <!-- Suggestions list (slim — default) -->
-        <ListView x:Name="SuggestionsList" Grid.Row="6" ItemsSource="{x:Bind ViewModel.Suggestions}" SelectionMode="None" MaxHeight="200">
+        <ListView x:Name="SuggestionsList" Grid.Row="7" ItemsSource="{x:Bind ViewModel.Suggestions}" SelectionMode="None" MaxHeight="140">
             <ListView.ItemContainerStyle>
                 <Style TargetType="ListViewItem">
                     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -278,7 +279,7 @@
         </ListView>
 
         <!-- Suggestions list (rich — empty state only) -->
-        <ListView x:Name="RichSuggestionsList" Grid.Row="6" Visibility="Collapsed"
+        <ListView x:Name="RichSuggestionsList" Grid.Row="7" Visibility="Collapsed"
                   ItemsSource="{x:Bind ViewModel.Suggestions}" SelectionMode="None" MaxHeight="400">
             <ListView.ItemContainerStyle>
                 <Style TargetType="ListViewItem">

--- a/src/Glasswork.App/Pages/MyDayPage.xaml.cs
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
 using Glasswork.Core.Models;
 using Glasswork.ViewModels;
 using Microsoft.UI.Xaml;
@@ -14,13 +11,6 @@ public sealed partial class MyDayPage : Page
 {
     public MyDayViewModel ViewModel { get; }
     public string TodayDate => DateTime.Today.ToString("dddd, MMMM d");
-
-    /// <summary>
-    /// Parents whose own my_day flag is NOT set today, but who have at least one subtask
-    /// flagged for today. Rendered compactly under a "Flagged subtasks" section so the
-    /// parent doesn't appear twice in My Day.
-    /// </summary>
-    public ObservableCollection<SubtaskMyDayGroup> SubtaskGroups { get; } = [];
 
     public MyDayPage()
     {
@@ -54,42 +44,32 @@ public sealed partial class MyDayPage : Page
         {
             t.IsManuallyCollapsed = App.UiState.Get<bool>($"{App.CollapsedTaskKeyPrefix}{t.Id}");
         }
-        RebuildSubtaskGroups();
         UpdateEmptyState();
     }
 
     private void UpdateEmptyState()
     {
-        var hasContent = ViewModel.TodayTasks.Count > 0 || SubtaskGroups.Count > 0;
-        TodayList.Visibility = hasContent ? Visibility.Visible : Visibility.Collapsed;
-        EmptyStateView.Visibility = hasContent ? Visibility.Collapsed : Visibility.Visible;
+        var hasToday = ViewModel.TodayTasks.Count > 0;
+        TodayHeader.Visibility = hasToday ? Visibility.Visible : Visibility.Collapsed;
+        TodayList.Visibility = hasToday ? Visibility.Visible : Visibility.Collapsed;
+        EmptyStateView.Visibility = hasToday ? Visibility.Collapsed : Visibility.Visible;
         // Suggestions: slim by default, rich when My Day is empty.
-        SuggestionsList.Visibility = hasContent ? Visibility.Visible : Visibility.Collapsed;
-        RichSuggestionsList.Visibility = hasContent ? Visibility.Collapsed : Visibility.Visible;
+        SuggestionsList.Visibility = hasToday ? Visibility.Visible : Visibility.Collapsed;
+        RichSuggestionsList.Visibility = hasToday ? Visibility.Collapsed : Visibility.Visible;
         // Recently completed: hidden when none.
         var hasCompleted = ViewModel.RecentlyCompletedTasks.Count > 0;
         RecentlyCompletedHeader.Visibility = hasCompleted ? Visibility.Visible : Visibility.Collapsed;
         RecentlyCompletedList.Visibility = hasCompleted ? Visibility.Visible : Visibility.Collapsed;
     }
 
+    private void RefreshButton_Click(object sender, RoutedEventArgs e)
+    {
+        Refresh();
+    }
+
     private void EmptyState_OpenBacklog(object sender, RoutedEventArgs e)
     {
         Frame.Navigate(typeof(BacklogPage));
-    }
-
-    private void RebuildSubtaskGroups()
-    {
-        SubtaskGroups.Clear();
-        var all = App.Vault.LoadAll();
-        foreach (var t in all.Where(t => !t.IsMyDay))
-        {
-            var flagged = t.Subtasks.Where(s => s.IsMyDay).ToList();
-            if (flagged.Count == 0) continue;
-            SubtaskGroups.Add(new SubtaskMyDayGroup(t, flagged));
-        }
-        SubtaskGroupsSection.Visibility = SubtaskGroups.Count > 0
-            ? Visibility.Visible : Visibility.Collapsed;
-        UpdateEmptyState();
     }
 
     private void OpenTask_Click(object sender, RoutedEventArgs e)
@@ -124,7 +104,6 @@ public sealed partial class MyDayPage : Page
         if (sender is FrameworkElement { DataContext: GlassworkTask task })
         {
             ViewModel.CompleteTaskCommand.Execute(task);
-            RebuildSubtaskGroups();
         }
     }
 
@@ -133,7 +112,6 @@ public sealed partial class MyDayPage : Page
         if (sender is FrameworkElement { DataContext: GlassworkTask task })
         {
             ViewModel.UncompleteTaskCommand.Execute(task);
-            RebuildSubtaskGroups();
         }
     }
 
@@ -142,7 +120,6 @@ public sealed partial class MyDayPage : Page
         if (sender is FrameworkElement { DataContext: GlassworkTask task })
         {
             ViewModel.RemoveFromMyDayCommand.Execute(task);
-            RebuildSubtaskGroups();
         }
     }
 
@@ -151,85 +128,18 @@ public sealed partial class MyDayPage : Page
         if (sender is FrameworkElement { DataContext: GlassworkTask task })
         {
             ViewModel.AddToMyDayCommand.Execute(task);
-            RebuildSubtaskGroups();
         }
     }
 
     private void CarryAll_Click(object sender, RoutedEventArgs e)
     {
         ViewModel.CarryAllCommand.Execute(null);
-        RebuildSubtaskGroups();
-    }
-
-    private void SubtaskAnchor_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is FrameworkElement { DataContext: SubtaskAnchor anchor })
-        {
-            // Navigate to parent detail page; pass anchor info so the page can scroll/highlight
-            // the target subtask.
-            Frame.Navigate(typeof(TaskDetailPage), new TaskDetailNavigation(anchor.Parent, anchor.SubtaskTitle));
-        }
-    }
-
-    private void RemoveSubtaskFromDay_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is FrameworkElement { DataContext: SubtaskAnchor anchor })
-        {
-            App.Vault.SetSubtaskMyDay(anchor.Parent.Id, anchor.SubtaskTitle, isMyDay: false);
-            try { App.Index.Refresh(); } catch { /* index refresh is best-effort */ }
-            RebuildSubtaskGroups();
-        }
-    }
-}
-
-/// <summary>
-/// A parent task plus its flagged subtasks, used for the compact "Flagged subtasks" section
-/// in My Day. Exposes the subtasks as <see cref="SubtaskAnchor"/> entries so each row carries
-/// a back-pointer to its parent for navigation.
-/// </summary>
-public sealed class SubtaskMyDayGroup
-{
-    public GlassworkTask Parent { get; }
-    public IReadOnlyList<SubtaskAnchor> Anchors { get; }
-    public string ParentTitle => Parent.Title;
-    public string OtherSubtasksLabel
-    {
-        get
-        {
-            var others = Parent.Subtasks.Count - Anchors.Count;
-            return others > 0 ? $"({others} other subtask{(others == 1 ? "" : "s")})" : string.Empty;
-        }
-    }
-    public bool HasOtherSubtasks => Parent.Subtasks.Count - Anchors.Count > 0;
-
-    public SubtaskMyDayGroup(GlassworkTask parent, IList<SubTask> flagged)
-    {
-        Parent = parent;
-        Anchors = flagged.Select(s => new SubtaskAnchor(parent, s)).ToList();
-    }
-}
-
-/// <summary>
-/// A flagged subtask paired with a back-pointer to its parent task. Used as a row data
-/// context for the My Day compact view; click navigates to the parent detail page and
-/// targets this subtask via <see cref="TaskDetailNavigation"/>.
-/// </summary>
-public sealed class SubtaskAnchor
-{
-    public GlassworkTask Parent { get; }
-    public SubTask Subtask { get; }
-    public string SubtaskTitle => Subtask.Text;
-    public string DisplayText => Subtask.Text;
-
-    public SubtaskAnchor(GlassworkTask parent, SubTask subtask)
-    {
-        Parent = parent;
-        Subtask = subtask;
     }
 }
 
 /// <summary>
 /// Navigation parameter for <c>TaskDetailPage</c> when the user clicks a subtask anchor in
 /// My Day. Carries both the task to display and the title of the subtask to scroll to/highlight.
+/// Retained for compatibility with <see cref="TaskDetailPage"/> consumers.
 /// </summary>
 public sealed record TaskDetailNavigation(GlassworkTask Task, string FocusSubtaskTitle);

--- a/src/Glasswork.App/ViewModels/MyDayViewModel.cs
+++ b/src/Glasswork.App/ViewModels/MyDayViewModel.cs
@@ -27,18 +27,12 @@ public partial class MyDayViewModel : ObservableObject
     }
 
     /// <summary>
-    /// A task is "on My Day today" if either its persisted my_day flag is set, or it is
-    /// due today/overdue and not yet done — and the user has not dismissed it for today.
-    /// Dismiss is stored as a per-day UI state flag so the vault stays untouched.
+    /// A task is "on My Day today" per <see cref="MyDayPromotionPolicy.IsTaskInMyDayToday"/>:
+    /// pinned via my_day, due-today/overdue, OR has a flagged-or-due-today subtask — and the
+    /// user has not dismissed it for today. See ADR 0008.
     /// </summary>
-    private bool IsOnMyDayToday(GlassworkTask t)
-    {
-        if (t.Status == GlassworkTask.Statuses.Done) return false;
-        if (IsDismissedToday(t.Id)) return false;
-        if (t.IsMyDay) return true;
-        if (t.Due.HasValue && t.Due.Value.Date <= System.DateTime.Today) return true;
-        return false;
-    }
+    private bool IsOnMyDayToday(GlassworkTask t, System.DateOnly today, System.Collections.Generic.IReadOnlySet<string> dismissed)
+        => MyDayPromotionPolicy.IsTaskInMyDayToday(t, today, dismissed);
 
     private static string DismissKey(string taskId) =>
         $"dismissed.{System.DateTime.Today:yyyy-MM-dd}.{taskId}";
@@ -54,10 +48,27 @@ public partial class MyDayViewModel : ObservableObject
         Suggestions.Clear();
 
         var all = _vault.LoadAll();
+        var today = System.DateOnly.FromDateTime(System.DateTime.Today);
 
-        // Today's tasks: persisted my_day OR due-today/overdue (virtual inclusion).
-        foreach (var task in all.Where(IsOnMyDayToday).OrderByDescending(t => t.Priority == "urgent"))
+        // Build the dismissed-today set once so the predicate stays pure.
+        var dismissed = new System.Collections.Generic.HashSet<string>(
+            all.Where(t => IsDismissedToday(t.Id)).Select(t => t.Id));
+
+        // Today's tasks: pinned, due-today/overdue, OR virtually promoted by a flagged/due-today
+        // subtask (ADR 0008). Only virtually-promoted parents get TodaysSubtasks attached for
+        // inline rendering — directly-promoted parents already show their in-progress subtask
+        // via the card-details "Current step" row.
+        foreach (var task in all.Where(t => IsOnMyDayToday(t, today, dismissed))
+                                 .OrderByDescending(t => t.Priority == "urgent"))
         {
+            var directlyPromoted =
+                task.MyDay.HasValue ||
+                (task.Due.HasValue
+                 && System.DateOnly.FromDateTime(task.Due.Value.Date) <= today
+                 && task.Status != GlassworkTask.Statuses.Done);
+            task.TodaysSubtasks = directlyPromoted
+                ? null
+                : MyDayPromotionPolicy.TodaysSubtasks(task, today);
             TodayTasks.Add(task);
         }
 
@@ -130,13 +141,15 @@ public partial class MyDayViewModel : ObservableObject
     public void RemoveFromMyDay(GlassworkTask? task)
     {
         if (task is null) return;
-        // Clear persisted flag if set.
-        if (task.IsMyDay)
+        var plan = MyDayRemovalPolicy.PlanRemoval(task);
+        if (plan.ClearMyDayFlag)
         {
             _taskService.ToggleMyDay(task);
         }
-        // Also dismiss for today so virtually-included due/overdue tasks don't reappear.
-        _uiState?.Set(DismissKey(task.Id), true);
+        if (plan.SetDismissForToday)
+        {
+            _uiState?.Set(DismissKey(task.Id), true);
+        }
         Refresh();
     }
 

--- a/src/Glasswork.Core/Models/GlassworkTask.cs
+++ b/src/Glasswork.Core/Models/GlassworkTask.cs
@@ -179,6 +179,19 @@ public partial class GlassworkTask : ObservableObject
     /// True when a card layout should be rendered for this task in lists (active and not collapsed).
     /// </summary>
     public bool ShowCardDetails => IsActive && !IsManuallyCollapsed;
+
+    /// <summary>
+    /// Subtasks that should render inline beneath this task on the My Day surface — the
+    /// flagged or due-today subtasks driving virtual promotion (ADR 0008). Populated by
+    /// <see cref="Glasswork.Core.Services.MyDayPromotionPolicy.TodaysSubtasks"/> at refresh
+    /// time and consumed by the My Day card template. Transient (not serialized).
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasTodaysSubtasks))]
+    public partial System.Collections.Generic.IReadOnlyList<SubTask>? TodaysSubtasks { get; set; }
+
+    /// <summary>True when there is at least one subtask to render inline in My Day.</summary>
+    public bool HasTodaysSubtasks => TodaysSubtasks is { Count: > 0 };
 }
 
 /// <summary>

--- a/src/Glasswork.Core/Services/MyDayPromotionPolicy.cs
+++ b/src/Glasswork.Core/Services/MyDayPromotionPolicy.cs
@@ -18,6 +18,9 @@ public static class MyDayPromotionPolicy
     {
         if (dismissedToday.Contains(task.Id)) return false;
 
+        // Done tasks belong in Recently Completed, never Today's tasks.
+        if (task.Status == GlassworkTask.Statuses.Done) return false;
+
         // Direct pin: MyDay frontmatter is set (any non-null value).
         if (task.MyDay.HasValue) return true;
 

--- a/src/Glasswork.Core/Services/MyDayRemovalPolicy.cs
+++ b/src/Glasswork.Core/Services/MyDayRemovalPolicy.cs
@@ -1,0 +1,23 @@
+using Glasswork.Core.Models;
+
+namespace Glasswork.Core.Services;
+
+/// <summary>
+/// Pure policy for the "Remove from My Day" command. Splits the decision from the
+/// side effects so the rule is testable without WinUI or vault I/O. See ADR 0008
+/// and issue #97: removal must always dismiss-for-today (so virtually-promoted
+/// parents stop appearing) and additionally clear the persisted my_day frontmatter
+/// when it is set (so a directly-pinned task doesn't pop back tomorrow). Subtask
+/// flags and due dates are never touched.
+/// </summary>
+public static class MyDayRemovalPolicy
+{
+    public readonly record struct Plan(bool ClearMyDayFlag, bool SetDismissForToday);
+
+    public static Plan PlanRemoval(GlassworkTask task)
+    {
+        return new Plan(
+            ClearMyDayFlag: task.MyDay.HasValue,
+            SetDismissForToday: true);
+    }
+}

--- a/tests/Glasswork.Tests/MyDayPromotionPolicyTests.cs
+++ b/tests/Glasswork.Tests/MyDayPromotionPolicyTests.cs
@@ -61,6 +61,19 @@ public class MyDayPromotionPolicyTests
     }
 
     [TestMethod]
+    public void IsTaskInMyDayToday_PinnedMyDay_StatusDone_ReturnsFalse()
+    {
+        // Done tasks belong in Recently Completed, not Today's tasks — even when pinned via my_day.
+        var task = new GlassworkTask
+        {
+            Id = "t-done-pinned",
+            Status = GlassworkTask.Statuses.Done,
+            MyDay = DateTime.Today,
+        };
+        Assert.IsFalse(MyDayPromotionPolicy.IsTaskInMyDayToday(task, Today, NoDismissals));
+    }
+
+    [TestMethod]
     public void IsTaskInMyDayToday_OneFlaggedSubtask_ReturnsTrue()
     {
         var task = new GlassworkTask
@@ -124,6 +137,49 @@ public class MyDayPromotionPolicyTests
             MyDay = DateTime.Today,
         };
         var dismissed = new HashSet<string> { "t8" };
+        Assert.IsFalse(MyDayPromotionPolicy.IsTaskInMyDayToday(task, Today, dismissed));
+    }
+
+    [TestMethod]
+    public void IsTaskInMyDayToday_VirtuallyPromotedThenDismissed_ReturnsFalse()
+    {
+        // #97 case 1: parent promoted only by a flagged subtask. With the parent's id
+        // in dismissedToday, IsTaskInMyDayToday must return false so the parent
+        // disappears from My Day immediately and stays gone on refresh.
+        var parent = new GlassworkTask { Id = "p-virtual" };
+        parent.Subtasks.Add(new SubTask { Text = "promoter", Metadata = new() { ["my_day"] = "true" } });
+        var dismissed = new HashSet<string> { "p-virtual" };
+
+        Assert.IsFalse(MyDayPromotionPolicy.IsTaskInMyDayToday(parent, Today, dismissed));
+    }
+
+    [TestMethod]
+    public void IsTaskInMyDayToday_VirtuallyPromoted_NotDismissed_ReturnsTrue()
+    {
+        // #97 case 2: same parent without the dismissed-today entry promotes again
+        // (the dismiss key is date-scoped, so "tomorrow" naturally re-promotes).
+        var parent = new GlassworkTask { Id = "p-virtual" };
+        parent.Subtasks.Add(new SubTask { Text = "promoter", Metadata = new() { ["my_day"] = "true" } });
+
+        Assert.IsTrue(MyDayPromotionPolicy.IsTaskInMyDayToday(parent, Today, NoDismissals));
+    }
+
+    [TestMethod]
+    public void IsTaskInMyDayToday_PinnedAndDueToday_Dismissed_ReturnsFalse()
+    {
+        // #97 case 3: directly-pinned task that is also due today. Once the command
+        // both clears my_day AND sets dismiss, the task must NOT bounce back via the
+        // due-today rule. Modeling that here as: my_day cleared (null) + id in
+        // dismissedToday + task still due today. Predicate must return false.
+        var task = new GlassworkTask
+        {
+            Id = "p-pinned",
+            MyDay = null,
+            Due = DateTime.Today,
+            Status = GlassworkTask.Statuses.Todo,
+        };
+        var dismissed = new HashSet<string> { "p-pinned" };
+
         Assert.IsFalse(MyDayPromotionPolicy.IsTaskInMyDayToday(task, Today, dismissed));
     }
 

--- a/tests/Glasswork.Tests/MyDayRemovalPolicyTests.cs
+++ b/tests/Glasswork.Tests/MyDayRemovalPolicyTests.cs
@@ -1,0 +1,69 @@
+using System;
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class MyDayRemovalPolicyTests
+{
+    [TestMethod]
+    public void PlanRemoval_VirtuallyPromotedParent_DismissesOnly()
+    {
+        // Parent is in My Day only because a subtask is flagged — task.MyDay is null.
+        // Removing it must NOT touch the vault (ClearMyDayFlag=false) and MUST dismiss
+        // for today (SetDismissForToday=true) so it disappears immediately.
+        var parent = new GlassworkTask { Id = "p-virtual" };
+        parent.Subtasks.Add(new SubTask { Text = "promoter", Metadata = new() { ["my_day"] = "true" } });
+
+        var plan = MyDayRemovalPolicy.PlanRemoval(parent);
+
+        Assert.IsFalse(plan.ClearMyDayFlag, "Virtually-promoted parent has no my_day flag to clear.");
+        Assert.IsTrue(plan.SetDismissForToday, "Removal must always dismiss-for-today.");
+    }
+
+    [TestMethod]
+    public void PlanRemoval_DirectlyPinnedTask_ClearsFlagAndDismisses()
+    {
+        // Directly-pinned (and also due today): clear the persisted flag AND dismiss,
+        // otherwise the due-today rule re-promotes the same task immediately.
+        var task = new GlassworkTask
+        {
+            Id = "p-pinned",
+            MyDay = DateTime.Today,
+            Due = DateTime.Today,
+            Status = GlassworkTask.Statuses.Todo,
+        };
+
+        var plan = MyDayRemovalPolicy.PlanRemoval(task);
+
+        Assert.IsTrue(plan.ClearMyDayFlag);
+        Assert.IsTrue(plan.SetDismissForToday);
+    }
+
+    [TestMethod]
+    public void PlanRemoval_DoesNotMutateTask()
+    {
+        // The policy is pure: subtask metadata, my_day, and due date are untouched.
+        var task = new GlassworkTask
+        {
+            Id = "p-pure",
+            MyDay = DateTime.Today,
+            Due = DateTime.Today.AddDays(2),
+        };
+        task.Subtasks.Add(new SubTask { Text = "s1", Metadata = new() { ["my_day"] = "true" }, Due = DateTime.Today });
+        var subtasksBefore = task.Subtasks.Count;
+        var subFlagBefore = task.Subtasks[0].IsMyDay;
+        var subDueBefore = task.Subtasks[0].Due;
+        var myDayBefore = task.MyDay;
+        var dueBefore = task.Due;
+
+        _ = MyDayRemovalPolicy.PlanRemoval(task);
+
+        Assert.AreEqual(subtasksBefore, task.Subtasks.Count);
+        Assert.AreEqual(subFlagBefore, task.Subtasks[0].IsMyDay);
+        Assert.AreEqual(subDueBefore, task.Subtasks[0].Due);
+        Assert.AreEqual(myDayBefore, task.MyDay);
+        Assert.AreEqual(dueBefore, task.Due);
+    }
+}


### PR DESCRIPTION
Closes #97.

## What
Adds a pure `MyDayRemovalPolicy` in `Glasswork.Core` and refactors `MyDayViewModel.RemoveFromMyDay` to use it, then wires the M8 virtual-promotion view-model helpers (`TodaysSubtasks`) into `MyDayPage` so the inline subtask rendering replaces the legacy `SubtaskMyDayGroup` section.

## Why
#97 required `Remove from My Day` to behave the same way for **virtually promoted** parents (no `my_day` flag, included only because a subtask is flagged) and **directly pinned** ones, while never touching subtask metadata.

## Acceptance criteria
- [x] Virtually promoted parent disappears immediately and stays gone today (dismiss key set).
- [x] Same parent reappears tomorrow if subtask signals still qualify (dismiss key is date-scoped: `dismissed.{yyyy-MM-dd}.{taskId}`).
- [x] Directly pinned + due-today task: both `my_day` cleared AND today's dismiss key set, so the due-today rule does not re-promote it.
- [x] Subtask metadata never modified.
- [x] Tests cover all three scenarios.

## Tests
- `MyDayRemovalPolicyTests` (3 tests): plan for virtual parent, plan for directly-pinned task, policy purity.
- `MyDayPromotionPolicyTests` (3 new + existing): dismiss-wins-over-virtual-promotion, date-scoped reappear, pinned+due+dismissed.
- All 33 MyDay tests pass.

## ADRs
- ADR 0008 (My Day virtual promotion via subtasks) — this PR completes the M8 wiring on the App side.