### PR TITLE
Fix Notes edit-toggle not switching to TextBox (#108)

### DIFF
--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml
@@ -379,25 +379,6 @@
                 </Grid>
 
                 <Grid x:Name="NotesContent">
-                    <VisualStateManager.VisualStateGroups>
-                        <VisualStateGroup x:Name="NotesModeStates">
-                            <VisualState x:Name="ReadState">
-                                <VisualState.Setters>
-                                    <Setter Target="NotesReadView.Visibility" Value="Visible" />
-                                    <Setter Target="NotesBox.Visibility" Value="Collapsed" />
-                                    <Setter Target="NotesEmptyHint.Visibility" Value="Collapsed" />
-                                </VisualState.Setters>
-                            </VisualState>
-                            <VisualState x:Name="EditState">
-                                <VisualState.Setters>
-                                    <Setter Target="NotesReadView.Visibility" Value="Collapsed" />
-                                    <Setter Target="NotesBox.Visibility" Value="Visible" />
-                                    <Setter Target="NotesEmptyHint.Visibility" Value="Collapsed" />
-                                </VisualState.Setters>
-                            </VisualState>
-                        </VisualStateGroup>
-                    </VisualStateManager.VisualStateGroups>
-
                     <controls:VaultMarkdownView x:Name="NotesReadView"
                                                 Loaded="OnNotesMarkdownLoaded"
                                                 Unloaded="OnNotesMarkdownUnloaded" />

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -117,10 +117,16 @@ public sealed partial class TaskDetailPage : Page
 
     private void ApplyNotesMode(NotesEditMode mode)
     {
+        // Bypass VisualStateManager: the VisualStateGroups in XAML are attached
+        // to the inner NotesContent grid, not to a child of `this` (the Page),
+        // so VisualStateManager.GoToState(this, ...) silently no-ops. Direct
+        // visibility writes on the two named children are simpler and reliable.
+        // See issue #108.
         if (mode == NotesEditMode.Read)
         {
             NotesReadView.Markdown = Task.Notes ?? string.Empty;
-            VisualStateManager.GoToState(this, "ReadState", false);
+            NotesReadView.Visibility = Visibility.Visible;
+            NotesBox.Visibility = Visibility.Collapsed;
             var hasContent = !string.IsNullOrWhiteSpace(Task.Notes);
             NotesEmptyHint.Visibility = hasContent ? Visibility.Collapsed : Visibility.Visible;
             NotesEditIcon.Glyph = "\uE70F";
@@ -128,7 +134,8 @@ public sealed partial class TaskDetailPage : Page
         }
         else
         {
-            VisualStateManager.GoToState(this, "EditState", false);
+            NotesReadView.Visibility = Visibility.Collapsed;
+            NotesBox.Visibility = Visibility.Visible;
             NotesEmptyHint.Visibility = Visibility.Collapsed;
             NotesEditIcon.Glyph = "\uE73E";
             ToolTipService.SetToolTip(NotesEditButton, "Done (Ctrl+E)");


### PR DESCRIPTION
Fixes #108.

## Root cause
`VisualStateManager.GoToState(this, "EditState", false)` silently no-ops because the `VisualStateGroups` in `TaskDetailPage.xaml` are attached to the inner `NotesContent` `Grid`, not to a child of the `Page`'s content root. The `NotesEditController` mode flips correctly, the icon glyph swap works (it's a direct property write), but the `TextBox` stays `Visibility=Collapsed`.

## Fix
- `ApplyNotesMode` now writes `Visibility` on `NotesReadView` / `NotesBox` directly (5 lines).
- Removed the dead `VisualStateGroups` block from XAML so it doesn't mislead future readers.

## Tests
449/452 pass; the 3 failures are pre-existing flaky timing tests (Debouncer / ArtifactWatcher / BacklinksWatcher) unrelated to this change. `NotesEditController` tests pass.

## Manual verification
App-side change; needs a Windows build to verify the toggle now reveals the TextBox. Recommend smoke test before merge.