### PR TITLE
feat: Backlog Board undo for mark-done

### DIFF
--- a/src/Glasswork.App/Pages/BacklogPage.xaml
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml
@@ -223,7 +223,7 @@
         <conv:CollapseChevronGlyphConverter x:Key="ChevronGlyph" />
     </Page.Resources>
 
-    <Grid Padding="32" RowDefinitions="Auto,Auto,*">
+    <Grid Padding="32" RowDefinitions="Auto,Auto,Auto,*">
 
         <!-- Header -->
         <TextBlock
@@ -231,8 +231,21 @@
             Style="{StaticResource TitleTextBlockStyle}"
             Text="Backlog" />
 
+        <!-- Undo InfoBar (board view only) -->
+        <InfoBar
+            x:Name="UndoInfoBar"
+            Grid.Row="1"
+            Severity="Informational"
+            IsOpen="False"
+            Closed="UndoInfoBar_Closed"
+            Margin="0,12,0,0">
+            <InfoBar.ActionButton>
+                <Button Content="Undo" Click="UndoButton_Click" />
+            </InfoBar.ActionButton>
+        </InfoBar>
+
         <!-- Filter bar -->
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8" Margin="0,16,0,16">
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8" Margin="0,16,0,16">
             <!-- View mode toggle -->
             <Border BorderThickness="1"
                     BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
@@ -289,7 +302,7 @@
 
         <!-- Task list (mixed: group headers + tasks when grouped, tasks only otherwise) -->
         <ListView
-            Grid.Row="2"
+            Grid.Row="3"
             x:Name="TaskList"
             ItemsSource="{x:Bind ViewModel.Rows}"
             ItemTemplateSelector="{StaticResource BacklogRowSelector}"
@@ -310,7 +323,7 @@
         <!-- Board view (two columns: To Do | In Progress) -->
         <ScrollViewer
             x:Name="BoardView"
-            Grid.Row="2"
+            Grid.Row="3"
             Visibility="Collapsed"
             HorizontalScrollBarVisibility="Auto"
             VerticalScrollBarVisibility="Disabled">
@@ -367,7 +380,7 @@
         <!-- Empty state: shown when the filtered Backlog has no tasks -->
         <controls:EmptyState
             x:Name="EmptyStateView"
-            Grid.Row="2"
+            Grid.Row="3"
             Glyph="&#xE8FD;"
             Headline="Nothing in the Backlog yet."
             Body="Capture a task to get started. You can pull anything you add here into My Day later."

--- a/src/Glasswork.App/Pages/BacklogPage.xaml.cs
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml.cs
@@ -394,8 +394,8 @@ public sealed partial class BacklogPage : Page
         UndoInfoBar.Title = $"Marked done: \"{taskTitle}\"";
         UndoInfoBar.IsOpen = true;
 
-        // Cancel any existing timer
-        _undoTimer?.Stop();
+        // Dispose and cancel any existing timer
+        DisposeTimer();
 
         // Start 6-second auto-dismiss timer
         _undoTimer = new DispatcherTimer
@@ -404,9 +404,9 @@ public sealed partial class BacklogPage : Page
         };
         _undoTimer.Tick += (_, _) =>
         {
-            _undoTimer.Stop();
             UndoInfoBar.IsOpen = false;
             _undoState.Clear();
+            DisposeTimer();
         };
         _undoTimer.Start();
     }
@@ -414,7 +414,7 @@ public sealed partial class BacklogPage : Page
     private void UndoInfoBar_Closed(InfoBar sender, InfoBarClosedEventArgs args)
     {
         // User manually closed or timer auto-dismissed
-        _undoTimer?.Stop();
+        DisposeTimer();
         _undoState.Clear();
     }
 
@@ -422,18 +422,28 @@ public sealed partial class BacklogPage : Page
     {
         if (!_undoState.HasUndo) return;
 
+        // Stop timer immediately to prevent race condition
+        DisposeTimer();
+
         // Find the task to restore
         var task = ViewModel.Tasks.FirstOrDefault(t => t.Id == _undoState.TaskId);
-        if (task is null) return;
+        if (task is null)
+        {
+            _undoState.Clear();
+            UndoInfoBar.IsOpen = false;
+            return;
+        }
 
-        // Cancel the timer
-        _undoTimer?.Stop();
+        // Validate task is still done (reject stale undo if status changed)
+        if (task.Status != GlassworkTask.Statuses.Done)
+        {
+            _undoState.Clear();
+            UndoInfoBar.IsOpen = false;
+            return;
+        }
 
-        // Restore previous status
+        // Restore previous status (don't write directly, let command handle it)
         var previousStatus = _undoState.PreviousStatus ?? GlassworkTask.Statuses.Todo;
-        task.Status = previousStatus;
-
-        // Write the restored status
         ViewModel.SelectedTask = task;
         ViewModel.SetStatusCommand.Execute(previousStatus);
 
@@ -473,6 +483,7 @@ public sealed partial class BacklogPage : Page
                 border.BorderBrush = originalBrush;
                 border.BorderThickness = originalThickness;
                 timer.Stop();
+                timer.Dispose();
             };
             timer.Start();
         });
@@ -507,9 +518,19 @@ public sealed partial class BacklogPage : Page
 
     private void ClearUndoState()
     {
-        _undoTimer?.Stop();
+        DisposeTimer();
         _undoState.Clear();
         UndoInfoBar.IsOpen = false;
+    }
+
+    private void DisposeTimer()
+    {
+        if (_undoTimer is not null)
+        {
+            _undoTimer.Stop();
+            _undoTimer.Dispose();
+            _undoTimer = null;
+        }
     }
 
     // Drag-to-change-status (Board view only)

--- a/src/Glasswork.App/Pages/BacklogPage.xaml.cs
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml.cs
@@ -9,12 +9,16 @@ using Glasswork.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
+using Microsoft.UI.Xaml.Media.Animation;
+using Microsoft.UI.Xaml.Media;
 
 namespace Glasswork.Pages;
 
 public sealed partial class BacklogPage : Page
 {
     public BacklogViewModel ViewModel { get; }
+    private readonly BacklogUndoState _undoState = new();
+    private DispatcherTimer? _undoTimer;
 
     public BacklogPage()
     {
@@ -131,12 +135,16 @@ public sealed partial class BacklogPage : Page
         base.OnNavigatedTo(e);
         Refresh();
         App.TaskFileChangedExternally += OnFileChanged;
+        // Clear undo state when navigating to the page
+        ClearUndoState();
     }
 
     protected override void OnNavigatedFrom(NavigationEventArgs e)
     {
         base.OnNavigatedFrom(e);
         App.TaskFileChangedExternally -= OnFileChanged;
+        // Clear undo state when navigating away
+        ClearUndoState();
     }
 
     private void OnFileChanged(object? sender, string fileName)
@@ -215,8 +223,23 @@ public sealed partial class BacklogPage : Page
     {
         if (sender is FrameworkElement { DataContext: GlassworkTask task })
         {
+            // Capture undo state ONLY for board view mark-done
+            var isBoard = ViewModel.ViewMode == "board";
+            var isMarkDone = status == GlassworkTask.Statuses.Done;
+
+            if (isBoard && isMarkDone)
+            {
+                _undoState.CaptureMarkDone(task);
+            }
+
             ViewModel.SelectedTask = task;
             ViewModel.SetStatusCommand.Execute(status);
+
+            // Show undo InfoBar ONLY for board view mark-done
+            if (isBoard && isMarkDone)
+            {
+                ShowUndoInfoBar(task.Title);
+            }
         }
     }
 
@@ -249,12 +272,27 @@ public sealed partial class BacklogPage : Page
     {
         if (sender is FrameworkElement { DataContext: GlassworkTask task })
         {
+            // Capture undo state ONLY for board view mark-done
+            var isBoard = ViewModel.ViewMode == "board";
+            var isMarkDone = !task.IsDone; // About to mark done
+
+            if (isBoard && isMarkDone)
+            {
+                _undoState.CaptureMarkDone(task);
+            }
+
             // Toggle based on current model state — Button has no IsChecked.
             var newStatus = task.IsDone
                 ? GlassworkTask.Statuses.Todo
                 : GlassworkTask.Statuses.Done;
             ViewModel.SelectedTask = task;
             ViewModel.SetStatusCommand.Execute(newStatus);
+
+            // Show undo InfoBar ONLY for board view mark-done
+            if (isBoard && isMarkDone)
+            {
+                ShowUndoInfoBar(task.Title);
+            }
         }
     }
 
@@ -345,6 +383,133 @@ public sealed partial class BacklogPage : Page
         var slugPath = p.Replace('/', Path.DirectorySeparatorChar);
         var absolutePath = Path.Combine(wikiRoot, slugPath + ".md");
         return File.Exists(absolutePath) ? absolutePath : null;
+    }
+
+    // Drag-to-change-status (Board view only)
+    private GlassworkTask? _draggedTask;
+
+    private void ShowUndoInfoBar(string taskTitle)
+    {
+        // Show InfoBar with task title
+        UndoInfoBar.Title = $"Marked done: \"{taskTitle}\"";
+        UndoInfoBar.IsOpen = true;
+
+        // Cancel any existing timer
+        _undoTimer?.Stop();
+
+        // Start 6-second auto-dismiss timer
+        _undoTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromSeconds(6)
+        };
+        _undoTimer.Tick += (_, _) =>
+        {
+            _undoTimer.Stop();
+            UndoInfoBar.IsOpen = false;
+            _undoState.Clear();
+        };
+        _undoTimer.Start();
+    }
+
+    private void UndoInfoBar_Closed(InfoBar sender, InfoBarClosedEventArgs args)
+    {
+        // User manually closed or timer auto-dismissed
+        _undoTimer?.Stop();
+        _undoState.Clear();
+    }
+
+    private void UndoButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (!_undoState.HasUndo) return;
+
+        // Find the task to restore
+        var task = ViewModel.Tasks.FirstOrDefault(t => t.Id == _undoState.TaskId);
+        if (task is null) return;
+
+        // Cancel the timer
+        _undoTimer?.Stop();
+
+        // Restore previous status
+        var previousStatus = _undoState.PreviousStatus ?? GlassworkTask.Statuses.Todo;
+        task.Status = previousStatus;
+
+        // Write the restored status
+        ViewModel.SelectedTask = task;
+        ViewModel.SetStatusCommand.Execute(previousStatus);
+
+        // Close InfoBar
+        UndoInfoBar.IsOpen = false;
+
+        // Clear undo state
+        _undoState.Clear();
+
+        // Flash the restored card with accent outline
+        FlashRestoredCard(task);
+    }
+
+    private void FlashRestoredCard(GlassworkTask task)
+    {
+        // Find the card in the board view
+        // We need to wait for the UI to update after status change
+        DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
+        {
+            // Find the Border element that represents this card
+            var border = FindCardBorder(task);
+            if (border is null) return;
+
+            // Create flash animation (accent outline for ~150ms)
+            var originalBrush = border.BorderBrush;
+            var originalThickness = border.BorderThickness;
+
+            border.BorderBrush = (Brush)Application.Current.Resources["SystemAccentColor"];
+            border.BorderThickness = new Thickness(2);
+
+            var timer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(150)
+            };
+            timer.Tick += (_, _) =>
+            {
+                border.BorderBrush = originalBrush;
+                border.BorderThickness = originalThickness;
+                timer.Stop();
+            };
+            timer.Start();
+        });
+    }
+
+    private Border? FindCardBorder(GlassworkTask task)
+    {
+        // Walk the visual tree to find the Border with matching DataContext
+        return FindChildByDataContext<Border>(BoardView, task);
+    }
+
+    private T? FindChildByDataContext<T>(DependencyObject parent, object dataContext) where T : FrameworkElement
+    {
+        if (parent is null) return null;
+
+        var childCount = VisualTreeHelper.GetChildrenCount(parent);
+        for (var i = 0; i < childCount; i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+            
+            if (child is T element && element.DataContext == dataContext)
+            {
+                return element;
+            }
+
+            var result = FindChildByDataContext<T>(child, dataContext);
+            if (result is not null) return result;
+        }
+
+        return null;
+    }
+
+    private void ClearUndoState()
+    {
+        _undoTimer?.Stop();
+        _undoState.Clear();
+        UndoInfoBar.IsOpen = false;
     }
 
     // Drag-to-change-status (Board view only)

--- a/src/Glasswork.Core/ViewModels/BacklogUndoState.cs
+++ b/src/Glasswork.Core/ViewModels/BacklogUndoState.cs
@@ -1,0 +1,29 @@
+using Glasswork.Core.Models;
+
+namespace Glasswork.ViewModels;
+
+/// <summary>
+/// Tracks the state needed to undo a mark-done action on the Backlog board.
+/// Captures the task ID and its previous status (todo or in_progress) at the
+/// moment of mark-done, allowing restoration if the user clicks Undo.
+/// </summary>
+public class BacklogUndoState
+{
+    public bool HasUndo { get; private set; }
+    public string? TaskId { get; private set; }
+    public string? PreviousStatus { get; private set; }
+
+    public void CaptureMarkDone(GlassworkTask task)
+    {
+        TaskId = task.Id;
+        PreviousStatus = task.Status;
+        HasUndo = true;
+    }
+
+    public void Clear()
+    {
+        TaskId = null;
+        PreviousStatus = null;
+        HasUndo = false;
+    }
+}

--- a/tests/Glasswork.Tests/BacklogUndoStateTests.cs
+++ b/tests/Glasswork.Tests/BacklogUndoStateTests.cs
@@ -1,0 +1,77 @@
+using Glasswork.Core.Models;
+using Glasswork.ViewModels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class BacklogUndoStateTests
+{
+    [TestMethod]
+    public void CaptureMarkDone_StoresPreviousStatus_WhenTaskWasTodo()
+    {
+        // Arrange
+        var state = new BacklogUndoState();
+        var task = new GlassworkTask { Id = "task-1", Status = GlassworkTask.Statuses.Todo };
+
+        // Act
+        state.CaptureMarkDone(task);
+
+        // Assert
+        Assert.IsTrue(state.HasUndo);
+        Assert.AreEqual("task-1", state.TaskId);
+        Assert.AreEqual(GlassworkTask.Statuses.Todo, state.PreviousStatus);
+    }
+
+    [TestMethod]
+    public void CaptureMarkDone_StoresPreviousStatus_WhenTaskWasInProgress()
+    {
+        // Arrange
+        var state = new BacklogUndoState();
+        var task = new GlassworkTask { Id = "task-2", Status = GlassworkTask.Statuses.InProgress };
+
+        // Act
+        state.CaptureMarkDone(task);
+
+        // Assert
+        Assert.IsTrue(state.HasUndo);
+        Assert.AreEqual("task-2", state.TaskId);
+        Assert.AreEqual(GlassworkTask.Statuses.InProgress, state.PreviousStatus);
+    }
+
+    [TestMethod]
+    public void Clear_RemovesUndoState()
+    {
+        // Arrange
+        var state = new BacklogUndoState();
+        var task = new GlassworkTask { Id = "task-1", Status = GlassworkTask.Statuses.Todo };
+        state.CaptureMarkDone(task);
+
+        // Act
+        state.Clear();
+
+        // Assert
+        Assert.IsFalse(state.HasUndo);
+        Assert.IsNull(state.TaskId);
+        Assert.IsNull(state.PreviousStatus);
+    }
+
+    [TestMethod]
+    public void CaptureMarkDone_ReplacesExistingState()
+    {
+        // Arrange
+        var state = new BacklogUndoState();
+        var task1 = new GlassworkTask { Id = "task-1", Status = GlassworkTask.Statuses.Todo };
+        var task2 = new GlassworkTask { Id = "task-2", Status = GlassworkTask.Statuses.InProgress };
+        
+        state.CaptureMarkDone(task1);
+
+        // Act - second mark-done replaces first
+        state.CaptureMarkDone(task2);
+
+        // Assert - only task-2 is stored
+        Assert.IsTrue(state.HasUndo);
+        Assert.AreEqual("task-2", state.TaskId);
+        Assert.AreEqual(GlassworkTask.Statuses.InProgress, state.PreviousStatus);
+    }
+}


### PR DESCRIPTION
# Backlog Board undo for mark-done

Implements slice 3 of 3 for the Backlog Board kanban feature.

Closes #147

## Review notes

Conducted dual-model code review with GPT-5.5 and Claude Opus 4.7 in parallel. Addressed all critical findings:

**GPT-5.5 findings (both adopted):**
1. Double status write in UndoButton_Click - removed direct task.Status assignment
2. Missing validation of task state - added check that task is still done before restoring

**Claude Opus 4.7 findings (all adopted):**
1. Duplicate _draggedTask field - fixed compilation error
2. Memory leaks - added DisposeTimer() helper to properly dispose DispatcherTimer
3. Race condition in UndoButton_Click - moved DisposeTimer() call to prevent timer firing mid-execution

All findings were critical for correctness or memory safety. Fix commit: 5d1a4ef