### PR TITLE
fix: sun icon feedback (#124) + quick agent-command menu on My Day (#152)

### DIFF
--- a/src/Glasswork.App/Converters/MyDayBrushConverter.cs
+++ b/src/Glasswork.App/Converters/MyDayBrushConverter.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.UI;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
+
+namespace Glasswork.Converters;
+
+/// <summary>
+/// Bool → SolidColorBrush converter that highlights the My Day toggle when active.
+/// True returns a sunny gold matching the sun glyph; false returns a muted gray to
+/// indicate the toggle is available but inactive.
+///
+/// Lives in <c>Glasswork.Converters</c> so any Page can declare it as a resource.
+/// Used today by TaskDetailPage subtask suns and Backlog list/board card suns.
+/// </summary>
+public sealed class MyDayBrushConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is bool b && b)
+        {
+            // Active: sunny gold to match the sun glyph.
+            return new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0xC1, 0x07));
+        }
+        return new SolidColorBrush(Color.FromArgb(0x80, 0x80, 0x80, 0x80));
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+        => throw new NotImplementedException();
+}

--- a/src/Glasswork.App/Pages/BacklogPage.xaml
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml
@@ -15,6 +15,7 @@
         <conv:SubtaskSegmentBrushConverter x:Key="SegBrush" />
         <conv:DueUrgencyBrushConverter x:Key="DueBg" />
         <conv:DueUrgencyForegroundBrushConverter x:Key="DueFg" />
+        <conv:MyDayBrushConverter x:Key="MyDayBrush" />
 
         <DataTemplate x:Key="BacklogTaskTemplate">
             <Grid Padding="10,8" RowDefinitions="Auto,Auto"
@@ -51,7 +52,8 @@
                             ToolTipService.ToolTip="Toggle My Day"
                             Background="Transparent" BorderThickness="0"
                             Padding="6,2" VerticalAlignment="Center" Margin="6,0,0,0">
-                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE706;" FontSize="13" />
+                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE706;" FontSize="13"
+                                  Foreground="{Binding IsMyDay, Converter={StaticResource MyDayBrush}}" />
                     </Button>
                     <Button Grid.Column="5" Background="Transparent" BorderThickness="0"
                             Padding="6,2" VerticalAlignment="Center">
@@ -177,7 +179,8 @@
                                 ToolTipService.ToolTip="Toggle My Day"
                                 Background="Transparent" BorderThickness="0"
                                 Padding="4" VerticalAlignment="Center">
-                            <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE706;" FontSize="12" />
+                            <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE706;" FontSize="12"
+                                      Foreground="{Binding IsMyDay, Converter={StaticResource MyDayBrush}}" />
                         </Button>
                     </StackPanel>
 

--- a/src/Glasswork.App/Pages/MyDayPage.xaml
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml
@@ -39,6 +39,16 @@
         <TextBlock x:Name="TodayHeader" Grid.Row="1" Text="Today's tasks"
                    Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,16,0,8" />
 
+        <!-- Clipboard hint: brief feedback when an agent-command line is copied -->
+        <InfoBar x:Name="ClipboardHint"
+                 Grid.Row="1"
+                 IsOpen="False"
+                 IsClosable="True"
+                 Severity="Success"
+                 HorizontalAlignment="Right"
+                 VerticalAlignment="Top"
+                 Margin="0,0,0,8" />
+
         <ListView
             Grid.Row="2"
             x:Name="TodayList"
@@ -64,7 +74,7 @@
                           ContextRequested="TaskRow_ContextRequested"
                           Background="Transparent">
                         <!-- Title row -->
-                        <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto,Auto,Auto">
+                        <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto,Auto,Auto,Auto">
                             <Grid Grid.Column="0" Width="22" Height="22" VerticalAlignment="Center" Margin="0,0,8,0">
                                 <CheckBox VerticalAlignment="Center" HorizontalAlignment="Center"
                                           IsChecked="{Binding IsDone, Mode=OneWay}"
@@ -97,6 +107,31 @@
                                     Padding="6,2" VerticalAlignment="Center" Margin="6,0,0,0"
                                     ToolTipService.ToolTip="Remove from My Day">
                                 <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE711;" FontSize="13" />
+                            </Button>
+                            <!-- More menu: copy agent-command lines without leaving My Day -->
+                            <Button Grid.Column="5" Background="Transparent" BorderThickness="0"
+                                    Padding="6,2" VerticalAlignment="Center"
+                                    ToolTipService.ToolTip="More actions">
+                                <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE712;" FontSize="13" />
+                                <Button.Flyout>
+                                    <MenuFlyout>
+                                        <MenuFlyoutItem Text="Copy 'Start work' command" Click="CopyStartWork_Click">
+                                            <MenuFlyoutItem.Icon>
+                                                <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE768;" />
+                                            </MenuFlyoutItem.Icon>
+                                        </MenuFlyoutItem>
+                                        <MenuFlyoutItem Text="Copy 'Resume' command" Click="CopyResume_Click">
+                                            <MenuFlyoutItem.Icon>
+                                                <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE72C;" />
+                                            </MenuFlyoutItem.Icon>
+                                        </MenuFlyoutItem>
+                                        <MenuFlyoutItem Text="Copy 'Wrap up' command" Click="CopyWrapUp_Click">
+                                            <MenuFlyoutItem.Icon>
+                                                <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE73E;" />
+                                            </MenuFlyoutItem.Icon>
+                                        </MenuFlyoutItem>
+                                    </MenuFlyout>
+                                </Button.Flyout>
                             </Button>
                         </Grid>
 

--- a/src/Glasswork.App/Pages/MyDayPage.xaml.cs
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml.cs
@@ -133,6 +133,43 @@ public sealed partial class MyDayPage : Page
         }
     }
 
+    // Quick-copy agent-command lines from a My Day card without round-tripping through
+    // TaskDetail. The strings come from TaskInvocationFormatter (the canonical source);
+    // this is purely a UX shortcut.
+    private void CopyStartWork_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { DataContext: GlassworkTask task })
+        {
+            CopyToClipboard(Glasswork.Core.Services.TaskInvocationFormatter.FormatStartWork(task.Id), "Start work");
+        }
+    }
+
+    private void CopyResume_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { DataContext: GlassworkTask task })
+        {
+            CopyToClipboard(Glasswork.Core.Services.TaskInvocationFormatter.FormatResume(task.Id), "Resume");
+        }
+    }
+
+    private void CopyWrapUp_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { DataContext: GlassworkTask task })
+        {
+            CopyToClipboard(Glasswork.Core.Services.TaskInvocationFormatter.FormatWrapUp(task.Id), "Wrap up");
+        }
+    }
+
+    private void CopyToClipboard(string text, string label)
+    {
+        var pkg = new Windows.ApplicationModel.DataTransfer.DataPackage();
+        pkg.SetText(text);
+        Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(pkg);
+        ClipboardHint.Title = $"Copied '{label}' command";
+        ClipboardHint.Message = "Paste into your Copilot CLI session.";
+        ClipboardHint.IsOpen = true;
+    }
+
     private void CarryAll_Click(object sender, RoutedEventArgs e)
     {
         ViewModel.CarryAllCommand.Execute(null);

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml
@@ -6,13 +6,14 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="using:Glasswork.Pages"
+    xmlns:conv="using:Glasswork.Converters"
     xmlns:controls="using:Glasswork.Controls"
     mc:Ignorable="d">
 
     <Page.Resources>
         <local:BoolToVisibilityConverter x:Key="BoolToVis" />
         <local:HexToBrushConverter x:Key="HexToBrush" />
-        <local:MyDayBrushConverter x:Key="MyDayBrush" />
+        <conv:MyDayBrushConverter x:Key="MyDayBrush" />
     </Page.Resources>
 
     <ScrollViewer Padding="32">

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -1275,24 +1275,3 @@ public sealed class HexToBrushConverter : IValueConverter
     public object ConvertBack(object value, Type targetType, object parameter, string language)
         => throw new NotImplementedException();
 }
-
-/// <summary>
-/// Bool → SolidColorBrush converter that highlights the My Day toggle when active.
-/// True returns the system accent brush; false returns a muted gray to indicate the
-/// toggle is available but inactive.
-/// </summary>
-public sealed class MyDayBrushConverter : IValueConverter
-{
-    public object Convert(object value, Type targetType, object parameter, string language)
-    {
-        if (value is bool b && b)
-        {
-            // Active: sunny gold to match the sun glyph.
-            return new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0xC1, 0x07));
-        }
-        return new SolidColorBrush(Color.FromArgb(0x80, 0x80, 0x80, 0x80));
-    }
-
-    public object ConvertBack(object value, Type targetType, object parameter, string language)
-        => throw new NotImplementedException();
-}


### PR DESCRIPTION
Closes #124. Closes #152.

Two small UX fixes shipped together since they touch the same Backlog/MyDay surfaces.

## #124 — Sun icon doesn't reflect My Day state on Backlog rows

User report: clicking the sun toggle on a Backlog list-card row writes `my_day` correctly but gives no visual confirmation. The exact same pattern (`MyDayBrushConverter` — sunny gold when active, muted gray when inactive) was already used for TaskDetail subtask suns, but the converter was buried inside `TaskDetailPage.xaml.cs` in the `local:` namespace, so other pages couldn't reach it.

**Fix:**
- Lifted `MyDayBrushConverter` to a new file under `Glasswork.Converters` (alongside `RowConverters`).
- Updated `TaskDetailPage.xaml` to reference it via the `conv:` namespace (existing TaskDetail subtask suns continue to work — regression check passed).
- Added `Foreground` bindings to both Backlog sun buttons: list-card (`BacklogPage.xaml:54`) and the new board-card sun added in PR #149 (`BacklogPage.xaml:180`).

**Note**: My Day card uses a separate "Remove from My Day" X-icon affordance, not a sun toggle, so no change there. Triage on #124 incorrectly flagged 3 sites; only 2 needed the fix.

## #152 — Quick-copy agent-command menu on My Day cards

User report (filed today): copying the start/resume/wrap-up agent-command lines requires drilling into TaskDetail and scrolling past the entire task body. Painful when running an agent loop.

**Fix:**
- Added a `⋯` MenuFlyout button to each My Day card title row, right of the existing X button.
- Three menu items: *Copy 'Start work' command* / *Copy 'Resume' command* / *Copy 'Wrap up' command*, each with an icon.
- Clicking any item copies the appropriate `TaskInvocationFormatter` output to the clipboard.
- Top-right `InfoBar` ("Copied 'X' command — Paste into your Copilot CLI session.") gives perceptible feedback. Mirrors the existing `ClipboardHint` precedent in `TaskDetailPage.xaml.cs:651-655`.

`TaskInvocationFormatter` (`Glasswork.Core.Services`) already produces the canonical strings and is fully unit-tested. No new domain logic was needed; the fix is pure presentation wiring.

## Verification

- `dotnet build src/Glasswork.App -r win-x64` → 0 errors, 2 pre-existing warnings (`TaskDetailPage.xaml.cs:375` / `:478`, out of scope).
- `dotnet test tests/Glasswork.Tests` → **495/496 pass.** The single failure is `DebouncerTests.Trigger_FiresAgainAfterQuietPeriodElapses` — an unrelated flaky timing-based test in a Core utility I didn't touch. Tracked as #155.
- Manually verified in the Release binary:
  - Backlog list view sun toggles between gold and gray on click.
  - Backlog board view: same.
  - TaskDetail subtask suns continue to work (regression check).
  - My Day `⋯` menu items each copy the right line and surface the InfoBar.

## Notes on TDD discipline

Per the repo's TDD convention I noted at the start: there's no testable surface here that doesn't already exist. The converter logic is unchanged (just moved); `TaskInvocationFormatter` already has full coverage. The new code is XAML wiring + thin click handlers that compose existing primitives. WinUI converter unit tests would require pulling `Microsoft.UI.Xaml.Media` into `Glasswork.Tests` — which would break the Linux-buildable invariant on `Glasswork.Core` tests (per `.github/copilot-instructions.md` rule). The honest answer is "manual smoke verification" — that's exactly the territory issue #63 (UI test infrastructure) covers.