### PR TITLE
fix(launcher): correct POSIX path conversion for Git Bash invocation

### DIFF
--- a/scripts/launch-ralph.ps1
+++ b/scripts/launch-ralph.ps1
@@ -166,7 +166,10 @@ function Start-Loop {
     $stderrLog = Join-Path $LogDir "launcher-$timestamp.err"
 
     # Convert Windows repo path to a /c/... POSIX path Git Bash understands.
-    $posixRepo = "/" + ($RepoRoot -replace '\\', '/' -replace '^([A-Za-z]):', '$1').Replace(':', '').Substring(0,1).ToLower() + ($RepoRoot -replace '\\', '/' -replace '^([A-Za-z]):', '').ToLower().Substring(1)
+    # Example: "C:\Users\toegbeji\Repos\Glasswork" -> "/c/Users/toegbeji/Repos/Glasswork"
+    $drive = $RepoRoot.Substring(0, 1).ToLower()
+    $rest = $RepoRoot.Substring(2) -replace '\\', '/'
+    $posixRepo = "/$drive$rest"
 
     # The 'exec' replaces the bash login shell with launch.sh so killing the
     # launcher kills the loop directly (no orphan parent to track).


### PR DESCRIPTION
## Bug

`scripts\launch-ralph.ps1 -Action Launch` died silently. The launcher PID was captured into `.ralph\launcher.pid` but the bash subprocess exited immediately because the converted POSIX path was wrong:

```
Repo:    C:\Users\toegbeji\Repos\Glasswork
POSIX:   /cusers/toegbeji/repos/glasswork    <-- broken
```

The chained `-replace` expression I wrote yesterday lost the leading `/c/` separator and lower-cased everything after the drive. Bash then `cd`-ed to a path that didn't exist and the loop never started. No errors surfaced because Start-Process detached too fast for stdout/stderr to land in the redirect files.

## Fix

Replaced the over-clever one-liner with three obvious steps + a worked example in a comment:

```powershell
# "C:\Users\toegbeji\Repos\Glasswork" -> "/c/Users/toegbeji/Repos/Glasswork"
$drive = $RepoRoot.Substring(0, 1).ToLower()
$rest = $RepoRoot.Substring(2) -replace '\\', '/'
$posixRepo = "/$drive$rest"
```

## Verification

* Tested the conversion in isolation via `pwsh -NoProfile -Command` — produces `/c/Users/toegbeji/Repos/Glasswork` as expected.
* The `Status` action (default, read-only) was already working correctly because it doesn't use the POSIX conversion.
* Full `Launch` path will be exercised immediately after this merges; loop is currently dead and three structured-links slices (#127, #128, #129) are still open.

## Followup

cygpath would have been a cleaner conversion mechanism but it's not on the default Git Bash PATH on this machine when invoked via `bash -c`. Left a note in the script header for future-me / future agents.