### PR TITLE
fix: restore Glasswork.App build on main

### DIFF
--- a/src/Glasswork.App/App.xaml.cs
+++ b/src/Glasswork.App/App.xaml.cs
@@ -285,7 +285,7 @@ public partial class App : Application
         InitVaultServices(newVaultPath, uiStateImpl);
     }
 
-    private static void OnAppInstanceActivated(AppInstance sender, AppActivationArguments args)
+    private static void OnAppInstanceActivated(object? sender, AppActivationArguments args)
     {
         // Fired on a background thread — marshal UI work to the dispatcher.
         var uri = ExtractUri(args);

--- a/src/Glasswork.App/MainWindow.xaml.cs
+++ b/src/Glasswork.App/MainWindow.xaml.cs
@@ -209,7 +209,7 @@ public sealed partial class MainWindow : Window
                 if (task is null)
                 {
                     DeepLinkErrorBar.Title = "Task not found";
-                    DeepLinkErrorBar.Message = $"No task with id "{t.TaskId}" was found in the vault.";
+                    DeepLinkErrorBar.Message = $"No task with id \"{t.TaskId}\" was found in the vault.";
                     DeepLinkErrorBar.IsOpen = true;
                     return;
                 }

--- a/src/Glasswork.App/Pages/BacklogPage.xaml.cs
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml.cs
@@ -385,9 +385,6 @@ public sealed partial class BacklogPage : Page
         return File.Exists(absolutePath) ? absolutePath : null;
     }
 
-    // Drag-to-change-status (Board view only)
-    private GlassworkTask? _draggedTask;
-
     private void ShowUndoInfoBar(string taskTitle)
     {
         // Show InfoBar with task title
@@ -483,7 +480,6 @@ public sealed partial class BacklogPage : Page
                 border.BorderBrush = originalBrush;
                 border.BorderThickness = originalThickness;
                 timer.Stop();
-                timer.Dispose();
             };
             timer.Start();
         });
@@ -528,7 +524,6 @@ public sealed partial class BacklogPage : Page
         if (_undoTimer is not null)
         {
             _undoTimer.Stop();
-            _undoTimer.Dispose();
             _undoTimer = null;
         }
     }
@@ -622,12 +617,5 @@ public sealed partial class BacklogPage : Page
         // Placeholder: InfoBar UI will be added in next iteration
         // For now, just log the error
         System.Diagnostics.Debug.WriteLine($"Drag-drop error: {message}");
-    }
-
-    private void BoardCard_DoubleTapped(object sender, Microsoft.UI.Xaml.Input.DoubleTappedRoutedEventArgs e)
-    {
-        if (sender is not FrameworkElement { DataContext: GlassworkTask task }) return;
-        Frame.Navigate(typeof(TaskDetailPage), task);
-        e.Handled = true;
     }
 }

--- a/src/Glasswork.App/Services/VaultPageHelper.cs
+++ b/src/Glasswork.App/Services/VaultPageHelper.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using Glasswork.Core.Models;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 
 namespace Glasswork.Services;


### PR DESCRIPTION
## Problem

`dotnet build src\Glasswork.App` was broken on `main` and nobody noticed because Ralph''s validation only builds `Glasswork.Core` + tests, not the WinUI App project. As a result, six bugs accumulated:

1. **`MainWindow.xaml.cs:212`** — unescaped double-quote characters inside an interpolated string. Pre-existing since #114 (deep-linking).
2. **`BacklogPage.xaml.cs`** — `BoardCard_DoubleTapped` defined twice. Slice 2 (#149) and slice 3 (#150) both added it.
3. **`BacklogPage.xaml.cs`** — `_draggedTask` field defined twice. Same root cause.
4. **`BacklogPage.xaml.cs`** — two `DispatcherTimer.Dispose()` calls. `Microsoft.UI.Xaml.DispatcherTimer` does not implement `IDisposable`; only `Stop()` exists. Slice 3 imported the WPF/WinForms timer pattern by mistake.
5. **`App.xaml.cs:288`** — `OnAppInstanceActivated` had `(AppInstance, AppActivationArguments)` signature; `AppInstance.Activated` event expects `EventHandler<AppActivationArguments>`. Likely Windows App SDK version drift.
6. **`VaultPageHelper.cs`** — missing `using Microsoft.UI.Xaml.Input;` for `FocusManager`.

## Verification

```
dotnet build src\Glasswork.App -nologo -r win-x64
...
Build succeeded.
    2 Warning(s)
    0 Error(s)
```

The 2 remaining warnings (`TaskDetailPage.xaml.cs:375` nullable deref, `:478` reference comparison) are pre-existing and not in scope here.

I also launched the resulting binary and confirmed the new Backlog Board view (`[List | Board]` toggle, columns, drag, undo InfoBar) renders and is interactive.

## Followup

`.ralph/config.json` now includes `dotnet build src/Glasswork.App -nologo -r win-x64` in the worker validation step (local-only change since `.ralph/` is gitignored). The next Ralph loop run will catch this class of duplicate-member / signature-drift bug at iteration time, before a PR is opened.