### PR TITLE
fix: XAML init-order crashes on Backlog navigation + defensive sweep

### DIFF
--- a/src/Glasswork.App/App.xaml.cs
+++ b/src/Glasswork.App/App.xaml.cs
@@ -131,6 +131,42 @@ public partial class App : Application
     {
         // Set AUMID before any window creation for consistent taskbar identity
         SetCurrentProcessExplicitAppUserModelID(AppUserModelId);
+
+        // Capture unhandled exceptions to a known file. Without this, self-contained
+        // WinUI desktop apps crash silently with only a STOWED_EXCEPTION (0xc000027b)
+        // in WER — no stack trace, no managed exception info.
+        UnhandledException += (_, e) =>
+        {
+            try
+            {
+                var logPath = Path.Combine(Path.GetTempPath(), "glasswork-unhandled.log");
+                File.AppendAllText(logPath,
+                    $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] UI thread:\n{e.Exception}\n\n");
+            }
+            catch { /* logging failure must not crash again */ }
+            // Don't mark Handled — let the app crash so we still get the WER report.
+        };
+        AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+        {
+            try
+            {
+                var logPath = Path.Combine(Path.GetTempPath(), "glasswork-unhandled.log");
+                File.AppendAllText(logPath,
+                    $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] AppDomain:\n{e.ExceptionObject}\n\n");
+            }
+            catch { }
+        };
+        System.Threading.Tasks.TaskScheduler.UnobservedTaskException += (_, e) =>
+        {
+            try
+            {
+                var logPath = Path.Combine(Path.GetTempPath(), "glasswork-unhandled.log");
+                File.AppendAllText(logPath,
+                    $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] Unobserved Task:\n{e.Exception}\n\n");
+            }
+            catch { }
+        };
+
         InitializeComponent();
     }
 

--- a/src/Glasswork.App/MainWindow.xaml.cs
+++ b/src/Glasswork.App/MainWindow.xaml.cs
@@ -184,6 +184,12 @@ public sealed partial class MainWindow : Window
 
     private void NavigateToTopLevel(Type pageType)
     {
+        // Defensive: NavView_SelectionChanged can fire during InitializeComponent if
+        // NavigationView's selection-deferral changes in a future WinUI version, or
+        // if anyone re-fires selection synchronously. NavFrame is declared after the
+        // MenuItems in MainWindow.xaml, so we must not dereference it before init
+        // completes. See "XAML init-order bug audit" (May 2026).
+        if (NavFrame is null) return;
         // Top-level nav represents an explicit user choice of section; flush the
         // back stack so "back" doesn't keep cycling through old detail pages.
         NavFrame.Navigate(pageType);

--- a/src/Glasswork.App/Pages/BacklogPage.xaml.cs
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml.cs
@@ -89,14 +89,17 @@ public sealed partial class BacklogPage : Page
     {
         if (ViewModel.ViewMode == "list") return;
         ViewModel.ViewMode = "list";
-        BoardViewToggle.IsChecked = false;
+        // Null-conditional: during InitializeComponent the other toggle may not
+        // exist yet when XAML sets IsChecked="True" on this one. UpdateViewModeUI
+        // syncs both toggles correctly after InitializeComponent completes.
+        if (BoardViewToggle is not null) BoardViewToggle.IsChecked = false;
     }
 
     private void BoardViewToggle_Checked(object sender, RoutedEventArgs e)
     {
         if (ViewModel.ViewMode == "board") return;
         ViewModel.ViewMode = "board";
-        ListViewToggle.IsChecked = false;
+        if (ListViewToggle is not null) ListViewToggle.IsChecked = false;
     }
 
     private void WorkLogLink_Click(object sender, RoutedEventArgs e)

--- a/src/Glasswork.App/Pages/SubtaskDetailDialog.xaml.cs
+++ b/src/Glasswork.App/Pages/SubtaskDetailDialog.xaml.cs
@@ -91,6 +91,13 @@ public sealed partial class SubtaskDetailDialog : ContentDialog
 
     private void UpdateBlockerVisibility()
     {
+        // Defensive: StatusBox.SelectionChanged would fire during InitializeComponent
+        // if anyone added a SelectedIndex= literal to the XAML, and BlockerBox is
+        // declared *after* StatusBox in the markup — it would be null at that point.
+        // No SelectedIndex= today; the constructor calls SetComboByTag(StatusBox, ...)
+        // after InitializeComponent, by which time BlockerBox exists. This guard makes
+        // that ordering invariant explicit. See "XAML init-order bug audit" (May 2026).
+        if (BlockerBox is null) return;
         var tag = (StatusBox.SelectedItem as ComboBoxItem)?.Tag?.ToString();
         BlockerBox.Visibility = tag == "blocked" ? Visibility.Visible : Visibility.Collapsed;
     }


### PR DESCRIPTION
## Background

The Backlog page was crashing the app on navigation when `backlog.viewMode` had been previously persisted as `"board"` in `ui-state.json`. The crash surfaced only as `STOWED_EXCEPTION (0xc000027b)` in WER — no managed stack trace, no exception type — because self-contained WinUI Desktop apps detach from console.

This PR delivers three things:

1. The actual crash fix.
2. A defensive sweep of every other instance of the same bug class.
3. A global unhandled-exception handler so this is the last time we have to guess what threw.

## 1. The crash (BacklogPage)

When `BacklogPage` constructor reads `ViewModel.ViewMode = "board"` from persisted UiState before `InitializeComponent`, XAML parses `ListViewToggle` (declared first) with `IsChecked="True"`. That fires the `Checked` event mid-init. The handler:

```cs
if (ViewModel.ViewMode == "list") return;   // false — ViewMode is "board"
ViewModel.ViewMode = "list";
BoardViewToggle.IsChecked = false;          // <-- BoardViewToggle is null
```

`BoardViewToggle` is declared later in the document and the XAML parser hasn't created it yet. NRE → wrapped as `XamlParseException` → silent crash.

**Fix**: null-conditional guard on the cross-toggle reference in both `ListViewToggle_Checked` and `BoardViewToggle_Checked`. `UpdateViewModeUI()` already syncs both toggles correctly after `InitializeComponent` finishes, so the in-handler write is redundant when the other toggle exists and harmless when it doesn't.

## 2. Defensive sweep

A repo-wide audit (general-purpose subagent prompted with the bug shape) found two MEDIUM-severity latent instances of the same class:

* **`MainWindow.NavigateToTopLevel`**: `NavView_SelectionChanged` is wired in XAML and the first `NavigationViewItem` has `IsSelected="True"`. `NavFrame` is declared *after* the `MenuItems` block. Today this is safe only because WinUI's `NavigationView` defers `SelectionChanged` until after its template is applied — undocumented framework timing. The MainWindow constructor's existing comment ("does not reliably navigate the Frame on first launch — be explicit") shows the team already knows this is fragile. Added `if (NavFrame is null) return;` at the top of `NavigateToTopLevel`.
* **`SubtaskDetailDialog.UpdateBlockerVisibility`**: `StatusBox.SelectionChanged` references `BlockerBox`, declared after `StatusBox`. No `SelectedIndex=` literal today, so the event doesn't fire during init — but adding one would be a one-attribute regression to the same crash class. Added a guard + comment pinning the invariant.

The audit also produced negative confirmations for nine other categories (no risky `ToggleSwitch` / `Slider` / `Pivot` / `RadioButton` / `TextBox.TextChanged` / `ListView.SelectedIndex` / etc.). Findings 5–12 in the audit are LOW (handlers don't cross-reference other named controls or no triggering markup) — left as-is.

## 3. Global unhandled-exception handler

Added `App.UnhandledException` + `AppDomain.CurrentDomain.UnhandledException` + `TaskScheduler.UnobservedTaskException` handlers that append exception details to `%TEMP%\glasswork-unhandled.log`. Without this, self-contained WinUI Desktop crashes are visible only as a STOWED_EXCEPTION code in WER. Future crashes will land a stack trace + exception type in a known location with zero ceremony.

## Verification

* `dotnet build src/Glasswork.App -r win-x64` → 0 errors, 2 pre-existing warnings (`TaskDetailPage.xaml.cs:375` / `:478`, not in scope).
* Manually launched the rebuilt Release binary, navigated to Backlog (which had `viewMode: "board"` persisted, the failing case), toggled List ↔ Board, marked tasks done, opened TaskDetail and SubtaskDetail dialog, switched themes — no crashes, no entries in `glasswork-unhandled.log`.

## Followup

The audit suggests an arch convention worth adopting: **WinUI XAML event handlers must not unconditionally dereference other named XAML elements**. Consider adding this as a one-liner to `CONTEXT.md` or `.github/copilot-instructions.md` so future Ralph slices and human PRs don't reintroduce the pattern. Not in this PR.