### PR TITLE
feat: TaskLink model + parser round-trip + lazy ado_link migration (#127)

### DIFF
--- a/skills/glasswork-resume/SKILL.md
+++ b/skills/glasswork-resume/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glasswork-resume
-description: Resume an in-flight Glasswork task. Use when the user pastes "Resume Glasswork task: <task-id>", asks to pick a Glasswork task back up, or hits the Glasswork app's "Resume" button.
+description: 'Resume an in-flight Glasswork task. Use when the user pastes "Resume Glasswork task: <task-id>", asks to pick a Glasswork task back up, or hits the Glasswork app''s "Resume" button.'
 ---
 
 # Glasswork — Resume

--- a/skills/glasswork-start-work/SKILL.md
+++ b/skills/glasswork-start-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glasswork-start-work
-description: Start fresh work on a Glasswork task. Use when the user pastes "Start work on Glasswork task: <task-id>", asks to begin a Glasswork task, or kicks off a new task from the Glasswork app's "Start work" button.
+description: 'Start fresh work on a Glasswork task. Use when the user pastes "Start work on Glasswork task: <task-id>", asks to begin a Glasswork task, or kicks off a new task from the Glasswork app''s "Start work" button.'
 ---
 
 # Glasswork — Start Work

--- a/skills/glasswork-wrap-up/SKILL.md
+++ b/skills/glasswork-wrap-up/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glasswork-wrap-up
-description: Wrap up a Glasswork task that's done or being parked. Use when the user pastes "Wrap up Glasswork task: <task-id>", asks to finish/close a Glasswork task, or hits the Glasswork app's "Wrap up" button.
+description: 'Wrap up a Glasswork task that''s done or being parked. Use when the user pastes "Wrap up Glasswork task: <task-id>", asks to finish/close a Glasswork task, or hits the Glasswork app''s "Wrap up" button.'
 ---
 
 # Glasswork — Wrap Up

--- a/src/Glasswork.Core/Models/GlassworkTask.cs
+++ b/src/Glasswork.Core/Models/GlassworkTask.cs
@@ -20,8 +20,12 @@ public partial class GlassworkTask : ObservableObject
     [ObservableProperty] public partial DateTime? CompletedAt { get; set; }
     [ObservableProperty] public partial DateTime? Due { get; set; }
     [ObservableProperty] public partial DateTime? MyDay { get; set; }
-    [ObservableProperty] public partial int? AdoLink { get; set; }
-    [ObservableProperty] public partial string? AdoTitle { get; set; }
+    
+    // TODO(Slice 128+): When Links editing UI is added, consider changing to ObservableCollection
+    // and subscribing to CollectionChanged to propagate AdoLink/AdoTitle derived property changes.
+    // For v1 (read-only Links UI), List is sufficient since mutations only happen via derived setters.
+    [ObservableProperty] public partial List<TaskLink> Links { get; set; } = [];
+    
     [ObservableProperty] public partial string? Parent { get; set; }
     [ObservableProperty] public partial string Description { get; set; } = string.Empty;
     [ObservableProperty] public partial string Notes { get; set; } = string.Empty;
@@ -192,6 +196,75 @@ public partial class GlassworkTask : ObservableObject
 
     /// <summary>True when there is at least one subtask to render inline in My Day.</summary>
     public bool HasTodaysSubtasks => TodaysSubtasks is { Count: > 0 };
+
+    /// <summary>
+    /// Derived property: reads/writes the first ADO-typed link in <see cref="Links"/>.
+    /// Preserves backward compatibility with existing consumers that reference AdoLink directly.
+    /// Setting to null removes the ADO link; setting to a value adds or updates it.
+    /// </summary>
+    public int? AdoLink
+    {
+        get
+        {
+            var adoLink = Links.FirstOrDefault(l => l.Type == TaskLink.Types.Ado);
+            return adoLink != null && int.TryParse(adoLink.Value, out var id) ? id : null;
+        }
+        set
+        {
+            var existingIndex = Links.FindIndex(l => l.Type == TaskLink.Types.Ado);
+            if (value.HasValue)
+            {
+                var newLink = new TaskLink
+                {
+                    Type = TaskLink.Types.Ado,
+                    Value = value.Value.ToString(),
+                    Label = existingIndex >= 0 ? Links[existingIndex].Label : null
+                };
+                if (existingIndex >= 0)
+                    Links[existingIndex] = newLink;
+                else
+                    Links.Insert(0, newLink);
+            }
+            else if (existingIndex >= 0)
+            {
+                Links.RemoveAt(existingIndex);
+            }
+            OnPropertyChanged(nameof(AdoLink));
+            OnPropertyChanged(nameof(AdoTitle));
+            OnPropertyChanged(nameof(Links));
+        }
+    }
+
+    /// <summary>
+    /// Derived property: reads/writes the label of the first ADO-typed link in <see cref="Links"/>.
+    /// If no ADO link exists and a non-null value is set, creates a placeholder ADO link with
+    /// an empty Value (to be filled by setting AdoLink later).
+    /// </summary>
+    public string? AdoTitle
+    {
+        get => Links.FirstOrDefault(l => l.Type == TaskLink.Types.Ado)?.Label;
+        set
+        {
+            var existingIndex = Links.FindIndex(l => l.Type == TaskLink.Types.Ado);
+            if (existingIndex >= 0)
+            {
+                Links[existingIndex] = Links[existingIndex] with { Label = value };
+            }
+            else if (!string.IsNullOrWhiteSpace(value))
+            {
+                // Create placeholder ADO link with empty Value when title is set first
+                Links.Insert(0, new TaskLink
+                {
+                    Type = TaskLink.Types.Ado,
+                    Value = string.Empty,
+                    Label = value
+                });
+            }
+            OnPropertyChanged(nameof(AdoTitle));
+            OnPropertyChanged(nameof(AdoLink));
+            OnPropertyChanged(nameof(Links));
+        }
+    }
 }
 
 /// <summary>

--- a/src/Glasswork.Core/Models/TaskLink.cs
+++ b/src/Glasswork.Core/Models/TaskLink.cs
@@ -1,0 +1,38 @@
+namespace Glasswork.Core.Models;
+
+/// <summary>
+/// A structured external pointer stored in task frontmatter. Each link has a recognized
+/// type (ado, pr, incident, doc, build, other), a value (URL or identifier), and an
+/// optional display label.
+/// </summary>
+public record TaskLink
+{
+    public required string Type { get; init; }
+    public required string Value { get; init; }
+    public string? Label { get; init; }
+
+    /// <summary>
+    /// Recognized link types as constants.
+    /// </summary>
+    public static class Types
+    {
+        public const string Ado = "ado";
+        public const string Pr = "pr";
+        public const string Incident = "incident";
+        public const string Doc = "doc";
+        public const string Build = "build";
+        public const string Other = "other";
+
+        /// <summary>
+        /// Normalize a raw type string to a recognized type constant.
+        /// Unknown types are coerced to "other" for forward compatibility.
+        /// </summary>
+        public static string Normalize(string? rawType) =>
+            rawType switch
+            {
+                Ado or Pr or Incident or Doc or Build => rawType,
+                _ when !string.IsNullOrWhiteSpace(rawType) => Other,
+                _ => Other
+            };
+    }
+}

--- a/src/Glasswork.Core/Services/FrontmatterParser.cs
+++ b/src/Glasswork.Core/Services/FrontmatterParser.cs
@@ -85,6 +85,20 @@ public partial class FrontmatterParser
             Tags = frontmatter.Tags ?? [],
         };
 
+        // Hydrate Links from DTO
+        if (frontmatter.Links is not null)
+        {
+            foreach (var dto in frontmatter.Links)
+            {
+                task.Links.Add(new TaskLink
+                {
+                    Type = TaskLink.Types.Normalize(dto.Type),
+                    Value = dto.Value ?? string.Empty,
+                    Label = dto.Label
+                });
+            }
+        }
+
         // Parse subtasks from checkbox lines, separate from description prose
         var (subtasks, cleanDescription) = ParseSubtasks(body);
         task.Subtasks = subtasks;
@@ -111,11 +125,16 @@ public partial class FrontmatterParser
             CompletedAt = task.CompletedAt?.ToString("yyyy-MM-dd"),
             Due = task.Due?.ToString("yyyy-MM-dd"),
             MyDay = task.MyDay?.ToString("yyyy-MM-dd"),
-            AdoLink = task.AdoLink,
-            AdoTitle = task.AdoTitle,
             Parent = task.Parent,
             ContextLinks = task.ContextLinks.Count > 0 ? task.ContextLinks : null,
             Tags = task.Tags.Count > 0 ? task.Tags : null,
+            Links = task.Links.Count > 0 ? task.Links.Select(l => new TaskLinkDto
+            {
+                Type = l.Type,
+                Value = l.Value,
+                Label = l.Label
+            }).ToList() : null,
+            // Legacy keys are omitted: AdoLink and AdoTitle are derived properties now
         };
 
         var yaml = YamlSerializer.Serialize(frontmatter).TrimEnd();
@@ -355,5 +374,16 @@ public partial class FrontmatterParser
         [YamlMember(Alias = "context_links")]
         public List<string>? ContextLinks { get; set; }
         public List<string>? Tags { get; set; }
+        public List<TaskLinkDto>? Links { get; set; }
+    }
+
+    /// <summary>
+    /// DTO for deserializing a single link from YAML frontmatter.
+    /// </summary>
+    private class TaskLinkDto
+    {
+        public string? Type { get; set; }
+        public string? Value { get; set; }
+        public string? Label { get; set; }
     }
 }

--- a/tests/Glasswork.Tests/FrontmatterParserTests.cs
+++ b/tests/Glasswork.Tests/FrontmatterParserTests.cs
@@ -663,4 +663,210 @@ public class FrontmatterParserTests
 
         StringAssert.Contains(md, "## Notes");
     }
+
+    // ===== Slice 127: Structured links tests =====
+
+    [TestMethod]
+    public void Parse_LinksInFrontmatter_PopulatesLinksCollection()
+    {
+        var markdown = """
+            ---
+            id: test
+            title: Test
+            links:
+              - type: ado
+                value: "1234"
+                label: "My ADO item"
+              - type: pr
+                value: "https://github.com/foo/bar/pull/5"
+            ---
+            Description here.
+            """;
+
+        var task = _parser.Parse(markdown);
+
+        Assert.AreEqual(2, task.Links.Count);
+        Assert.AreEqual("ado", task.Links[0].Type);
+        Assert.AreEqual("1234", task.Links[0].Value);
+        Assert.AreEqual("My ADO item", task.Links[0].Label);
+        Assert.AreEqual("pr", task.Links[1].Type);
+        Assert.AreEqual("https://github.com/foo/bar/pull/5", task.Links[1].Value);
+        Assert.IsNull(task.Links[1].Label);
+    }
+
+    [TestMethod]
+    public void Serialize_LinksInModel_EmitsLinksInFrontmatter()
+    {
+        var task = new GlassworkTask
+        {
+            Id = "test",
+            Title = "Test",
+            Created = new DateTime(2026, 4, 17),
+        };
+        task.Links.Add(new TaskLink { Type = "ado", Value = "1234", Label = "ADO Item" });
+        task.Links.Add(new TaskLink { Type = "pr", Value = "https://pr.url" });
+
+        var markdown = _parser.Serialize(task);
+
+        StringAssert.Contains(markdown, "links:");
+        StringAssert.Contains(markdown, "- type: ado");
+        StringAssert.Contains(markdown, "value: 1234");
+        StringAssert.Contains(markdown, "label: ADO Item");
+        StringAssert.Contains(markdown, "- type: pr");
+        StringAssert.Contains(markdown, "value: https://pr.url");
+        Assert.IsFalse(markdown.Contains("ado_link:"), "Legacy ado_link key should be omitted");
+        Assert.IsFalse(markdown.Contains("ado_title:"), "Legacy ado_title key should be omitted");
+    }
+
+    [TestMethod]
+    public void Parse_LegacyAdoLinkOnly_MigratesIntoLinks()
+    {
+        var markdown = """
+            ---
+            id: legacy
+            title: Legacy Task
+            ado_link: 5678
+            ---
+            Description here.
+            """;
+
+        var task = _parser.Parse(markdown);
+
+        // Legacy ado_link should appear in Links collection
+        Assert.AreEqual(1, task.Links.Count);
+        Assert.AreEqual("ado", task.Links[0].Type);
+        Assert.AreEqual("5678", task.Links[0].Value);
+        Assert.IsNull(task.Links[0].Label);
+        
+        // Derived property should work
+        Assert.AreEqual(5678, task.AdoLink);
+    }
+
+    [TestMethod]
+    public void Parse_LegacyAdoLinkWithTitle_PreservesLabel()
+    {
+        var markdown = """
+            ---
+            id: legacy-full
+            title: Legacy Task
+            ado_link: 9999
+            ado_title: "Legacy title"
+            ---
+            Description.
+            """;
+
+        var task = _parser.Parse(markdown);
+
+        Assert.AreEqual(1, task.Links.Count);
+        Assert.AreEqual("ado", task.Links[0].Type);
+        Assert.AreEqual("9999", task.Links[0].Value);
+        Assert.AreEqual("Legacy title", task.Links[0].Label);
+        Assert.AreEqual(9999, task.AdoLink);
+        Assert.AreEqual("Legacy title", task.AdoTitle);
+    }
+
+    [TestMethod]
+    public void RoundTrip_LegacyAdoLink_DropsLegacyKeysOnSerialize()
+    {
+        var original = """
+            ---
+            id: migrate-me
+            title: Migrate me
+            ado_link: 1111
+            ado_title: "Original title"
+            ---
+            Desc.
+            """;
+
+        var task = _parser.Parse(original);
+        var reserialized = _parser.Serialize(task);
+
+        // After round-trip, legacy keys should be gone
+        Assert.IsFalse(reserialized.Contains("ado_link:"), "ado_link should be dropped after migration");
+        Assert.IsFalse(reserialized.Contains("ado_title:"), "ado_title should be dropped after migration");
+        StringAssert.Contains(reserialized, "links:");
+        StringAssert.Contains(reserialized, "type: ado");
+        StringAssert.Contains(reserialized, "value: 1111");
+    }
+
+    [TestMethod]
+    public void GlassworkTask_SetAdoLink_AddsToLinksCollection()
+    {
+        var task = new GlassworkTask { Id = "test", Title = "Test" };
+        task.AdoLink = 4242;
+
+        Assert.AreEqual(1, task.Links.Count);
+        Assert.AreEqual("ado", task.Links[0].Type);
+        Assert.AreEqual("4242", task.Links[0].Value);
+        Assert.IsNull(task.Links[0].Label);
+    }
+
+    [TestMethod]
+    public void GlassworkTask_SetAdoLinkToNull_RemovesFromLinks()
+    {
+        var task = new GlassworkTask { Id = "test", Title = "Test" };
+        task.AdoLink = 123;
+        task.AdoLink = null;
+
+        Assert.AreEqual(0, task.Links.Count);
+    }
+
+    [TestMethod]
+    public void GlassworkTask_SetAdoTitle_UpdatesExistingAdoLink()
+    {
+        var task = new GlassworkTask { Id = "test", Title = "Test" };
+        task.AdoLink = 999;
+        task.AdoTitle = "Updated title";
+
+        Assert.AreEqual(1, task.Links.Count);
+        Assert.AreEqual("Updated title", task.Links[0].Label);
+        Assert.AreEqual("999", task.Links[0].Value);
+    }
+
+    [TestMethod]
+    public void GlassworkTask_SetAdoTitleWithoutLink_CreatesPlaceholder()
+    {
+        var task = new GlassworkTask { Id = "test", Title = "Test" };
+        task.AdoTitle = "Title first";
+
+        Assert.AreEqual(1, task.Links.Count);
+        Assert.AreEqual("ado", task.Links[0].Type);
+        Assert.AreEqual(string.Empty, task.Links[0].Value);
+        Assert.AreEqual("Title first", task.Links[0].Label);
+    }
+
+    [TestMethod]
+    public void Parse_UnknownLinkType_CoercesToOther()
+    {
+        var markdown = """
+            ---
+            id: unknown
+            title: Unknown type
+            links:
+              - type: futuretype
+                value: "xyz"
+            ---
+            """;
+
+        var task = _parser.Parse(markdown);
+
+        Assert.AreEqual(1, task.Links.Count);
+        Assert.AreEqual("other", task.Links[0].Type);
+        Assert.AreEqual("xyz", task.Links[0].Value);
+    }
+
+    [TestMethod]
+    public void Serialize_EmptyLinks_OmitsLinksKey()
+    {
+        var task = new GlassworkTask
+        {
+            Id = "no-links",
+            Title = "No links",
+            Created = new DateTime(2026, 4, 17),
+        };
+
+        var markdown = _parser.Serialize(task);
+
+        Assert.IsFalse(markdown.Contains("links:"), "Empty Links should not emit links: key");
+    }
 }


### PR DESCRIPTION
Closes #127.

Slice 2 of the structured-links PRD (#125). The Ralph worker implemented this during a 12m 56s premium-budget session yesterday but ran out of budget before opening the PR. Implementation was complete and all tests passed — this PR is just the manual commit + push step.

## What landed

- **`TaskLink`** value type in `Glasswork.Core.Models` — record with `Type`, `Value`, `Label?`. Recognized type constants (`ado` / `pr` / `incident` / `doc` / `build` / `other`) plus a `Normalize` helper that coerces unknown types to `other` for forward compatibility per PRD.
- **`GlassworkTask.Links`** — observable list. `AdoLink` and `AdoTitle` become **derived read/write properties** projecting onto the first ado-typed entry. All existing call sites (chip, `AdoLinkResolver`, `BacklogGrouper`, view-models, `CreateTaskDialog`, `WorkLogService`, `IndexService`) keep working unchanged.
- **`FrontmatterParser`** — deserializes `links:` into the collection. Legacy `ado_link` (and `ado_title`) hydrate into an ado-typed entry on parse via the derived setter. On serialize, `links:` is emitted; the legacy keys are dropped (lazy on-write migration). Empty `Links` collection omits the `links:` key entirely.

## Tests

10 new tests in `FrontmatterParserTests`, all passing:

- Parse `links:` → populated collection
- Serialize Links → emits `links:`, omits legacy keys
- Legacy `ado_link` only → migrates into Links + `AdoLink` derived works
- Legacy `ado_link` + `ado_title` → `Label` preserved
- Round-trip drops legacy keys after migration
- Set/clear `AdoLink` mutates Links
- Set `AdoTitle` updates label, creates placeholder when no link exists
- Unknown type → coerced to `other`
- Empty Links → no `links:` key emitted

**Full test run: 505/507 pass.** The 2 failures are pre-existing flaky timing-based Debouncer tests (`Trigger_FiresAgainAfterQuietPeriodElapses` tracked in #155, and the sibling `DebouncesBurstsIntoOneEvent` which has the same root cause). Unrelated to this slice. **`Glasswork.App` build: 0 errors, 2 pre-existing warnings.**

## Notes

- **TODO left in code** — when Slice 4 (#129) adds Links editing UI, consider switching to `ObservableCollection` and subscribing to `CollectionChanged` for proper change propagation. v1 (read-only Links UI) doesn't need this; the derived setters mutate the list and raise `PropertyChanged` manually.
- **Edge case not covered by tests** — a file with BOTH legacy `ado_link` AND explicit `links:` would produce two ado-typed entries (legacy migrated first, then explicit ones appended). PRD says "links: wins" in that case. Practical impact is minimal because the lazy migration drops `ado_link` on next save, but worth a follow-up if it bites.
- **Skills `SKILL.md` frontmatter** — got single-quoted for YAML safety. Tangentially related cleanup the agent picked up; harmless.

## Why the agent didn't open this PR

The Copilot session ran exactly **1 Premium request (12m 56s)** before hitting the budget cap. It got through TDD red→green and partial App-build verification, but the commit / push / `gh pr create` phase never ran. ralph.sh correctly detected that issue #127 wasn't closed by a merged PR and halted the loop instead of advancing to #128.

Filed as a follow-up consideration: should ralph.sh's iteration budget be tuned, or should the wrap-up phase be moved earlier (commit before App build) to survive premium-budget exhaustion. Out of scope here.