### PR TITLE
docs: record structured links decision

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,6 +46,11 @@ The in-memory shape of a task and its subtasks. Pure C# in
   - `Artifacts` — agent-produced markdown work-products in a sibling
     `<taskId>.artifacts/` folder. **Read-only in the app**; rendered via
     `VaultMarkdownView`.
+- **Structured links** (see ADR 0009): `links:` is a typed frontmatter list of
+  outbound task pointers (`ado`, `pr`, `incident`, `doc`, `build`, `other`) with
+  `value` and optional `label`. Links are not a fourth prose tier; they are
+  machine-readable task metadata adjacent to Description, Notes, and Artifacts.
+  The v1 app surface is read-only, with editing in Obsidian or YAML.
 - **Markdown rendering** (see ADR 0006, supersedes parts of ADR 0003):
   every rendered-markdown surface in the app (Artifacts, Notes read mode)
   goes through a single `VaultMarkdownView` UserControl in

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -7,7 +7,7 @@
 | Term | Definition | Aliases to avoid |
 |---|---|---|
 | **Vault** | The Obsidian folder Glasswork reads tasks from. Source of truth for all task data. Currently `%UserProfile%\Wiki\wiki\todo`. | folder, directory, repo, store |
-| **Task** | A work item represented by one `.md` file in the vault. May have subtasks, notes, ADO links, due date. | item, work item (work item is overloaded — use only when explicitly referring to ADO) |
+| **Task** | A work item represented by one `.md` file in the vault. May have subtasks, notes, Links, due date, and legacy ADO frontmatter during migration. | item, work item (work item is overloaded — use only when explicitly referring to ADO) |
 | **Subtask** | A child step inside a task. Has its own status (`todo`, `in_progress`, `blocked`, `done`, `dropped`), title, optional notes. Lives inline in the parent's `.md` body. | step, todo (step is fine in user copy; subtask is canonical in code) |
 | **Subtask row** | The list-item template that renders one subtask in TaskDetail **and** in the today's-subtasks list beneath each promoted parent on My Day. Two interactive hit zones: the **circle glyph** (single-click toggles done) and the **subtask text** (single-click opens `SubtaskDetailDialog`). Hand cursor on the text advertises the affordance. Same model in active and completed lists. See ADR 0004 (interaction) and ADR 0008 (My Day surface). | subtask line, subtask item |
 | **Active subtask list** | The `ListView` rendering subtasks not in `done` or `dropped` status. Supports drag-reorder. Each row carries the full action set (My Day toggle, `⋯` More menu). | open subtasks, pending subtasks |
@@ -18,6 +18,8 @@
 | **Artifacts section** | Collapsible-list surface in TaskDetail rendered beneath Notes. Hidden when zero artifacts. One `Expander` per artifact, ordered by mtime descending; the newest auto-expands and the rest start collapsed. Each header carries a relative-time badge and an "Open in Obsidian" link; the body renders the artifact markdown read-only. | artifacts panel, artifacts list, attachments section |
 | **Backlink** | An incoming wikilink to a Glasswork task from a vault page **outside** `wiki/todo/` — i.e., any concept, decision, system, incident, or other wiki note that references a task via `[[task-id]]`. The convention lives in [`wiki/concepts/glasswork-task-linking.md`](wiki/concepts/glasswork-task-linking.md) and is mirrored in-app by the Backlinks section. Task-to-task wikilinks (those originating under `wiki/todo/`) are explicitly excluded — those surface as Related, not Backlinks. | reference, mention, incoming link, referenced-from (the UI shows "Backlinks"; use that term in code, copy, and conversation) |
 | **Backlinks section** | Collapsible-list surface in TaskDetail rendered beneath Related. Hidden when zero backlinks. One row per linking page, grouped by `BacklinkPageType` (concept, decision, system, incident, other), ordered by page title. Each row shows the page title and a small page-type badge; click opens the page in Obsidian via `obsidian://` URI, gated through `ArtifactLinkPolicy`. Updates live as the vault changes — see `BacklinksWatcher`. | backlinks panel, backlinks list, references section, referenced-from section |
+| **Link** | A structured outbound pointer stored in task frontmatter under `links:` with `type`, `value`, and optional `label`. Recognized v1 types are `ado`, `pr`, `incident`, `doc`, `build`, and `other`; unknown types are tolerated as `other`. Distinct from Wiki link (markdown syntax inside rendered prose) and Backlink (incoming reference from another vault page). | hyperlink (too broad), external ref, reference |
+| **Links section** | TaskDetail surface that renders a task's Links as read-only rows with type badges and display text. Hidden when `links:` is empty or missing. In v1, Links are edited in Obsidian or YAML, not in-app. | links panel, external refs, references section (reserved for Backlinks-like phrasing) |
 | **Page** | A top-level navigation destination in the app shell (My Day, Backlog, Work Log, Settings). Glasswork keeps "Page" rather than the todo-app convention "Smart List." | screen, view, tab, smart list |
 | **My Day** | The default landing page. Shows tasks that are "in My Day today" — see the inclusion rule below. | today, dashboard, home (Home is reserved for the future Home Dashboard) |
 | **In My Day today** | A task is in My Day today if **any** of: (a) `task.IsMyDay` (`my_day` frontmatter is today), (b) `task.Due <= today` and not done, (c) any of its subtasks is a **flagged subtask**, (d) any of its subtasks has `Due <= today` and is not done. (a) and (b) are *direct*; (c) and (d) are *virtual promotion* — the parent's frontmatter is untouched. Dismiss-for-today (`IUiStateService`) overrides all four. See ADR 0008. | on My Day, today's tasks |
@@ -39,7 +41,7 @@
 | **Chip** | A small inline metadata badge on the title row. Three kinds today: priority chip, due chip, ADO chip. | tag (tag is reserved for vault tags), pill, badge |
 | **Priority chip** | Title-row chip showing task priority (`low`, `med`, `high`, `urgent`). Color-coded. Hidden when priority is unset. | — |
 | **Due chip** | Title-row chip showing relative due date (`overdue` red, `today` orange, `≤ 3 days` accent, `future` neutral). Hidden when no due date. | due date, deadline |
-| **ADO chip** | Title-row chip showing linked Azure DevOps work item (`ADO #1234`). Hidden when no link. Click jumps to ADO. | work item link, ado link |
+| **ADO chip** | Title-row chip showing linked Azure DevOps work item (`ADO #1234`). Hidden when no ADO Link. Click jumps to ADO. Driven by the derived `AdoLink` projection over `Links[type=ado]`; legacy `ado_link` is migration input only. | work item link, ado link |
 | **Empty state** | The visual rendered when a page has no tasks to show. Headline + sub copy + up to 2 CTAs. One reusable `EmptyState` control covers all pages. | placeholder, blank state, zero state |
 | **Footer status bar** | A thin (~28px) strip at the bottom of `MainWindow` showing vault path, task counts, watcher state, and last-reload time. | status strip, status line, footer |
 | **UI state** | Persistent app-local user preferences that **do not belong in the vault**. Stored in `%LocalAppData%\Glasswork\ui-state.json` via `IUiStateService`. Examples: collapsed task ids, future sidebar pane state. | preferences (reserved for actual user settings), settings (reserved for the Settings page), local state |
@@ -58,7 +60,7 @@
 
 - **Code symbols**: `PascalCase` for types, `camelCase` for parameters and locals, `_camelCase` for private fields. Match the term spelling exactly (`SubTask`, not `Subtask` or `Sub_Task`).
 - **UI labels**: title case for headings (`My Day`), sentence case for sub-copy (`Pick something from your backlog.`).
-- **Frontmatter keys**: `snake_case` (`my_day`, `ado_link`, future `summary`).
+- **Frontmatter keys**: `snake_case` (`my_day`, `links`, legacy `ado_link`, future `summary`).
 
 ## When this file is wrong
 

--- a/docs/adr/0009-structured-links.md
+++ b/docs/adr/0009-structured-links.md
@@ -1,0 +1,181 @@
+# ADR 0009: Structured links use a typed frontmatter list
+
+**Status**: Accepted
+**Context slice**: Structured links PRD #125; resolves issue #126
+
+## Context
+
+Before this slice, a task had one structured external pointer: the legacy
+`ado_link` frontmatter field, with `ado_title` as optional display text. Other
+references that help a human or agent pick up a task — pull requests, incidents,
+builds, eng.ms docs, and arbitrary URLs — lived in prose inside Description,
+Notes, or ad-hoc fields. That made the references hard to scan, hard to preserve
+when prose changed, and expensive for agents to rediscover.
+
+Structured links need to coexist with the three-tier task prose model from ADR
+0002 without becoming a fourth prose tier. They are task metadata in frontmatter:
+machine-readable pointers that complement Description, Notes, and Artifacts.
+They are also distinct from Wiki links and Backlinks. Wiki links are markdown
+references inside rendered prose; Backlinks are incoming wiki references from
+non-task pages. Structured links are explicit outbound task metadata.
+
+The design also has to preserve existing `ado_link` behavior. Existing tasks
+must continue to show their ADO chip and ADO title after the format change, and
+the on-disk format should converge without a one-time vault rewrite.
+
+## Decision
+
+Adopt a `links:` frontmatter field containing an ordered list of typed entries:
+
+```yaml
+links:
+  - type: ado
+    value: 1234
+    label: IAM routing fix
+  - type: pr
+    value: https://github.com/tjegbejimba/Glasswork/pull/123
+  - type: incident
+    value: ICM 965114
+  - type: doc
+    value: https://eng.ms/docs/products/example
+  - type: build
+    value: https://dev.azure.com/example/_build/results?buildId=123
+  - type: other
+    value: https://example.com/context
+    label: Whitepaper
+```
+
+Each Link has:
+
+| Field | Required? | Meaning |
+|---|---:|---|
+| `type` | Yes | Recognized v1 values are `ado`, `pr`, `incident`, `doc`, `build`, and `other`. Unknown values are tolerated and surfaced as `other`. |
+| `value` | Yes | The target identifier or URL, stored uniformly by the model even when YAML authors write a number. |
+| `label` | No | Human-friendly display text. When omitted, the app may derive a type-specific display value such as `ADO #1234`. |
+
+Use a typed list instead of a flat keyed dictionary such as
+`links: { ado: 1234, pr: [...] }`.
+
+The list shape is canonical because it:
+
+1. Preserves author-chosen ordering.
+2. Allows multiple Links of the same type without special-case array semantics.
+3. Keeps optional per-Link `label` data local to the Link it describes.
+4. Leaves room for future per-Link metadata without changing the top-level
+   schema again.
+
+`ado_link` and `ado_title` become legacy compatibility fields. On parse, a task
+with only legacy ADO fields hydrates an `ado` Link into the model. On serialize,
+the canonical `links:` field is emitted and `ado_link` / `ado_title` are not
+written back. If both `links:` and legacy ADO fields are present, `links:` wins.
+This is a lazy on-save migration: old files remain valid indefinitely, and files
+converge only when Glasswork next saves them. This follows the same philosophy as
+the V1-to-V2 task body migration: transform on read, write the canonical shape,
+and avoid a flag-day vault rewrite.
+
+The v1 UI boundary is read-only in-app. TaskDetail may render a Links section,
+but editing Links happens in Obsidian or by editing YAML directly. In-app add,
+remove, and edit affordances are deferred.
+
+Any UI that launches a structured Link must use the same untrusted-link safety
+boundary as rendered markdown: route launch decisions through `ArtifactLinkPolicy`
+or its direct successor. Link values are vault content and may be agent-produced.
+
+## Alternatives considered
+
+### A. Keep `ado_link` and add one field per new type
+
+- ✅ Minimal parser churn for each individual type.
+- ❌ Multiplies bespoke frontmatter keys (`pr_link`, `incident_link`,
+  `doc_link`, etc.).
+- ❌ Cannot represent multiple links of the same type cleanly.
+- ❌ Makes optional labels inconsistent or requires a second field per type.
+- **Rejected** — repeats the exact shape limitation that structured links are
+  meant to solve.
+
+### B. Flat keyed dictionary
+
+```yaml
+links:
+  ado: 1234
+  pr:
+    - https://github.com/tjegbejimba/Glasswork/pull/123
+```
+
+- ✅ Compact for the common one-link-per-type case.
+- ❌ Ordering is implicit and type-grouped instead of author-controlled.
+- ❌ Multiples require type-specific scalar-vs-list rules.
+- ❌ Optional labels become awkward sibling data or nested special cases.
+- **Rejected** — compactness is not worth the long-term schema complexity.
+
+### C. Markdown-only links in Description or Notes
+
+- ✅ Zero schema change.
+- ✅ Authors can already paste URLs in prose.
+- ❌ Agents and app code must parse prose to discover task context.
+- ❌ Links are mixed with narrative text and can be lost during prose edits.
+- ❌ No typed badge, no predictable migration path for the existing ADO chip.
+- **Rejected** — does not solve the structured-context problem.
+
+### D. Bulk migrate every vault task immediately
+
+- ✅ Converts the entire vault to the new shape in one operation.
+- ❌ Surprising, high-blast-radius write across user-authored files.
+- ❌ Requires additional UX, rollback, and conflict handling.
+- ❌ Unnecessary because legacy fields can be read indefinitely.
+- **Rejected** — lazy on-save migration is safer and consistent with prior
+  vault migrations.
+
+### E. Add in-app editing in v1
+
+- ✅ More complete user workflow.
+- ❌ Expands the slice from schema/rendering into collection editing UX,
+  validation, conflict handling, and save semantics.
+- ❌ Increases the chance of getting the durable on-disk shape wrong.
+- **Rejected for v1** — the YAML surface is sufficient while the schema settles.
+
+## Consequences
+
+### Good
+
+- A task gains one structured place for external context: ADO work items, PRs,
+  incidents, docs, builds, and arbitrary labeled URLs.
+- The schema supports ordering, duplicates, and labels from the start.
+- Existing ADO behavior can remain source-compatible through a derived `AdoLink`
+  projection over the first `Links[type=ado]` entry.
+- Unknown future Link types do not break parsing; they degrade to `other`.
+- Migration is incremental and avoids a bulk vault rewrite.
+
+### Bad / accepted trade-offs
+
+- There are now two on-disk ADO shapes during migration. Parser and serializer
+  tests must cover read-old/write-new behavior until legacy support is removed.
+- A list is more verbose than a flat dictionary for a single ADO link. The
+  verbosity buys ordering, multiples, labels, and future metadata.
+- Read-only v1 means users must edit YAML or use Obsidian to change Links until a
+  later UI slice adds editing.
+- Implementation slices that write migrated tasks must register those writes with
+  `SelfWriteCoordinator`; otherwise `FileWatcherService` will treat lazy
+  migration writes as external edits.
+
+### Reversible?
+
+Partially. The UI can defer or remove the Links section without changing stored
+task prose. The schema commitment is harder to reverse once tasks serialize
+`links:` because consumers will expect typed entries. Keeping `ado_link` parsing
+as a compatibility layer makes rollback of the app behavior possible, but the
+typed list should be treated as the durable canonical format after implementation
+lands.
+
+## Why this ADR exists
+
+The skill rule for ADRs: hard to reverse + surprising without context + real
+trade-off. This decision qualifies on all three:
+
+- **Hard to reverse**: the on-disk task schema is source-of-truth vault data.
+  Once `links:` is written, agents, docs, and future UI slices will depend on it.
+- **Surprising without context**: future contributors may ask why a verbose list
+  was chosen over a compact keyed dictionary, or why `ado_link` disappears on
+  save. This ADR records the schema and migration rationale.
+- **Real trade-off**: bulk migration and in-app editing are attractive, but the
+  accepted v1 boundary favors a safer lazy migration and read-only UI.


### PR DESCRIPTION
## Summary

- Adds ADR 0009 for the structured-links task frontmatter decision.
- Adds Ubiquitous Language entries for Link and Links section, and updates ADO chip/frontmatter wording for the `Links[type=ado]` migration path.
- Documents `links:` under the Task Model bounded context as structured metadata adjacent to, but not part of, the three-tier prose model.

Closes #126

## Decisions

- This is a documentation-only slice, so no production code or tests were added in order to preserve the issue acceptance criterion: "No code changes in this slice."
- Because `main` is checked out by another linked worktree on this host, this branch was created from `origin/main` after fetching instead of checking out local `main` in this worktree.
- The ADR explicitly treats Links as structured outbound task metadata, distinct from Wiki links and Backlinks.
- The ADR captures the lazy migration policy: parse legacy `ado_link` / `ado_title`, serialize only canonical `links:`.

## Blockers

This PR is intentionally draft and must not be merged yet:

1. `%UserProfile%\Wiki\wiki\todo\_schema.md` could not be read or edited from this headless environment. Both the file viewer and PowerShell access returned `Permission denied and could not request permission from user`. The missing vault-schema edit is an acceptance criterion for #126.
2. The required local test command repeatedly failed in existing debounce/watcher timing tests unrelated to this documentation-only diff:
   - `Glasswork.Tests.DebouncerTests.Trigger_FiresAgainAfterQuietPeriodElapses`
   - `Glasswork.Tests.ArtifactWatcherServiceTests.DebouncesBurstsIntoOneEvent`
   - one run also failed `Glasswork.Tests.BacklinksWatcherTests.DebouncesBurstsIntoOneEvent`

Suggested vault schema excerpt once the vault file is accessible:

```yaml
links:
  - type: ado
    value: 1234
    label: IAM routing fix
  - type: pr
    value: https://github.com/tjegbejimba/Glasswork/pull/123
  - type: incident
    value: ICM 965114
  - type: doc
    value: https://eng.ms/docs/products/example
  - type: build
    value: https://dev.azure.com/example/_build/results?buildId=123
  - type: other
    value: https://example.com/context
    label: Whitepaper
```

Legacy migration note for `_schema.md`: `ado_link` and `ado_title` remain readable legacy inputs. When a task is next serialized, Glasswork writes the canonical `links:` list and drops the legacy fields.

## Validation

- `dotnet build src\Glasswork.Core\Glasswork.Core.csproj` passed.
- `dotnet build src\Glasswork.Mcp\Glasswork.Mcp.csproj` passed.
- `dotnet test tests\Glasswork.Tests\Glasswork.Tests.csproj` failed in the timing tests listed above on two consecutive runs.
- `dotnet test tests\Glasswork.Mcp.Tests\Glasswork.Mcp.Tests.csproj` did not run because the chained command stopped after `Glasswork.Tests` failed.

## Review notes

Mandatory dual-model code review has not been run because this draft is blocked before merge eligibility.
