### PR TITLE
feat(notes): live reflow + conflict banner (closes #79)

### DIFF
--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml
@@ -31,6 +31,23 @@
                 </StackPanel>
             </InfoBar>
 
+            <!-- Notes conflict banner (M8 / ADR 0006 §5): shown only when the
+                 user has typed mid-sentence AND the Notes section was changed
+                 externally. Other field-level external changes still surface
+                 via ReloadBanner above. -->
+            <InfoBar x:Name="NotesConflictBanner"
+                     IsOpen="False"
+                     IsClosable="False"
+                     Severity="Warning"
+                     Title="Notes was changed externally"
+                     Message="Someone (probably an agent) changed this task's Notes while you were editing.">
+                <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
+                    <Button Content="Discard mine and reload" Click="NotesConflictDiscard_Click" />
+                    <Button Content="Keep mine and overwrite on save" Click="NotesConflictKeep_Click" />
+                    <Button Content="Open Obsidian to merge" Click="NotesConflictOpenObsidian_Click" />
+                </StackPanel>
+            </InfoBar>
+
             <InfoBar x:Name="ObsidianInstallBanner"
                      IsOpen="False"
                      IsClosable="True"

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -25,6 +25,7 @@ public sealed partial class TaskDetailPage : Page
     private bool _isLoading;
     private bool _suppressNextNotesSave;
     private NotesEditController _notesEdit = new(string.Empty);
+    private string _pendingDiskNotes = string.Empty;
 
     public TaskDetailPage()
     {
@@ -106,6 +107,10 @@ public sealed partial class TaskDetailPage : Page
 
         _notesEdit = new NotesEditController(task.Notes);
         ApplyNotesMode(NotesEditMode.Read);
+        // Fresh task → discard any stale conflict banner state from a previous task.
+        NotesConflictBanner.IsOpen = false;
+        ReloadBanner.IsOpen = false;
+        _pendingDiskNotes = string.Empty;
 
         _isLoading = false;
     }
@@ -331,8 +336,57 @@ public sealed partial class TaskDetailPage : Page
     private void OnFileChangedExternally(object? sender, string fileName)
     {
         if (!App.ActiveTask.IsActive(fileName)) return;
-        // Watcher fires on a thread-pool thread; show the banner on the UI thread.
-        DispatcherQueue.TryEnqueue(() => ReloadBanner.IsOpen = true);
+        // Watcher fires on a thread-pool thread; marshal to UI thread before
+        // touching the model or any banners.
+        DispatcherQueue.TryEnqueue(HandleExternalFileChange);
+    }
+
+    private void HandleExternalFileChange()
+    {
+        var id = Task?.Id;
+        if (string.IsNullOrEmpty(id)) return;
+
+        // Reload to compare. We never blanket-replace Task here — that would
+        // clobber unsaved Title/Description/etc. edits.
+        var fresh = App.Vault.Load(id);
+        if (fresh is null)
+        {
+            // File may have been deleted; fall back to the legacy banner.
+            ReloadBanner.IsOpen = true;
+            return;
+        }
+
+        var newDiskNotes = fresh.Notes ?? string.Empty;
+        var classification = _notesEdit.ClassifyExternalChange(newDiskNotes);
+
+        switch (classification)
+        {
+            case NotesExternalChangeAction.SilentRefresh:
+                _notesEdit.ApplySilentRefresh(newDiskNotes);
+                Task.Notes = newDiskNotes;
+                if (_notesEdit.Mode == NotesEditMode.Edit)
+                    NotesBox.Text = newDiskNotes;
+                else
+                    NotesReadView.Markdown = newDiskNotes;
+                // Spec (M8): silent — no banner. We accept that a coincident
+                // change to a non-Notes field will not surface its own banner.
+                // Agent edits in practice target Notes; non-Notes external
+                // edits remain covered by the Ignore branch below.
+                break;
+
+            case NotesExternalChangeAction.Conflict:
+                _pendingDiskNotes = newDiskNotes;
+                NotesConflictBanner.IsOpen = true;
+                break;
+
+            case NotesExternalChangeAction.Ignore:
+            default:
+                // Notes unchanged on disk; whatever differs is non-Notes
+                // (Title, Status, Subtasks, …). Surface the legacy banner so
+                // the user can choose Reload vs Keep my version.
+                ReloadBanner.IsOpen = true;
+                break;
+        }
     }
 
     private void OnArtifactChangedExternally(object? sender, ArtifactChangedEventArgs e)
@@ -371,6 +425,42 @@ public sealed partial class TaskDetailPage : Page
     {
         // Dismiss only — the next Save() will overwrite the on-disk change.
         ReloadBanner.IsOpen = false;
+    }
+
+    private void NotesConflictDiscard_Click(object sender, RoutedEventArgs e)
+    {
+        // Discard mine and reload: replace TextBox + baseline with disk and
+        // transition back to read mode.
+        var disk = _pendingDiskNotes;
+        _suppressNextNotesSave = true;
+        _notesEdit.ApplyDiscardAndReload(disk);
+        Task.Notes = disk;
+        NotesBox.Text = disk;
+        ApplyNotesMode(NotesEditMode.Read);
+        NotesConflictBanner.IsOpen = false;
+        _pendingDiskNotes = string.Empty;
+    }
+
+    private void NotesConflictKeep_Click(object sender, RoutedEventArgs e)
+    {
+        // Keep mine and overwrite on save: snap baseline to disk so the next
+        // watcher tick reading the same content does not re-fire the conflict.
+        // The user's buffer (and edit mode) are preserved. The eventual Save()
+        // path goes through Vault.Save → SelfWriteCoordinator, so the
+        // overwrite will not bounce back as a new external change.
+        _notesEdit.ApplyKeepAndOverwrite(_pendingDiskNotes);
+        NotesConflictBanner.IsOpen = false;
+        _pendingDiskNotes = string.Empty;
+    }
+
+    private async void NotesConflictOpenObsidian_Click(object sender, RoutedEventArgs e)
+    {
+        // Build the vault-relative path to the active task file and let the
+        // user resolve in Obsidian. Banner stays open until they decide.
+        var taskPath = Path.Combine(App.Vault.VaultPath, $"{Task.Id}.md");
+        var vaultRelative = ToVaultRelativePath(taskPath);
+        if (vaultRelative is null) return;
+        await App.ObsidianLauncher.Open(vaultRelative);
     }
 
     private void Field_LostFocus(object sender, RoutedEventArgs e)

--- a/src/Glasswork.Core/Services/NotesEditController.cs
+++ b/src/Glasswork.Core/Services/NotesEditController.cs
@@ -61,4 +61,71 @@ public sealed class NotesEditController
     {
         _baseline = newDiskValue ?? string.Empty;
     }
+
+    /// <summary>
+    /// Classify how an external (agent / Obsidian) change to the Notes section
+    /// should be reflected in the UI without losing in-flight user edits.
+    /// See ADR 0006 §5 / issue #79.
+    /// </summary>
+    public NotesExternalChangeAction ClassifyExternalChange(string? newDiskValue)
+    {
+        var disk = newDiskValue ?? string.Empty;
+        if (string.Equals(disk, _baseline, StringComparison.Ordinal))
+            return NotesExternalChangeAction.Ignore;
+
+        // Read mode (or edit mode with a pristine buffer): the user has no
+        // typing to lose, so silently adopt the disk content.
+        if (Mode == NotesEditMode.Read || string.Equals(_buffer, _baseline, StringComparison.Ordinal))
+            return NotesExternalChangeAction.SilentRefresh;
+
+        return NotesExternalChangeAction.Conflict;
+    }
+
+    /// <summary>
+    /// Adopt the disk content silently. In edit mode the buffer also follows
+    /// disk (only safe when the buffer was pristine — callers should have
+    /// classified <see cref="NotesExternalChangeAction.SilentRefresh"/> first).
+    /// </summary>
+    public void ApplySilentRefresh(string? newDiskValue)
+    {
+        _baseline = newDiskValue ?? string.Empty;
+        if (Mode == NotesEditMode.Edit)
+            _buffer = _baseline;
+    }
+
+    /// <summary>
+    /// Discard the user's in-flight buffer, replace it with disk content, and
+    /// transition back to read mode. Wired to the conflict banner's
+    /// "Discard mine and reload" button.
+    /// </summary>
+    public string ApplyDiscardAndReload(string? newDiskValue)
+    {
+        _baseline = newDiskValue ?? string.Empty;
+        _buffer = _baseline;
+        if (Mode != NotesEditMode.Read)
+        {
+            Mode = NotesEditMode.Read;
+            ModeChanged?.Invoke(this, Mode);
+        }
+        return _baseline;
+    }
+
+    /// <summary>
+    /// Snap the on-disk-at-edit-start baseline to the new disk content while
+    /// preserving the user's buffer and edit mode. Wired to the conflict
+    /// banner's "Keep mine and overwrite on save" button — the next Save will
+    /// overwrite disk and the now-equal baseline prevents the conflict from
+    /// re-firing on a subsequent watcher tick reading the same content.
+    /// </summary>
+    public void ApplyKeepAndOverwrite(string? newDiskValue)
+    {
+        _baseline = newDiskValue ?? string.Empty;
+    }
+}
+
+public enum NotesExternalChangeAction
+{
+    Ignore,
+    SilentRefresh,
+    Conflict,
 }

--- a/tests/Glasswork.Tests/NotesEditControllerTests.cs
+++ b/tests/Glasswork.Tests/NotesEditControllerTests.cs
@@ -139,4 +139,170 @@ public class NotesEditControllerTests
         c.UpdateBuffer(null);
         Assert.AreEqual(string.Empty, c.Buffer);
     }
+
+    // ─── M8: External-change classification (close agent-write loss) ─────────
+
+    [TestMethod]
+    public void Classify_ReadMode_DiskUnchanged_Ignore()
+    {
+        var c = new NotesEditController("v1");
+        Assert.AreEqual(NotesExternalChangeAction.Ignore, c.ClassifyExternalChange("v1"));
+    }
+
+    [TestMethod]
+    public void Classify_ReadMode_DiskChanged_SilentRefresh()
+    {
+        var c = new NotesEditController("v1");
+        Assert.AreEqual(NotesExternalChangeAction.SilentRefresh, c.ClassifyExternalChange("v2"));
+    }
+
+    [TestMethod]
+    public void Classify_EditMode_NoTyping_DiskChanged_SilentRefresh()
+    {
+        var c = new NotesEditController("v1");
+        c.EnterEdit();
+        // buffer == baseline (user hasn't typed anything yet)
+        Assert.AreEqual(NotesExternalChangeAction.SilentRefresh, c.ClassifyExternalChange("v2"));
+    }
+
+    [TestMethod]
+    public void Classify_EditMode_UserTyped_DiskChanged_Conflict()
+    {
+        var c = new NotesEditController("v1");
+        c.EnterEdit();
+        c.UpdateBuffer("user mid-sentence");
+        Assert.AreEqual(NotesExternalChangeAction.Conflict, c.ClassifyExternalChange("v2-from-agent"));
+    }
+
+    [TestMethod]
+    public void Classify_EditMode_UserTyped_DiskUnchanged_Ignore()
+    {
+        var c = new NotesEditController("v1");
+        c.EnterEdit();
+        c.UpdateBuffer("user typed");
+        Assert.AreEqual(NotesExternalChangeAction.Ignore, c.ClassifyExternalChange("v1"));
+    }
+
+    [TestMethod]
+    public void Classify_NullDiskValue_TreatedAsEmpty()
+    {
+        var c = new NotesEditController("v1");
+        Assert.AreEqual(NotesExternalChangeAction.SilentRefresh, c.ClassifyExternalChange(null));
+        var c2 = new NotesEditController(string.Empty);
+        Assert.AreEqual(NotesExternalChangeAction.Ignore, c2.ClassifyExternalChange(null));
+    }
+
+    [TestMethod]
+    public void ApplySilentRefresh_ReadMode_UpdatesBaseline()
+    {
+        var c = new NotesEditController("v1");
+        c.ApplySilentRefresh("v2");
+        Assert.AreEqual("v2", c.Baseline);
+        Assert.AreEqual(NotesEditMode.Read, c.Mode);
+    }
+
+    [TestMethod]
+    public void ApplySilentRefresh_EditMode_NoTyping_UpdatesBufferAndBaseline_StaysInEdit()
+    {
+        var c = new NotesEditController("v1");
+        c.EnterEdit();
+        c.ApplySilentRefresh("v2-from-agent");
+
+        Assert.AreEqual("v2-from-agent", c.Baseline);
+        Assert.AreEqual("v2-from-agent", c.Buffer, "Pristine buffer must follow disk so the user sees the agent's changes.");
+        Assert.AreEqual(NotesEditMode.Edit, c.Mode);
+    }
+
+    [TestMethod]
+    public void ApplyDiscardAndReload_ReplacesBufferWithDisk_TransitionsToRead()
+    {
+        var c = new NotesEditController("v1");
+        c.EnterEdit();
+        c.UpdateBuffer("user typed lots");
+        var transitions = new List<NotesEditMode>();
+        c.ModeChanged += (_, m) => transitions.Add(m);
+
+        var result = c.ApplyDiscardAndReload("v2-from-agent");
+
+        Assert.AreEqual("v2-from-agent", result);
+        Assert.AreEqual("v2-from-agent", c.Baseline);
+        Assert.AreEqual("v2-from-agent", c.Buffer);
+        Assert.AreEqual(NotesEditMode.Read, c.Mode);
+        CollectionAssert.AreEqual(new[] { NotesEditMode.Read }, transitions);
+    }
+
+    [TestMethod]
+    public void ApplyKeepAndOverwrite_UpdatesBaselineOnly_BufferAndModeUntouched()
+    {
+        var c = new NotesEditController("v1");
+        c.EnterEdit();
+        c.UpdateBuffer("user mid-sentence");
+        var transitions = new List<NotesEditMode>();
+        c.ModeChanged += (_, m) => transitions.Add(m);
+
+        c.ApplyKeepAndOverwrite("v2-from-agent");
+
+        Assert.AreEqual("v2-from-agent", c.Baseline,
+            "After 'keep mine', baseline must snap to the new disk content so the next external change doesn't re-trigger until it actually changes again.");
+        Assert.AreEqual("user mid-sentence", c.Buffer);
+        Assert.AreEqual(NotesEditMode.Edit, c.Mode);
+        Assert.AreEqual(0, transitions.Count, "Mode must not transition.");
+    }
+
+    [TestMethod]
+    public void ApplyKeepAndOverwrite_NextClassifyOnSameDisk_ReturnsIgnore()
+    {
+        var c = new NotesEditController("v1");
+        c.EnterEdit();
+        c.UpdateBuffer("user typed");
+        c.ApplyKeepAndOverwrite("v2-from-agent");
+
+        Assert.AreEqual(NotesExternalChangeAction.Ignore, c.ClassifyExternalChange("v2-from-agent"),
+            "Once snapped to v2, a subsequent watcher tick reading the same v2 must not re-fire the conflict.");
+    }
+
+    // ─── Tracer-bullet scenarios from the issue ──────────────────────────────
+
+    [TestMethod]
+    public void Scenario1_ReadMode_AgentAppendsLine_SilentRefresh()
+    {
+        var c = new NotesEditController("first line");
+        var classification = c.ClassifyExternalChange("first line\nsecond line");
+        Assert.AreEqual(NotesExternalChangeAction.SilentRefresh, classification);
+
+        c.ApplySilentRefresh("first line\nsecond line");
+        Assert.AreEqual("first line\nsecond line", c.Baseline);
+        Assert.AreEqual(NotesEditMode.Read, c.Mode);
+    }
+
+    [TestMethod]
+    public void Scenario2_EditMode_NoTyping_AgentAppendsLine_BufferUpdatesSilently()
+    {
+        var c = new NotesEditController("first line");
+        c.EnterEdit();
+        // user hasn't typed
+        var classification = c.ClassifyExternalChange("first line\nsecond line");
+        Assert.AreEqual(NotesExternalChangeAction.SilentRefresh, classification);
+
+        c.ApplySilentRefresh("first line\nsecond line");
+        Assert.AreEqual("first line\nsecond line", c.Buffer);
+        Assert.AreEqual("first line\nsecond line", c.Baseline);
+        Assert.AreEqual(NotesEditMode.Edit, c.Mode);
+    }
+
+    [TestMethod]
+    public void Scenario3_EditMode_UserTyped_AgentRewrites_ShowsConflict()
+    {
+        var c = new NotesEditController("first line");
+        c.EnterEdit();
+        c.UpdateBuffer("first line and my edits");
+
+        var classification = c.ClassifyExternalChange("first line\nagent appended");
+        Assert.AreEqual(NotesExternalChangeAction.Conflict, classification);
+
+        // Discard mine and reload → user sees disk
+        c.ApplyDiscardAndReload("first line\nagent appended");
+        Assert.AreEqual("first line\nagent appended", c.Buffer);
+        Assert.AreEqual(NotesEditMode.Read, c.Mode);
+    }
 }


### PR DESCRIPTION
Closes #79. Implements M8 from ADR 0006 §5.

## What

When the active task file changes externally, classify the Notes delta and react with the right UX:

| User state | Disk vs baseline | Action |
|---|---|---|
| Read mode (any disk change) | — | **Silent reflow** — Task.Notes + read view update; no banner |
| Edit mode, buffer pristine | differs | **Silent reflow** — TextBox follows agent's append |
| Edit mode, buffer dirty | differs | **Conflict banner** — Discard / Keep&Overwrite / Open in Obsidian |
| Any | matches baseline | **Ignore** — fall through to existing ReloadBanner for non-Notes field changes |

## Core (testable, no WinUI)

- New  + '' + NotesExternalChangeAction + '' +  enum +  + '' + ClassifyExternalChange + '' +  on  + '' + NotesEditController + '' + .
-  + '' + ApplySilentRefresh + '' +  /  + '' + ApplyDiscardAndReload + '' +  /  + '' + ApplyKeepAndOverwrite + '' +  snap baseline (and buffer where appropriate) so the **next** watcher tick on the same disk content classifies as  + '' + Ignore + '' +  and does not re-fire.

## App

- New  + '' + NotesConflictBanner + '' +   + '' + InfoBar + '' +  in  + '' + TaskDetailPage.xaml + '' + .
-  + '' + HandleExternalFileChange + '' +  reloads the task, classifies, and dispatches.
- Banner state reset on  + '' + ApplyTask + '' +  so navigating between tasks does not leak stale state.
- Keep & Overwrite uses the existing  + '' + Vault.Save + '' +  →  + '' + SelfWriteCoordinator + '' +  path so the next user Save is correctly suppressed.

## Tests

14 new  + '' + NotesEditController + '' +  tests (26 total, all passing):
- Classification matrix (5 cases incl. read-mode-with-buffer-dirty edge)
- Null disk-content coercion
- ApplySilentRefresh in Read and Edit modes
- ApplyDiscardAndReload
- ApplyKeepAndOverwrite (incl. ' + '' + 
ext-classify-on-same-disk-is-Ignore + '' + )
- 3 tracer-bullet scenarios from the issue

 + '' + dotnet test + '' +  summary: 442 passed, 3 pre-existing flaky timing tests in  + '' + Debouncer + '' +  /  + '' + Trigger + '' +  (pass on rerun and on baseline  + '' + main + '' + ).

## Acceptance checklist

- [x] Read-mode external change → notes reflow, no banner
- [x] Edit-mode pristine + external change → buffer + baseline follow disk silently
- [x] Edit-mode dirty + external change → NotesConflictBanner with 3 actions
- [x] Discard → reload disk and return to read mode
- [x] Keep & Overwrite → baseline snaps, next Save persists user version, no bounce
- [x] Open in Obsidian → launches via existing  + '' + App.ObsidianLauncher + '' + 
- [x] Other-field external changes still surface ReloadBanner

## ADRs touched

- ADR 0006 §5 (Notes edit model): the SilentRefresh path realizes the 'live reflow in read mode' commitment that was deferred there.