### PR TITLE
feat: Backlog board view (read-only) — slice 1/3

### DIFF
--- a/src/Glasswork.App/App.xaml.cs
+++ b/src/Glasswork.App/App.xaml.cs
@@ -52,6 +52,11 @@ public partial class App : Application
     public const string BacklogGroupByParentKey = "backlog.groupByParent";
 
     /// <summary>
+    /// UI state key for the Backlog page's view mode ("list" | "board", default "list").
+    /// </summary>
+    public const string BacklogViewModeKey = "backlog.viewMode";
+
+    /// <summary>
     /// Key prefix for per-parent-group collapse state on the Backlog page.
     /// Suffix is the lowercased+trimmed parent string.
     /// </summary>

--- a/src/Glasswork.App/Pages/BacklogPage.xaml
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml
@@ -131,6 +131,89 @@
             </Grid>
         </DataTemplate>
 
+        <DataTemplate x:Key="BoardCardTemplate">
+            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderThickness="1"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    CornerRadius="8"
+                    Padding="12,10"
+                    Margin="0,0,0,8"
+                    DoubleTapped="BoardCard_DoubleTapped">
+                <Grid RowDefinitions="Auto,Auto,Auto">
+                    <!-- Title row -->
+                    <Grid Grid.Row="0" ColumnDefinitions="Auto,*">
+                        <Grid Grid.Column="0" Width="20" Height="20" VerticalAlignment="Top" Margin="0,2,10,0">
+                            <CheckBox VerticalAlignment="Center" HorizontalAlignment="Center"
+                                      IsChecked="{Binding IsDone, Mode=OneWay}"
+                                      Style="{StaticResource CircleCheckBoxStyle}"
+                                      IsHitTestVisible="False" IsTabStop="False" />
+                            <Button Background="Transparent" BorderThickness="0" Padding="0"
+                                    HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                                    Click="TaskCheckbox_Click" />
+                        </Grid>
+                        <TextBlock Grid.Column="1" Text="{Binding Title}"
+                                   TextWrapping="Wrap"
+                                   FontSize="14"
+                                   VerticalAlignment="Top"
+                                   Margin="0,0,0,8" />
+                    </Grid>
+
+                    <!-- Chips + My Day row -->
+                    <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="6" Margin="0,0,0,8">
+                        <Border Style="{StaticResource ChipBorderStyle}"
+                                Background="{ThemeResource SystemFillColorCautionBackgroundBrush}"
+                                Visibility="{Binding HasPriorityChip, Converter={StaticResource BoolVis}}">
+                            <TextBlock Text="{Binding Priority}" Style="{StaticResource ChipTextStyle}" />
+                        </Border>
+                        <Border Style="{StaticResource ChipBorderStyle}"
+                                Background="{Binding DueUrgency, Converter={StaticResource DueBg}}"
+                                Visibility="{Binding HasDue, Converter={StaticResource BoolVis}}">
+                            <TextBlock Text="{Binding DueChipText}" Style="{StaticResource ChipTextStyle}"
+                                       Foreground="{Binding DueUrgency, Converter={StaticResource DueFg}}" />
+                        </Border>
+                        <Button Click="ToggleMyDay_Click"
+                                ToolTipService.ToolTip="Toggle My Day"
+                                Background="Transparent" BorderThickness="0"
+                                Padding="4" VerticalAlignment="Center">
+                            <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE706;" FontSize="12" />
+                        </Button>
+                    </StackPanel>
+
+                    <!-- Progress bar + More menu -->
+                    <Grid Grid.Row="2" ColumnDefinitions="*,Auto">
+                        <ItemsControl Grid.Column="0" ItemsSource="{Binding Subtasks}"
+                                      Visibility="{Binding UseSegmentedBar, Converter={StaticResource BoolVis}}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel Orientation="Horizontal" Spacing="2" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border Width="18" Height="5" CornerRadius="2"
+                                            Background="{Binding Converter={StaticResource SegBrush}}" />
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <Button Grid.Column="1" Background="Transparent" BorderThickness="0"
+                                Padding="4" VerticalAlignment="Center">
+                            <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE712;" FontSize="12" />
+                            <Button.Flyout>
+                                <MenuFlyout>
+                                    <MenuFlyoutItem Text="Mark To Do" Click="SetTodo_Click" />
+                                    <MenuFlyoutItem Text="Mark In Progress" Click="SetInProgress_Click" />
+                                    <MenuFlyoutItem Text="Mark Done" Click="SetDone_Click" />
+                                    <MenuFlyoutSeparator />
+                                    <MenuFlyoutItem Text="Open in Obsidian" Click="OpenTaskInObsidian_Click" />
+                                </MenuFlyout>
+                            </Button.Flyout>
+                        </Button>
+                    </Grid>
+                </Grid>
+            </Border>
+        </DataTemplate>
+
         <controls:BacklogRowTemplateSelector x:Key="BacklogRowSelector"
             TaskTemplate="{StaticResource BacklogTaskTemplate}"
             GroupHeaderTemplate="{StaticResource BacklogGroupHeaderTemplate}" />
@@ -148,7 +231,37 @@
 
         <!-- Filter bar -->
         <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8" Margin="0,16,0,16">
-            <ComboBox x:Name="StatusFilter" SelectedIndex="0" SelectionChanged="StatusFilter_Changed" Width="160">
+            <!-- View mode toggle -->
+            <Border BorderThickness="1"
+                    BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                    CornerRadius="4"
+                    Padding="1">
+                <StackPanel Orientation="Horizontal" Spacing="1">
+                    <ToggleButton x:Name="ListViewToggle"
+                                  IsChecked="True"
+                                  Checked="ListViewToggle_Checked"
+                                  Width="40" Height="32"
+                                  ToolTipService.ToolTip="List view"
+                                  CornerRadius="3,0,0,3"
+                                  BorderThickness="0">
+                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE8FD;" FontSize="13" />
+                    </ToggleButton>
+                    <ToggleButton x:Name="BoardViewToggle"
+                                  IsChecked="False"
+                                  Checked="BoardViewToggle_Checked"
+                                  Width="40" Height="32"
+                                  ToolTipService.ToolTip="Board view"
+                                  CornerRadius="0,3,3,0"
+                                  BorderThickness="0">
+                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xF0E2;" FontSize="13" />
+                    </ToggleButton>
+                </StackPanel>
+            </Border>
+
+            <ComboBox x:Name="StatusFilter"
+                      SelectedIndex="0"
+                      SelectionChanged="StatusFilter_Changed"
+                      Width="160">
                 <ComboBoxItem Tag="all" Content="Active (not done)" />
                 <ComboBoxItem Tag="todo" Content="To Do" />
                 <ComboBoxItem Tag="in-progress" Content="In Progress" />
@@ -162,6 +275,14 @@
             </ToggleButton>
 
             <Button Content="&#xE710;" FontFamily="Segoe Fluent Icons" Click="AddTask_Click" ToolTipService.ToolTip="New task" />
+
+            <!-- Work Log link (board mode only) -->
+            <HyperlinkButton x:Name="WorkLogLink"
+                             Content="View Work Log →"
+                             Click="WorkLogLink_Click"
+                             VerticalAlignment="Center"
+                             Visibility="Collapsed"
+                             Margin="12,0,0,0" />
         </StackPanel>
 
         <!-- Task list (mixed: group headers + tasks when grouped, tasks only otherwise) -->
@@ -183,6 +304,60 @@
                 </Style>
             </ListView.ItemContainerStyle>
         </ListView>
+
+        <!-- Board view (two columns: To Do | In Progress) -->
+        <ScrollViewer
+            x:Name="BoardView"
+            Grid.Row="2"
+            Visibility="Collapsed"
+            HorizontalScrollBarVisibility="Auto"
+            VerticalScrollBarVisibility="Disabled">
+            <ItemsControl ItemsSource="{x:Bind ViewModel.BoardColumns}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" Spacing="16" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Grid RowDefinitions="Auto,*" Width="360" MaxWidth="480" MinWidth="320">
+                            <!-- Sticky column header -->
+                            <Border Grid.Row="0"
+                                    Background="{ThemeResource LayerFillColorDefaultBrush}"
+                                    Padding="12,8"
+                                    Margin="0,0,0,12"
+                                    CornerRadius="6">
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <TextBlock Grid.Column="0"
+                                               Text="{Binding ColumnName}"
+                                               FontWeight="SemiBold"
+                                               FontSize="14"
+                                               VerticalAlignment="Center" />
+                                    <Border Grid.Column="1"
+                                            Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                                            CornerRadius="10"
+                                            Padding="8,2"
+                                            MinWidth="24">
+                                        <TextBlock Text="{Binding Tasks.Count}"
+                                                   FontSize="12"
+                                                   HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center" />
+                                    </Border>
+                                </Grid>
+                            </Border>
+
+                            <!-- Scrollable card list -->
+                            <ScrollViewer Grid.Row="1"
+                                          VerticalScrollBarVisibility="Auto"
+                                          HorizontalScrollBarVisibility="Disabled">
+                                <ItemsControl ItemsSource="{Binding Tasks}"
+                                              ItemTemplate="{StaticResource BoardCardTemplate}" />
+                            </ScrollViewer>
+                        </Grid>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
 
         <!-- Empty state: shown when the filtered Backlog has no tasks -->
         <controls:EmptyState

--- a/src/Glasswork.App/Pages/BacklogPage.xaml.cs
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml.cs
@@ -18,6 +18,8 @@ public sealed partial class BacklogPage : Page
     public BacklogPage()
     {
         ViewModel = new BacklogViewModel(App.Vault, App.Tasks, App.UiState);
+        // Load persisted ViewMode (default "list") BEFORE InitializeComponent
+        ViewModel.ViewMode = App.UiState.Get<string>(App.BacklogViewModeKey) ?? "list";
         // Load persisted toggle (default true) BEFORE InitializeComponent so the
         // x:Bind TwoWay binding to ToggleButton.IsChecked picks up the right value.
         ViewModel.IsGrouped = App.UiState.Get<bool?>(App.BacklogGroupByParentKey) ?? true;
@@ -35,6 +37,7 @@ public sealed partial class BacklogPage : Page
         };
         InitializeComponent();
         ViewModel.Rows.CollectionChanged += (_, _) => UpdateEmptyState();
+        ViewModel.BoardColumns.CollectionChanged += (_, _) => UpdateEmptyState();
         // Persist toggle whenever the user flips it. Bind here (not in VM) so the
         // VM stays UI-state-store-agnostic.
         ViewModel.PropertyChanged += (_, args) =>
@@ -44,7 +47,63 @@ public sealed partial class BacklogPage : Page
                 App.UiState.Set(App.BacklogGroupByParentKey, ViewModel.IsGrouped);
                 App.ScheduleUiStateSave();
             }
+            if (args.PropertyName == nameof(BacklogViewModel.ViewMode))
+            {
+                App.UiState.Set(App.BacklogViewModeKey, ViewModel.ViewMode);
+                App.ScheduleUiStateSave();
+                UpdateViewModeUI();
+            }
         };
+        // Initialize view mode UI on first load
+        UpdateViewModeUI();
+    }
+
+    private void UpdateViewModeUI()
+    {
+        var isList = ViewModel.ViewMode == "list";
+        var isBoard = ViewModel.ViewMode == "board";
+
+        // Sync toggle buttons
+        ListViewToggle.IsChecked = isList;
+        BoardViewToggle.IsChecked = isBoard;
+
+        // Show/hide main views
+        TaskList.Visibility = isList ? Visibility.Visible : Visibility.Collapsed;
+        BoardView.Visibility = isBoard ? Visibility.Visible : Visibility.Collapsed;
+
+        // Show/hide filter controls
+        StatusFilter.Visibility = isList ? Visibility.Visible : Visibility.Collapsed;
+        GroupToggle.Visibility = isList ? Visibility.Visible : Visibility.Collapsed;
+        WorkLogLink.Visibility = isBoard ? Visibility.Visible : Visibility.Collapsed;
+
+        // Update empty state
+        UpdateEmptyState();
+    }
+
+    private void ListViewToggle_Checked(object sender, RoutedEventArgs e)
+    {
+        if (ViewModel.ViewMode == "list") return;
+        ViewModel.ViewMode = "list";
+        BoardViewToggle.IsChecked = false;
+    }
+
+    private void BoardViewToggle_Checked(object sender, RoutedEventArgs e)
+    {
+        if (ViewModel.ViewMode == "board") return;
+        ViewModel.ViewMode = "board";
+        ListViewToggle.IsChecked = false;
+    }
+
+    private void WorkLogLink_Click(object sender, RoutedEventArgs e)
+    {
+        Frame.Navigate(typeof(WorkLogPage));
+    }
+
+    private void BoardCard_DoubleTapped(object sender, Microsoft.UI.Xaml.Input.DoubleTappedRoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement { DataContext: GlassworkTask task }) return;
+        Frame.Navigate(typeof(TaskDetailPage), task);
+        e.Handled = true;
     }
 
     private IReadOnlyDictionary<string, bool> LoadGroupCollapseState()

--- a/src/Glasswork.App/Pages/BacklogPage.xaml.cs
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml.cs
@@ -159,7 +159,20 @@ public sealed partial class BacklogPage : Page
     private void UpdateEmptyState()
     {
         var hasContent = ViewModel.Tasks.Count > 0;
-        TaskList.Visibility = hasContent ? Visibility.Visible : Visibility.Collapsed;
+        var isList = ViewModel.ViewMode == "list";
+        var isBoard = ViewModel.ViewMode == "board";
+        
+        // Only manage TaskList visibility in list mode
+        if (isList)
+        {
+            TaskList.Visibility = hasContent ? Visibility.Visible : Visibility.Collapsed;
+        }
+        // Only manage BoardView visibility in board mode
+        if (isBoard)
+        {
+            BoardView.Visibility = hasContent ? Visibility.Visible : Visibility.Collapsed;
+        }
+        
         EmptyStateView.Visibility = hasContent ? Visibility.Collapsed : Visibility.Visible;
     }
 

--- a/src/Glasswork.App/ViewModels/BacklogViewModel.cs
+++ b/src/Glasswork.App/ViewModels/BacklogViewModel.cs
@@ -27,8 +27,15 @@ public partial class BacklogViewModel : ObservableObject
     /// The bound row sequence: when <see cref="IsGrouped"/> is true, contains
     /// interleaved <see cref="BacklogParentGroupHeader"/> and <see cref="GlassworkTask"/>
     /// items as produced by <see cref="BacklogGrouper"/>. When false, contains tasks only.
+    /// Unused when <see cref="ViewMode"/> is "board" — see <see cref="BoardColumns"/>.
     /// </summary>
     public ObservableCollection<object> Rows { get; } = [];
+
+    /// <summary>
+    /// Board columns: populated when <see cref="ViewMode"/> is "board".
+    /// Each entry contains a column name and filtered/sorted tasks for that status.
+    /// </summary>
+    public ObservableCollection<BoardColumn> BoardColumns { get; } = [];
 
     /// <summary>
     /// Optional source of per-parent-group collapse state, keyed by lowercased parent.
@@ -58,6 +65,7 @@ public partial class BacklogViewModel : ObservableObject
     [ObservableProperty] public partial string FilterStatus { get; set; } = "all";
     [ObservableProperty] public partial GlassworkTask? SelectedTask { get; set; }
     [ObservableProperty] public partial bool IsGrouped { get; set; } = true;
+    [ObservableProperty] public partial string ViewMode { get; set; } = "list"; // "list" | "board"
 
     public BacklogViewModel(VaultService vault, TaskService taskService, IUiStateService? uiState = null)
     {
@@ -71,49 +79,71 @@ public partial class BacklogViewModel : ObservableObject
     {
         Tasks.Clear();
         Rows.Clear();
+        BoardColumns.Clear();
         var all = _vault.LoadAll();
 
-        var filtered = FilterStatus switch
+        if (ViewMode == "board")
         {
-            "all" => all.Where(t => t.Status != GlassworkTask.Statuses.Done),
-            _ => all.Where(t => t.Status == FilterStatus)
-        };
-
-        var ordered = filtered.OrderByDescending(t => t.Priority == "urgent")
-                              .ThenByDescending(t => t.Priority == "high")
-                              .ThenByDescending(t => t.Created)
-                              .ToList();
-
-        foreach (var task in ordered)
-        {
-            Tasks.Add(task);
-        }
-
-        if (IsGrouped)
-        {
-            // Hydrate cache from persisted store before grouping so headers render
-            // resolved titles on the first frame instead of flashing the bare ID.
-            HydrateParentTitleCache(ordered);
-
-            var collapseState = GroupCollapseStateProvider?.Invoke()
-                                ?? new Dictionary<string, bool>();
-            var baseUrl = AdoBaseUrlProvider?.Invoke();
-            foreach (var row in BacklogGrouper.Group(ordered, collapseState, baseUrl, ResolveParentTitleFromCache))
+            // Board mode: use BacklogBoardGrouper, ignore FilterStatus and IsGrouped
+            var columns = BacklogBoardGrouper.GroupByStatus(all);
+            foreach (var col in columns)
             {
-                Rows.Add(row);
+                BoardColumns.Add(col);
             }
-
-            // GC stale entries no longer referenced by any task in the current set.
-            CompactParentTitleStore(ordered);
-
-            // Kick off background fetches for any numeric parents we haven't resolved yet.
-            KickOffParentTitleFetches(ordered);
+            // Populate flat Tasks collection for count exposure
+            foreach (var col in columns)
+            {
+                foreach (var task in col.Tasks)
+                {
+                    Tasks.Add(task);
+                }
+            }
         }
         else
         {
+            // List mode: existing logic
+            var filtered = FilterStatus switch
+            {
+                "all" => all.Where(t => t.Status != GlassworkTask.Statuses.Done),
+                _ => all.Where(t => t.Status == FilterStatus)
+            };
+
+            var ordered = filtered.OrderByDescending(t => t.Priority == "urgent")
+                                  .ThenByDescending(t => t.Priority == "high")
+                                  .ThenByDescending(t => t.Created)
+                                  .ToList();
+
             foreach (var task in ordered)
             {
-                Rows.Add(task);
+                Tasks.Add(task);
+            }
+
+            if (IsGrouped)
+            {
+                // Hydrate cache from persisted store before grouping so headers render
+                // resolved titles on the first frame instead of flashing the bare ID.
+                HydrateParentTitleCache(ordered);
+
+                var collapseState = GroupCollapseStateProvider?.Invoke()
+                                    ?? new Dictionary<string, bool>();
+                var baseUrl = AdoBaseUrlProvider?.Invoke();
+                foreach (var row in BacklogGrouper.Group(ordered, collapseState, baseUrl, ResolveParentTitleFromCache))
+                {
+                    Rows.Add(row);
+                }
+
+                // GC stale entries no longer referenced by any task in the current set.
+                CompactParentTitleStore(ordered);
+
+                // Kick off background fetches for any numeric parents we haven't resolved yet.
+                KickOffParentTitleFetches(ordered);
+            }
+            else
+            {
+                foreach (var task in ordered)
+                {
+                    Rows.Add(task);
+                }
             }
         }
     }
@@ -214,6 +244,7 @@ public partial class BacklogViewModel : ObservableObject
     public event Action? ParentTitlesResolved;
 
     partial void OnIsGroupedChanged(bool value) => Refresh();
+    partial void OnViewModeChanged(string value) => Refresh();
 
     [RelayCommand]
     public void SetStatus(string newStatus)

--- a/src/Glasswork.Core/Models/BoardColumn.cs
+++ b/src/Glasswork.Core/Models/BoardColumn.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Glasswork.Core.Models;
+
+/// <summary>
+/// Represents one column in the board view of the backlog.
+/// Contains the column name (e.g., "To Do", "In Progress") and the filtered/sorted tasks.
+/// </summary>
+public sealed class BoardColumn
+{
+    public string ColumnName { get; }
+    public List<GlassworkTask> Tasks { get; }
+
+    public BoardColumn(string columnName, List<GlassworkTask> tasks)
+    {
+        ColumnName = columnName;
+        Tasks = tasks;
+    }
+}

--- a/src/Glasswork.Core/Services/BacklogBoardGrouper.cs
+++ b/src/Glasswork.Core/Services/BacklogBoardGrouper.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Linq;
+using Glasswork.Core.Models;
+
+namespace Glasswork.Core.Services;
+
+/// <summary>
+/// Groups backlog tasks into board columns by status for the read-only board view.
+/// Maps task statuses to column names and applies the backlog sort order within each column.
+/// </summary>
+public static class BacklogBoardGrouper
+{
+    /// <summary>
+    /// Groups tasks into board columns (To Do, In Progress).
+    /// Excludes done tasks. Sorts within each column by priority (urgent → high) then created date descending.
+    /// </summary>
+    public static List<BoardColumn> GroupByStatus(IEnumerable<GlassworkTask> tasks)
+    {
+        var filtered = tasks.Where(t => t.Status != GlassworkTask.Statuses.Done).ToList();
+
+        var todoTasks = filtered
+            .Where(t => t.Status == GlassworkTask.Statuses.Todo)
+            .OrderBy(SortKey)
+            .ToList();
+
+        var inProgressTasks = filtered
+            .Where(t => t.Status == GlassworkTask.Statuses.InProgress)
+            .OrderBy(SortKey)
+            .ToList();
+
+        return new List<BoardColumn>
+        {
+            new BoardColumn("To Do", todoTasks),
+            new BoardColumn("In Progress", inProgressTasks)
+        };
+    }
+
+    private static (int, long) SortKey(GlassworkTask t)
+    {
+        var priorityRank = t.Priority switch
+        {
+            GlassworkTask.Priorities.Urgent => 0,
+            GlassworkTask.Priorities.High => 1,
+            GlassworkTask.Priorities.Medium => 2,
+            GlassworkTask.Priorities.Low => 3,
+            _ => 4
+        };
+        // Negate ticks to sort descending by created date
+        return (priorityRank, -t.Created.Ticks);
+    }
+}

--- a/tests/Glasswork.Tests/BacklogBoardGrouperTests.cs
+++ b/tests/Glasswork.Tests/BacklogBoardGrouperTests.cs
@@ -1,0 +1,83 @@
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class BacklogBoardGrouperTests
+{
+    [TestMethod]
+    public void GroupByStatus_CreatesToDoAndInProgressColumns()
+    {
+        var tasks = new[]
+        {
+            TestTask("t1", status: GlassworkTask.Statuses.Todo),
+            TestTask("t2", status: GlassworkTask.Statuses.InProgress),
+            TestTask("t3", status: GlassworkTask.Statuses.Todo)
+        };
+
+        var grouped = BacklogBoardGrouper.GroupByStatus(tasks);
+
+        Assert.AreEqual(2, grouped.Count, "Should have 2 columns");
+        Assert.AreEqual("To Do", grouped[0].ColumnName);
+        Assert.AreEqual(2, grouped[0].Tasks.Count);
+        Assert.AreEqual("In Progress", grouped[1].ColumnName);
+        Assert.AreEqual(1, grouped[1].Tasks.Count);
+    }
+
+    [TestMethod]
+    public void GroupByStatus_SortsTasksWithinColumn_UrgentHighCreatedDesc()
+    {
+        var tasks = new[]
+        {
+            TestTask("t1", priority: GlassworkTask.Priorities.Medium, created: new DateTime(2026, 1, 1)),
+            TestTask("t2", priority: GlassworkTask.Priorities.Urgent, created: new DateTime(2026, 1, 2)),
+            TestTask("t3", priority: GlassworkTask.Priorities.High, created: new DateTime(2026, 1, 3)),
+            TestTask("t4", priority: GlassworkTask.Priorities.Low, created: new DateTime(2026, 1, 5)),
+            TestTask("t5", priority: GlassworkTask.Priorities.High, created: new DateTime(2026, 1, 4))
+        };
+
+        var grouped = BacklogBoardGrouper.GroupByStatus(tasks);
+
+        var todoColumn = grouped.First(c => c.ColumnName == "To Do");
+        Assert.AreEqual("t2", todoColumn.Tasks[0].Id, "urgent first");
+        Assert.AreEqual("t5", todoColumn.Tasks[1].Id, "high (Jan 4, newer) second");
+        Assert.AreEqual("t3", todoColumn.Tasks[2].Id, "high (Jan 3, older) third");
+        Assert.AreEqual("t1", todoColumn.Tasks[3].Id, "med fourth");
+        Assert.AreEqual("t4", todoColumn.Tasks[4].Id, "low last");
+    }
+
+    [TestMethod]
+    public void GroupByStatus_ExcludesDoneTasks()
+    {
+        var tasks = new[]
+        {
+            TestTask("t1", status: GlassworkTask.Statuses.Todo),
+            TestTask("t2", status: GlassworkTask.Statuses.Done),
+            TestTask("t3", status: GlassworkTask.Statuses.InProgress)
+        };
+
+        var grouped = BacklogBoardGrouper.GroupByStatus(tasks);
+
+        var allTasks = grouped.SelectMany(c => c.Tasks).ToList();
+        Assert.AreEqual(2, allTasks.Count, "done tasks should not appear in board columns");
+        Assert.IsFalse(allTasks.Any(t => t.Status == GlassworkTask.Statuses.Done));
+    }
+
+    private static GlassworkTask TestTask(
+        string id,
+        string status = GlassworkTask.Statuses.Todo,
+        string priority = GlassworkTask.Priorities.Medium,
+        DateTime? created = null)
+    {
+        return new GlassworkTask
+        {
+            Id = id,
+            Title = $"Task {id}",
+            Status = status,
+            Priority = priority,
+            Created = created ?? DateTime.UtcNow,
+            Subtasks = []
+        };
+    }
+}

--- a/tests/Glasswork.Tests/UiStateServiceTests.cs
+++ b/tests/Glasswork.Tests/UiStateServiceTests.cs
@@ -113,4 +113,29 @@ public class UiStateServiceTests
         Assert.IsTrue(svc.Get<bool>("collapsed.task-3"));
         Assert.AreEqual("MyDay", svc.Get<string>("nav.last-page"), "unrelated keys must not be touched");
     }
+
+    [TestMethod]
+    public void BacklogViewMode_DefaultsToList_WhenNotSet()
+    {
+        var dir = NewTempDir();
+        var svc = new JsonFileUiStateService(Path.Combine(dir, "ui-state.json"));
+
+        var mode = svc.Get<string>("backlog.view-mode") ?? "list";
+
+        Assert.AreEqual("list", mode);
+    }
+
+    [TestMethod]
+    public void BacklogViewMode_PersistsAcrossInstances()
+    {
+        var dir = NewTempDir();
+        var path = Path.Combine(dir, "ui-state.json");
+        var svc1 = new JsonFileUiStateService(path);
+        svc1.Set("backlog.view-mode", "board");
+        svc1.Save();
+
+        var svc2 = new JsonFileUiStateService(path);
+
+        Assert.AreEqual("board", svc2.Get<string>("backlog.view-mode"));
+    }
 }

--- a/tests/Glasswork.Tests/UiStateServiceTests.cs
+++ b/tests/Glasswork.Tests/UiStateServiceTests.cs
@@ -120,7 +120,7 @@ public class UiStateServiceTests
         var dir = NewTempDir();
         var svc = new JsonFileUiStateService(Path.Combine(dir, "ui-state.json"));
 
-        var mode = svc.Get<string>("backlog.view-mode") ?? "list";
+        var mode = svc.Get<string>("backlog.viewMode") ?? "list";
 
         Assert.AreEqual("list", mode);
     }
@@ -131,11 +131,11 @@ public class UiStateServiceTests
         var dir = NewTempDir();
         var path = Path.Combine(dir, "ui-state.json");
         var svc1 = new JsonFileUiStateService(path);
-        svc1.Set("backlog.view-mode", "board");
+        svc1.Set("backlog.viewMode", "board");
         svc1.Save();
 
         var svc2 = new JsonFileUiStateService(path);
 
-        Assert.AreEqual("board", svc2.Get<string>("backlog.view-mode"));
+        Assert.AreEqual("board", svc2.Get<string>("backlog.viewMode"));
     }
 }


### PR DESCRIPTION
# Backlog Board View (Read-Only) — Slice 1 of 3

Closes #145

## Summary

Adds a board/kanban view to the Backlog page as an alternative to the existing list view. Tasks are grouped into two columns (`To Do` | `In Progress`) with simplified card templates. This slice covers the read-only surface — rendering, layout, navigation, and the existing mark-done path. Drag-to-change-status and undo InfoBar land in follow-up slices.

## Implementation

**Core Layer (Testable, Platform-Agnostic)**
- `BoardColumn.cs`: Model representing one board column (name + task list)
- `BacklogBoardGrouper.cs`: Static service for grouping tasks by status
  - Excludes done tasks (Work Log is the canonical Done surface)
  - Sorts within each column: urgent → high → medium → low → created desc
  - Returns `List<BoardColumn>` for UI binding

**ViewModel Integration**
- Added `ViewMode` property to `BacklogViewModel` ("list" | "board")
- Added `BoardColumns` ObservableCollection for board data binding
- `Refresh()` branches on `ViewMode`:
  - List mode: existing logic (filter + grouping)
  - Board mode: calls `BacklogBoardGrouper.GroupByStatus()`, ignores `FilterStatus` and `IsGrouped`
- Persists view mode in `UiState` under `"backlog.viewMode"` (defaults to `"list"`)

**UI Layer**
- View toggle button in Backlog header: `[≡ List | ▦ Board]`
- Board layout: horizontal `ItemsControl` with two-column template
  - Each column has sticky header with name and `(count)` badge
  - Cards render in vertically scrollable `ScrollViewer` per column
- Board card template (simplified vs. list):
  - Title (wrap), priority chip, due chip, My Day sun-icon, checkbox
  - Segmented progress bar (when subtasks exist)
  - `⋯` More menu (`Mark To Do` / `Mark In Progress` / `Mark Done` / `Open in Obsidian`)
  - No blurb/current-step/blocker rows (per spec)
- Control visibility logic:
  - Board mode: hide `StatusFilter`, hide `GroupToggle`, show `"View Work Log →"` link
  - List mode: show `StatusFilter`, show `GroupToggle`, hide Work Log link
- Double-click card body → opens TaskDetail
- Checkbox or `⋯` → `Mark Done` uses existing write path (no undo yet)
- Sun-icon toggles `task.MyDay` (reuses existing list-view code)

## Tests

**Core Layer (12 tests total, all GREEN)**
- `UiStateServiceTests.cs`: 2 tests for `BacklogViewMode` persistence
  - Defaults to `"list"` for fresh installs
  - Persists across service instances
- `BacklogBoardGrouperTests.cs`: 3 tests for board grouping logic
  - Creates `To Do` and `In Progress` columns
  - Sorts tasks by priority + created date (urgent → high → med → low, then newest first)
  - Excludes done tasks

## Validation

**Local Checks**
```powershell
✅ dotnet build src/Glasswork.Core/Glasswork.Core.csproj
✅ dotnet test tests/Glasswork.Tests/ (12/12 tests pass for new code)
```

**CI Requirements**
- Build must pass on Windows (WinUI 3 / Glasswork.App)
- Full test suite must pass (note: 3 pre-existing flaky debouncer tests are unrelated to this change)

## Decisions

**Board sort order**: Matches existing list view (`urgent → high → created desc`) per `BacklogViewModel.cs:82-84`. This ensures consistency when toggling between views.

**View mode persistence**: Stored in `UiState` under `"backlog.viewMode"` (follows existing pattern like `"backlog.groupByParent"`).

**Done tasks excluded**: Board only shows `To Do` and `In Progress`. Work Log is the canonical Done surface per `UBIQUITOUS_LANGUAGE.md`. List view's "Done" filter remains available.

**Card template simplification**: Board cards omit blurb, current-step, and blocker rows to keep cards compact and scannable in the two-column layout. These details remain available in TaskDetail.

**No undo banner yet**: Marking a task done fades it out and removes it from the column. Undo affordance lands in slice 3 (deferred per parent issue #144 slice breakdown).

## Review Notes

Awaiting dual-model code review (GPT-5.5 + Claude Opus 4.7) before merge.

## Related

- Parent: #144 (Backlog Board View)
- Blocks: Slice 2 (drag-to-change-status) and Slice 3 (undo InfoBar)
