### PR TITLE
fix(launcher): use System.Diagnostics.Process for stable detach

### DIFF
--- a/scripts/launch-ralph.ps1
+++ b/scripts/launch-ralph.ps1
@@ -171,9 +171,12 @@ function Start-Loop {
     $rest = $RepoRoot.Substring(2) -replace '\\', '/'
     $posixRepo = "/$drive$rest"
 
-    # The 'exec' replaces the bash login shell with launch.sh so killing the
-    # launcher kills the loop directly (no orphan parent to track).
-    $bashCmd = "cd '$posixRepo' && exec ./.ralph/launch.sh --foreground"
+    # Output is captured via shell redirection inside bash (relative paths, since
+    # we cd into the repo first). This avoids the .NET RedirectStandardOutput/Error
+    # properties, which (on this machine, in this combo) caused the spawned bash to
+    # exit immediately with no error output. The 'exec' replaces the bash login
+    # shell with launch.sh so killing the launcher kills the loop directly.
+    $bashCmd = "cd '$posixRepo' && exec ./.ralph/launch.sh --foreground > .ralph/logs/launcher-$timestamp.out 2> .ralph/logs/launcher-$timestamp.err"
 
     Write-Host "=== Launching Ralph (foreground, detached) ===" -ForegroundColor Cyan
     Write-Host "  Repo:    $RepoRoot"
@@ -181,15 +184,20 @@ function Start-Loop {
     Write-Host "  stdout:  $stdoutLog"
     Write-Host "  stderr:  $stderrLog"
 
-    $proc = Start-Process `
-        -FilePath $BashExe `
-        -ArgumentList @("-lc", $bashCmd) `
-        -WorkingDirectory $RepoRoot `
-        -WindowStyle Hidden `
-        -RedirectStandardOutput $stdoutLog `
-        -RedirectStandardError $stderrLog `
-        -PassThru
+    # Use System.Diagnostics.Process directly. Start-Process with -WindowStyle Hidden
+    # + -RedirectStandardOutput/-Error reliably FAILED on this machine: the spawned
+    # bash exited immediately, redirect files stayed 0 bytes, no error surfaced.
+    # The .NET ProcessStartInfo path with UseShellExecute=false + CreateNoWindow=true
+    # launches detached, survives the spawning PowerShell session ending, and is the
+    # canonical Windows pattern for "spawn console process with no window".
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $BashExe
+    $psi.Arguments = "-lc `"$bashCmd`""
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow = $true
+    $psi.WorkingDirectory = $RepoRoot
 
+    $proc = [System.Diagnostics.Process]::Start($psi)
     $proc.Id | Set-Content $PidFile
 
     Write-Host ""


### PR DESCRIPTION
## Bug

`scripts\launch-ralph.ps1 -Action Launch` was spawning a bash that exited within seconds. The launcher PID was captured but the loop never started; redirect files stayed 0 bytes; no error surfaced. After PR #159 fixed the POSIX path conversion, the bash was definitely receiving a valid command — it just wouldn't stay alive when launched via `Start-Process`.

## Why Start-Process failed (best guess)

`Start-Process -WindowStyle Hidden -RedirectStandardOutput X -RedirectStandardError Y` produces an unstable process on this Windows + Git Bash combo. The PowerShell docs note that `RedirectStandardOutput` requires `UseShellExecute=false` internally, which conflicts with `WindowStyle=Hidden` (a UseShellExecute-true feature). Whatever Start-Process does to reconcile that, the resulting bash process exits before producing any output. I couldn't get a stable repro of the underlying race, but the symptom is reliable.

## Fix

Use `System.Diagnostics.Process` directly:

```powershell
$psi = New-Object System.Diagnostics.ProcessStartInfo
$psi.FileName = $BashExe
$psi.Arguments = "-lc `"$bashCmd`""
$psi.UseShellExecute = $false
$psi.CreateNoWindow = $true
$psi.WorkingDirectory = $RepoRoot
$proc = [System.Diagnostics.Process]::Start($psi)
```

This is the canonical Windows pattern for "spawn a console process with no window." Output capture moves into the bash command itself via shell redirection (`> ... 2> ...`), since the .NET `RedirectStandardOutput`/`Error` properties seem to be the actual irritant.

## Verification

Tested by hand right before opening this PR — spawned via the new pattern, launcher PID stayed alive, worker claimed #127, iter log started growing. **The structured-links PRD loop is currently running on this exact mechanism**, working through Slice 2 (TaskLink model + parser). Expect it to continue through #128 and #129 over the next few hours.

The Status and Stop paths weren't touched and continue to work against the new launcher.pid format (which is the same — just an integer PID).

## Side note for future agents

The wrapper docs in `.github/copilot-instructions.md` (added in PR #158) don't need updating — they already say "use the wrapper, not `bash launch.sh` directly", which is now actually true again.