### PR TITLE
chore: add scripts/launch-ralph.ps1 + agent-facing docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,6 +43,39 @@ this content, it does not own it.
 - **.NET SDK** — 10.x. Preinstalled in cloud agent via
   `.github/workflows/copilot-setup-steps.yml`.
 
+## Running Ralph (TDD loop) from PowerShell on Windows
+
+Ralph (the autonomous TDD loop in `ralph-loop-dashboard`) drives one issue at
+a time through red→green→refactor and merges the resulting PR. Locally on
+Windows, **always use [`scripts/launch-ralph.ps1`](../scripts/launch-ralph.ps1)
+to start it from any agent context** — including Copilot CLI agents running
+in PowerShell.
+
+```powershell
+pwsh -File scripts\launch-ralph.ps1                  # default: status (read-only)
+pwsh -File scripts\launch-ralph.ps1 -Action Launch   # start the loop detached
+pwsh -File scripts\launch-ralph.ps1 -Action Stop     # stop launcher + active worker
+```
+
+**Why this exists**: `.ralph/launch.sh` background mode crashes Cygwin's fork
+emulation when Git Bash is spawned from a non-Bash parent (PowerShell,
+conhost, `Start-Process`):
+
+```
+bash 1026 dofork: child 1027 - died waiting for dll loading, errno 11
+```
+
+The wrapper sidesteps this by spawning `bash --foreground` via `Start-Process`
+with a hidden window — no fork required. The Windows process is detached, so
+the loop survives the agent session ending. See the script header comment for
+the full rationale.
+
+**When NOT to use it**: if you are typing in a real interactive Git Bash
+window (not a PowerShell-spawned bash), `.ralph/launch.sh` works directly
+and supports `RALPH_PARALLELISM>1`. The wrapper is foreground-only (one
+worker). For real parallelism on Windows, install WSL2 and launch from
+inside Ubuntu.
+
 ## Architectural hard rules
 
 1. **Three-tier task prose model** (ADR 0002):

--- a/scripts/launch-ralph.ps1
+++ b/scripts/launch-ralph.ps1
@@ -1,0 +1,206 @@
+<#
+.SYNOPSIS
+    Launch / monitor / stop the Ralph TDD loop on Windows from PowerShell.
+
+.DESCRIPTION
+    Wraps Ralph's Bash launcher (.ralph\launch.sh) so an agent — including
+    Copilot CLI agents running in a PowerShell session — can drive the loop
+    without hitting the Git-Bash-on-Windows background-mode fork crash.
+
+    The loop's own background mode (`launch.sh` without `--foreground`) uses
+    `nohup ... &`, which crashes Cygwin's fork emulation when Git Bash is
+    spawned from a non-Bash parent (PowerShell, conhost, Start-Process):
+
+        bash 1026 dofork: child 1027 - died waiting for dll loading, errno 11
+
+    The workaround: spawn `bash --foreground` via Start-Process with a hidden
+    window. Bash itself runs the loop attached to its own (hidden) console;
+    no fork is needed; the Windows process is detached and survives this
+    session ending.
+
+    See ADR considerations and PR history for context. This script supersedes
+    the documented `.ralph/launch.sh` invocation on Windows.
+
+.PARAMETER Action
+    One of:
+      Launch  - Pre-flight, then start the loop detached. Writes
+                .ralph\launcher.pid for later -Status / -Stop calls.
+      Status  - Show launcher PID + alive state + recent iteration logs.
+                This is the default (safe / read-only).
+      Stop    - SIGTERM the launcher process and any spawned copilot worker.
+
+.PARAMETER Parallelism
+    Workers to start (Launch only). Defaults to 1. Foreground mode only
+    runs ONE worker; if you pass >1 the script falls back to 1 with a
+    warning. (Native parallelism requires either WSL or fixing the fork
+    crash upstream.)
+
+.EXAMPLE
+    pwsh -File scripts\launch-ralph.ps1
+    # Default: shows status. Safe to run anytime.
+
+.EXAMPLE
+    pwsh -File scripts\launch-ralph.ps1 -Action Launch
+    # Pre-flights and starts the loop in the background. Returns immediately.
+
+.EXAMPLE
+    pwsh -File scripts\launch-ralph.ps1 -Action Stop
+    # Stops the launcher + any active worker.
+#>
+param(
+    [ValidateSet("Launch", "Status", "Stop")]
+    [string]$Action = "Status",
+
+    [int]$Parallelism = 1
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path $PSScriptRoot -Parent
+$RalphDir = Join-Path $RepoRoot ".ralph"
+$LogDir = Join-Path $RalphDir "logs"
+$PidFile = Join-Path $RalphDir "launcher.pid"
+$BashExe = "C:\Program Files\Git\usr\bin\bash.exe"
+
+function Get-LauncherProcess {
+    if (-not (Test-Path $PidFile)) { return $null }
+    $launcherPid = [int]((Get-Content $PidFile -Raw).Trim())
+    return Get-Process -Id $launcherPid -ErrorAction SilentlyContinue
+}
+
+function Show-Status {
+    Write-Host "=== Ralph launcher status ===" -ForegroundColor Cyan
+    $proc = Get-LauncherProcess
+    if ($proc) {
+        $age = [int]((Get-Date) - $proc.StartTime).TotalMinutes
+        Write-Host ("  Launcher PID {0} alive, {1} min old" -f $proc.Id, $age) -ForegroundColor Green
+    } elseif (Test-Path $PidFile) {
+        $stalePid = (Get-Content $PidFile -Raw).Trim()
+        Write-Host ("  Launcher PID {0}: dead (stale pidfile, will be cleared on next Launch)" -f $stalePid) -ForegroundColor Yellow
+    } else {
+        Write-Host "  No launcher running" -ForegroundColor Gray
+    }
+
+    Write-Host ""
+    Write-Host "=== Active issue claims (.ralph\state.json) ===" -ForegroundColor Cyan
+    $stateFile = Join-Path $RalphDir "state.json"
+    if (Test-Path $stateFile) {
+        Get-Content $stateFile -Raw
+    } else {
+        Write-Host "  (no state.json)"
+    }
+
+    Write-Host ""
+    Write-Host "=== 5 most recent iteration logs ===" -ForegroundColor Cyan
+    Get-ChildItem $LogDir -Filter "iter-*.log" -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -First 5 |
+        Select-Object @{n='Modified'; e={$_.LastWriteTime.ToString('HH:mm:ss')}}, @{n='Bytes'; e={$_.Length}}, Name |
+        Format-Table -AutoSize
+}
+
+function Stop-Loop {
+    Write-Host "=== Stopping Ralph loop ===" -ForegroundColor Cyan
+    $proc = Get-LauncherProcess
+    if ($proc) {
+        Write-Host ("  Stopping launcher PID {0}" -f $proc.Id)
+        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+    }
+
+    # Kill any copilot workers spawned in the last 4 hours that are still alive.
+    # Conservative window so we don't murder the user's interactive Copilot CLI.
+    $cutoff = (Get-Date).AddHours(-4)
+    $copilots = Get-Process -Name copilot -ErrorAction SilentlyContinue |
+        Where-Object { $_.StartTime -gt $cutoff -and $_.CPU -gt 60 }
+    foreach ($c in $copilots) {
+        Write-Host ("  Stopping copilot worker PID {0} (CPU {1:N0}s, age {2} min)" -f `
+            $c.Id, $c.CPU, [int]((Get-Date) - $c.StartTime).TotalMinutes)
+        Stop-Process -Id $c.Id -Force -ErrorAction SilentlyContinue
+    }
+
+    if (Test-Path $PidFile) { Remove-Item $PidFile -Force }
+    Write-Host "  Done." -ForegroundColor Green
+}
+
+function Test-PreFlight {
+    Push-Location $RepoRoot
+    try {
+        if (-not (Test-Path $BashExe)) {
+            throw "Git Bash not found at $BashExe. Install Git for Windows."
+        }
+        if (-not (Test-Path (Join-Path $RalphDir "launch.sh"))) {
+            throw ".ralph\launch.sh not found. Re-run ralph-loop-dashboard\install.sh."
+        }
+        $branch = (git branch --show-current).Trim()
+        if ($branch -ne "main") {
+            throw "Must be on main branch (currently on '$branch'). Switch branches before launching."
+        }
+        $dirty = git status --porcelain
+        if ($dirty) {
+            throw "Working tree is not clean. Commit or stash changes first.`n$dirty"
+        }
+        $existing = Get-LauncherProcess
+        if ($existing) {
+            throw ("Launcher PID {0} is already running. Run -Action Stop first." -f $existing.Id)
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+function Start-Loop {
+    Test-PreFlight
+
+    if ($Parallelism -gt 1) {
+        Write-Host "WARNING: --foreground only runs 1 worker. Falling back to Parallelism=1." -ForegroundColor Yellow
+        Write-Host "         To run multiple workers on Windows, install WSL2 and launch from there." -ForegroundColor Yellow
+        $Parallelism = 1
+    }
+
+    if (-not (Test-Path $LogDir)) {
+        New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+    }
+
+    $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $stdoutLog = Join-Path $LogDir "launcher-$timestamp.out"
+    $stderrLog = Join-Path $LogDir "launcher-$timestamp.err"
+
+    # Convert Windows repo path to a /c/... POSIX path Git Bash understands.
+    $posixRepo = "/" + ($RepoRoot -replace '\\', '/' -replace '^([A-Za-z]):', '$1').Replace(':', '').Substring(0,1).ToLower() + ($RepoRoot -replace '\\', '/' -replace '^([A-Za-z]):', '').ToLower().Substring(1)
+
+    # The 'exec' replaces the bash login shell with launch.sh so killing the
+    # launcher kills the loop directly (no orphan parent to track).
+    $bashCmd = "cd '$posixRepo' && exec ./.ralph/launch.sh --foreground"
+
+    Write-Host "=== Launching Ralph (foreground, detached) ===" -ForegroundColor Cyan
+    Write-Host "  Repo:    $RepoRoot"
+    Write-Host "  POSIX:   $posixRepo"
+    Write-Host "  stdout:  $stdoutLog"
+    Write-Host "  stderr:  $stderrLog"
+
+    $proc = Start-Process `
+        -FilePath $BashExe `
+        -ArgumentList @("-lc", $bashCmd) `
+        -WorkingDirectory $RepoRoot `
+        -WindowStyle Hidden `
+        -RedirectStandardOutput $stdoutLog `
+        -RedirectStandardError $stderrLog `
+        -PassThru
+
+    $proc.Id | Set-Content $PidFile
+
+    Write-Host ""
+    Write-Host ("  Launcher PID: {0}" -f $proc.Id) -ForegroundColor Green
+    Write-Host ""
+    Write-Host "Monitor with:" -ForegroundColor Cyan
+    Write-Host "  pwsh -File $PSCommandPath"
+    Write-Host ""
+    Write-Host "Stop with:" -ForegroundColor Cyan
+    Write-Host "  pwsh -File $PSCommandPath -Action Stop"
+}
+
+switch ($Action) {
+    "Launch" { Start-Loop }
+    "Status" { Show-Status }
+    "Stop"   { Stop-Loop }
+}


### PR DESCRIPTION
## Why

The documented Ralph background launch — `.ralph/launch.sh` — crashes Cygwin's fork emulation when Git Bash is spawned from a non-Bash parent (PowerShell, conhost, `Start-Process`):

```
bash 1026 dofork: child 1027 - died waiting for dll loading, errno 11
```

Reproduced twice in this repo: once when first launching the kanban PRD loop, once when launching the structured-links PRD with `RALPH_PARALLELISM=2`. Both crashes left dead worker processes and orphaned worktrees that had to be manually cleaned up.

The blast radius is broader than my own usage: any future Copilot CLI agent (or human running a quick PowerShell command) hits the same trap and has no in-repo guidance on how to avoid it.

## What

`scripts/launch-ralph.ps1` — a PowerShell wrapper with three actions:

| Action | Behavior |
|---|---|
| `Status` (default, read-only) | Prints launcher PID, current claims from `.ralph/state.json`, last 5 iter logs. Safe to run anytime. Works even when the loop was started by some other mechanism (e.g. an interactive Git Bash window). |
| `Launch` | Pre-flights (clean tree / on main / no existing launcher), then spawns `bash --foreground` via `Start-Process -WindowStyle Hidden`. Captures PID to `.ralph/launcher.pid` for tracking. Returns immediately. |
| `Stop` | Terminates the launcher and any copilot worker process recently spawned by it. |

The trick: `bash --foreground` doesn't fork — it just runs `ralph.sh` in-process — so the Cygwin fork failure never happens. `Start-Process -WindowStyle Hidden` detaches the bash process at the Windows-process level, so the loop survives this session ending. `RedirectStandardOutput`/`-Error` keep the launcher's stdout/stderr in `.ralph/logs/launcher-<timestamp>.{out,err}` for debugging.

## Limitation

Foreground mode runs one worker only. For real parallelism on Windows, the documented WSL2 path remains the answer. The wrapper is the "I just need it to work from PowerShell" answer, not a replacement for WSL.

## Doc updates

Added a "Running Ralph (TDD loop) from PowerShell on Windows" section to `.github/copilot-instructions.md` so future agent sessions see the wrapper in their context window when reading the canonical file. Includes the **why**, the three commands, and the explicit "use Git Bash directly if you have it open" carve-out.

## Verification

* `pwsh -File scripts\launch-ralph.ps1` — tested against the currently-running structured-links loop (started by hand from an interactive Git Bash window earlier today, mid-flight on #126). Correctly read `state.json`, identified the active worker claim, listed the freshly-opened iter log file. **No interference** with the running loop.
* `Launch` and `Stop` paths will be exercised the next time the loop is needed; deferred to avoid disturbing the in-progress run.
* Pre-flight rejects: dirty tree, wrong branch, missing `.ralph/launch.sh`, missing Git Bash, existing launcher PID.

## Followup (not in this PR)

The underlying fork crash is a real portability bug in `ralph-loop-dashboard` that affects every Windows user. Worth filing upstream once we have a clean repro independent of Glasswork. This PR is the local mitigation.