### PR TITLE
Fix Notes TextBox not visually appearing on edit toggle (#108 follow-up)

### DIFF
--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml
@@ -389,6 +389,9 @@
                                Visibility="Collapsed" />
                     <TextBox x:Name="NotesBox" AcceptsReturn="True"
                              MinHeight="120" TextWrapping="Wrap"
+                             PlaceholderText="Add notes in markdown..."
+                             BorderThickness="1"
+                             BorderBrush="{ThemeResource TextControlBorderBrush}"
                              Text="{x:Bind Task.Notes, Mode=TwoWay}"
                              KeyDown="NotesBox_KeyDown"
                              LostFocus="Field_LostFocus"

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -139,6 +139,8 @@ public sealed partial class TaskDetailPage : Page
             NotesEmptyHint.Visibility = Visibility.Collapsed;
             NotesEditIcon.Glyph = "\uE73E";
             ToolTipService.SetToolTip(NotesEditButton, "Done (Ctrl+E)");
+            // Force layout so the TextBox is in the tree before we focus it.
+            NotesContent.UpdateLayout();
             NotesBox.Focus(FocusState.Programmatic);
             NotesBox.SelectionStart = NotesBox.Text?.Length ?? 0;
         }


### PR DESCRIPTION
Follow-up to #111. Smoke test revealed the visibility flip is working (the empty-state `"No notes yet..."` placeholder disappears on edit toggle), but the TextBox itself was not visually perceptible: no header, no PlaceholderText, transparent background, and a subtle theme border that's hard to see in dark mode when the TextBox is empty.

### Changes

- `PlaceholderText="Add notes in markdown..."` so an empty TextBox is unmistakable.
- Explicit `BorderThickness="1"` + `BorderBrush="{ThemeResource TextControlBorderBrush}"` so the frame draws in any theme.
- `NotesContent.UpdateLayout()` before `NotesBox.Focus(...)` to ensure the just-made-visible TextBox is in the visual tree before we focus it.

### Tests

449/452 (same 3 pre-existing flaky timing tests unrelated).

Closes the follow-up to #108.