### PR TITLE
docs: add XAML init-order rule to architectural hard rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,6 +68,18 @@ this content, it does not own it.
 5. **Any code that writes the vault must register with `SelfWriteCoordinator`**
    or `FileWatcherService` will fire spurious external-change events.
 
+6. **WinUI XAML event handlers must not unconditionally dereference other
+   named XAML elements.** Initial-state attributes (`IsChecked="True"`,
+   `SelectedIndex="0"`, `IsSelected="True"`, `Value=`, `IsOn="True"`, etc.)
+   fire their corresponding `Changed`/`Checked`/`SelectionChanged` events
+   *during* `InitializeComponent`, in document order — sibling controls
+   declared *later* in the XAML are still `null` at that point. A handler
+   that pokes another named control crashes with `XamlParseException`
+   (surfaces in self-contained Release as a silent `STOWED_EXCEPTION
+   0xc000027b`). Either gate cross-references with `if (Other is not null)`
+   / `?.`, or do the cross-control sync in a method called *after*
+   `InitializeComponent`. See PR #153 and the audit it carries.
+
 ## Investigation guidance (for issue triage & root-cause analysis)
 
 When assigned a user-reported issue (label `user-report`):


### PR DESCRIPTION
Adds a sixth rule to the **Architectural hard rules** section of `.github/copilot-instructions.md`:

> **WinUI XAML event handlers must not unconditionally dereference other named XAML elements.** Initial-state attributes (`IsChecked="True"`, `SelectedIndex="0"`, `IsSelected="True"`, `Value=`, `IsOn="True"`, etc.) fire their corresponding `Changed`/`Checked`/`SelectionChanged` events *during* `InitializeComponent`, in document order — sibling controls declared *later* in the XAML are still `null` at that point. A handler that pokes another named control crashes with `XamlParseException` (surfaces in self-contained Release as a silent `STOWED_EXCEPTION 0xc000027b`). Either gate cross-references with `if (Other is not null)` / `?.`, or do the cross-control sync in a method called *after* `InitializeComponent`. See PR #153 and the audit it carries.

## Why this file

`.github/copilot-instructions.md` is read on every Copilot CLI session — including by Ralph workers (the `install.sh` for `ralph-loop-dashboard` appends to it). Putting the rule here means future autonomous slices and human PRs alike see it in their context window when generating WinUI code. CONTEXT.md is for bounded-context architecture; this is a defensive coding convention so it belongs with the other hard rules.

## Verification

Markdown only — no build/test impact.