### PR TITLE
feat: LinkUriPolicy deep module with per-type URI generation (#128)

### DIFF
--- a/src/Glasswork.Core/Services/LinkUriPolicy.cs
+++ b/src/Glasswork.Core/Services/LinkUriPolicy.cs
@@ -80,7 +80,7 @@ public static class LinkUriPolicy
         {
             var trimmedBase = adoBaseUrl.Trim().TrimEnd('/');
             if (trimmedBase.Length == 0) return null;
-            var url = $"{trimmedBase}/_git//pullrequest/{trimmed}";
+            var url = $"{trimmedBase}/_git/pullrequest/{trimmed}";
             return Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri : null;
         }
 
@@ -100,7 +100,8 @@ public static class LinkUriPolicy
         }
 
         // Extract incident number from "ICM 123456" or bare "123456"
-        var match = Regex.Match(trimmed, @"(?:ICM\s+)?(\d+)", RegexOptions.IgnoreCase);
+        // Anchor to require entire string matches pattern (not just substring)
+        var match = Regex.Match(trimmed, @"^(?:ICM\s+)?(\d+)$", RegexOptions.IgnoreCase);
         if (match.Success && match.Groups[1].Success)
         {
             var incidentId = match.Groups[1].Value;

--- a/src/Glasswork.Core/Services/LinkUriPolicy.cs
+++ b/src/Glasswork.Core/Services/LinkUriPolicy.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Text.RegularExpressions;
+using Glasswork.Core.Models;
+
+namespace Glasswork.Core.Services;
+
+/// <summary>
+/// Deep module that owns "given a TaskLink, where do I navigate."
+/// Returns null for malformed entries. Adding a future link type = one localized branch + tests.
+/// </summary>
+public static class LinkUriPolicy
+{
+    public static Uri? Resolve(TaskLink link, string? adoBaseUrl)
+    {
+        if (link is null) return null;
+
+        switch (link.Type)
+        {
+            case TaskLink.Types.Ado:
+                return ResolveAdo(link.Value, adoBaseUrl);
+            case TaskLink.Types.Pr:
+                return ResolvePr(link.Value, adoBaseUrl);
+            case TaskLink.Types.Incident:
+                return ResolveIncident(link.Value);
+            case TaskLink.Types.Doc:
+            case TaskLink.Types.Build:
+            case TaskLink.Types.Other:
+                return ResolveUrl(link.Value);
+            default:
+                // Unknown types treated as "other" - URL pass-through
+                return ResolveUrl(link.Value);
+        }
+    }
+
+    public static string DisplayText(TaskLink link)
+    {
+        if (link is null) return string.Empty;
+        if (!string.IsNullOrWhiteSpace(link.Label)) return link.Label;
+
+        return link.Type switch
+        {
+            TaskLink.Types.Ado => $"ADO #{link.Value}",
+            TaskLink.Types.Incident => FormatIncidentDisplay(link.Value),
+            TaskLink.Types.Pr => FormatPrDisplay(link.Value),
+            TaskLink.Types.Doc => FormatHostDisplay(link.Value, "Doc"),
+            TaskLink.Types.Build => FormatHostDisplay(link.Value, "Build"),
+            TaskLink.Types.Other => FormatHostDisplay(link.Value, null),
+            _ => FormatHostDisplay(link.Value, null)
+        };
+    }
+
+    // ── Type-specific resolution ────────────────────────────────────────────
+
+    private static Uri? ResolveAdo(string? value, string? adoBaseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        if (string.IsNullOrWhiteSpace(adoBaseUrl)) return null;
+
+        var trimmedBase = adoBaseUrl.Trim().TrimEnd('/');
+        if (trimmedBase.Length == 0) return null;
+
+        var url = $"{trimmedBase}/_workitems/edit/{value.Trim()}";
+        return Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri : null;
+    }
+
+    private static Uri? ResolvePr(string? value, string? adoBaseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        var trimmed = value.Trim();
+
+        // If it's a URL, pass through
+        if (trimmed.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            return Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) ? uri : null;
+        }
+
+        // If it's an integer and we have ADO base URL, build ADO PR URL
+        if (IsAllDigits(trimmed) && !string.IsNullOrWhiteSpace(adoBaseUrl))
+        {
+            var trimmedBase = adoBaseUrl.Trim().TrimEnd('/');
+            if (trimmedBase.Length == 0) return null;
+            var url = $"{trimmedBase}/_git//pullrequest/{trimmed}";
+            return Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri : null;
+        }
+
+        return null;
+    }
+
+    private static Uri? ResolveIncident(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        var trimmed = value.Trim();
+
+        // If it's a URL, pass through
+        if (trimmed.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            return Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) ? uri : null;
+        }
+
+        // Extract incident number from "ICM 123456" or bare "123456"
+        var match = Regex.Match(trimmed, @"(?:ICM\s+)?(\d+)", RegexOptions.IgnoreCase);
+        if (match.Success && match.Groups[1].Success)
+        {
+            var incidentId = match.Groups[1].Value;
+            var url = $"https://portal.microsofticm.com/imp/v5/incidents/details/{incidentId}/home";
+            return Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri : null;
+        }
+
+        return null;
+    }
+
+    private static Uri? ResolveUrl(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        var trimmed = value.Trim();
+
+        if (trimmed.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            return Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) ? uri : null;
+        }
+
+        return null;
+    }
+
+    // ── Display text formatting ─────────────────────────────────────────────
+
+    private static string FormatIncidentDisplay(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+        var trimmed = value.Trim();
+
+        // If already has ICM prefix, return as-is
+        if (trimmed.StartsWith("ICM ", StringComparison.OrdinalIgnoreCase))
+        {
+            return trimmed;
+        }
+
+        // If it's a bare number, add ICM prefix
+        if (IsAllDigits(trimmed))
+        {
+            return $"ICM {trimmed}";
+        }
+
+        // Otherwise (e.g., URL), return as-is
+        return trimmed;
+    }
+
+    private static string FormatPrDisplay(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+        var trimmed = value.Trim();
+
+        // If it's a number, format as "PR #123"
+        if (IsAllDigits(trimmed))
+        {
+            return $"PR #{trimmed}";
+        }
+
+        // If it's a URL, extract host
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+        {
+            return $"PR ({uri.Host})";
+        }
+
+        return trimmed;
+    }
+
+    private static string FormatHostDisplay(string? value, string? typeLabel)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+        var trimmed = value.Trim();
+
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+        {
+            return typeLabel is null
+                ? uri.Host
+                : $"{typeLabel} ({uri.Host})";
+        }
+
+        return trimmed;
+    }
+
+    // ── Utilities ───────────────────────────────────────────────────────────
+
+    private static bool IsAllDigits(string s)
+    {
+        if (s.Length == 0) return false;
+        foreach (var c in s)
+        {
+            if (c < '0' || c > '9') return false;
+        }
+        return true;
+    }
+}

--- a/tests/Glasswork.Tests/LinkUriPolicyEdgeCaseTests.cs
+++ b/tests/Glasswork.Tests/LinkUriPolicyEdgeCaseTests.cs
@@ -1,0 +1,84 @@
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class LinkUriPolicyEdgeCaseTests
+{
+    [TestMethod]
+    public void IncidentType_TextWithEmbeddedDigits_ShouldNotExtractId()
+    {
+        // This tests whether "foo123bar" incorrectly extracts "123" as an incident ID
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Incident,
+            Value = "foo123bar"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+
+        // Expected: null (not a valid incident format)
+        // Actual: might incorrectly build URL with "123"
+        Console.WriteLine($"Result: {(result != null ? result.ToString() : "null")}");
+        if (result != null)
+        {
+            Assert.Fail($"Expected null for 'foo123bar', but got: {result}");
+        }
+    }
+
+    [TestMethod]
+    public void IncidentType_IcmWithTrailingText_ShouldNotExtractId()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Incident,
+            Value = "ICM 123 with extra text"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+        Console.WriteLine($"Result: {(result != null ? result.ToString() : "null")}");
+        
+        // This should be null since it's not a clean ICM ID
+        if (result != null)
+        {
+            Assert.Fail($"Expected null for 'ICM 123 with extra text', but got: {result}");
+        }
+    }
+
+    [TestMethod]
+    public void PrType_IntegerValue_WithAdoBaseUrl_ChecksForDoubleSlash()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Pr,
+            Value = "456"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, "https://dev.azure.com/org/proj");
+        
+        Assert.IsNotNull(result);
+        var url = result.ToString();
+        Console.WriteLine($"Generated URL: {url}");
+        
+        // Check if URL contains double slashes (bug)
+        if (url.Contains("//pullrequest"))
+        {
+            Assert.Fail($"URL contains double slash: {url}");
+        }
+    }
+
+    [TestMethod]
+    public void Resolve_NullLink_ReturnsNull()
+    {
+        var result = LinkUriPolicy.Resolve(null, "https://base.com");
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void DisplayText_NullLink_ReturnsEmptyString()
+    {
+        var result = LinkUriPolicy.DisplayText(null);
+        Assert.AreEqual(string.Empty, result);
+    }
+}

--- a/tests/Glasswork.Tests/LinkUriPolicyTests.cs
+++ b/tests/Glasswork.Tests/LinkUriPolicyTests.cs
@@ -1,0 +1,315 @@
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class LinkUriPolicyTests
+{
+    // ── ADO type ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void AdoType_NumericValue_WithBaseUrl_BuildsWorkItemUrl()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Ado,
+            Value = "12345"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, "https://dev.azure.com/myorg/myproj");
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("https://dev.azure.com/myorg/myproj/_workitems/edit/12345", result.ToString());
+    }
+
+    [TestMethod]
+    public void AdoType_WithoutBaseUrl_ReturnsNull()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Ado,
+            Value = "12345"
+        };
+
+        Assert.IsNull(LinkUriPolicy.Resolve(link, null));
+        Assert.IsNull(LinkUriPolicy.Resolve(link, ""));
+        Assert.IsNull(LinkUriPolicy.Resolve(link, "   "));
+    }
+
+    // ── PR type ───────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void PrType_UrlValue_PassesThrough()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Pr,
+            Value = "https://github.com/owner/repo/pull/123"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("https://github.com/owner/repo/pull/123", result.ToString());
+    }
+
+    [TestMethod]
+    public void PrType_IntegerValue_WithAdoBaseUrl_BuildsAdoPrUrl()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Pr,
+            Value = "456"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, "https://dev.azure.com/myorg/myproj");
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("https://dev.azure.com/myorg/myproj/_git//pullrequest/456", result.ToString());
+    }
+
+    [TestMethod]
+    public void PrType_IntegerValue_WithoutAdoBaseUrl_ReturnsNull()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Pr,
+            Value = "456"
+        };
+
+        Assert.IsNull(LinkUriPolicy.Resolve(link, null));
+    }
+
+    // ── Incident type ─────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void IncidentType_IcmPrefix_BuildsIcmPortalUrl()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Incident,
+            Value = "ICM 965114"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("https://portal.microsofticm.com/imp/v5/incidents/details/965114/home", result.ToString());
+    }
+
+    [TestMethod]
+    public void IncidentType_BareInteger_BuildsIcmPortalUrl()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Incident,
+            Value = "965114"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("https://portal.microsofticm.com/imp/v5/incidents/details/965114/home", result.ToString());
+    }
+
+    [TestMethod]
+    public void IncidentType_UrlValue_PassesThrough()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Incident,
+            Value = "https://portal.microsofticm.com/imp/v5/incidents/details/12345/home"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("https://portal.microsofticm.com/imp/v5/incidents/details/12345/home", result.ToString());
+    }
+
+    // ── Doc/Build/Other types ─────────────────────────────────────────────────
+
+    [TestMethod]
+    public void DocType_ValidUrl_PassesThrough()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Doc,
+            Value = "https://eng.ms/docs/products/arm"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("https://eng.ms/docs/products/arm", result.ToString());
+    }
+
+    [TestMethod]
+    public void BuildType_ValidUrl_PassesThrough()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Build,
+            Value = "https://dev.azure.com/org/proj/_build/results?buildId=123"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("https://dev.azure.com/org/proj/_build/results?buildId=123", result.ToString());
+    }
+
+    [TestMethod]
+    public void OtherType_ValidUrl_PassesThrough()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Other,
+            Value = "https://example.com/resource"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("https://example.com/resource", result.ToString());
+    }
+
+    [TestMethod]
+    public void DocType_InvalidUrl_ReturnsNull()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Doc,
+            Value = "not a url"
+        };
+
+        Assert.IsNull(LinkUriPolicy.Resolve(link, null));
+    }
+
+    // ── Unknown type ──────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void UnknownType_ValidUrl_TreatedAsOther()
+    {
+        var link = new TaskLink
+        {
+            Type = "future-type",
+            Value = "https://example.com/future"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("https://example.com/future", result.ToString());
+    }
+
+    // ── DisplayText ───────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void DisplayText_WithLabel_ReturnsLabel()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Ado,
+            Value = "12345",
+            Label = "My custom label"
+        };
+
+        Assert.AreEqual("My custom label", LinkUriPolicy.DisplayText(link));
+    }
+
+    [TestMethod]
+    public void DisplayText_AdoType_NoLabel_ReturnsFormattedText()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Ado,
+            Value = "12345"
+        };
+
+        Assert.AreEqual("ADO #12345", LinkUriPolicy.DisplayText(link));
+    }
+
+    [TestMethod]
+    public void DisplayText_IncidentType_NoLabel_ReturnsFormattedText()
+    {
+        var link1 = new TaskLink
+        {
+            Type = TaskLink.Types.Incident,
+            Value = "ICM 965114"
+        };
+        var link2 = new TaskLink
+        {
+            Type = TaskLink.Types.Incident,
+            Value = "965114"
+        };
+
+        Assert.AreEqual("ICM 965114", LinkUriPolicy.DisplayText(link1));
+        Assert.AreEqual("ICM 965114", LinkUriPolicy.DisplayText(link2));
+    }
+
+    [TestMethod]
+    public void DisplayText_PrType_Url_ReturnsHostLabel()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Pr,
+            Value = "https://github.com/owner/repo/pull/123"
+        };
+
+        var result = LinkUriPolicy.DisplayText(link);
+        Assert.IsTrue(result.Contains("github.com"), $"Expected host in display text, got: {result}");
+    }
+
+    [TestMethod]
+    public void DisplayText_PrType_Integer_ReturnsFormattedText()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Pr,
+            Value = "456"
+        };
+
+        Assert.AreEqual("PR #456", LinkUriPolicy.DisplayText(link));
+    }
+
+    [TestMethod]
+    public void DisplayText_DocType_ReturnsHostLabel()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Doc,
+            Value = "https://eng.ms/docs/products/arm"
+        };
+
+        var result = LinkUriPolicy.DisplayText(link);
+        Assert.IsTrue(result.Contains("eng.ms"), $"Expected host in display text, got: {result}");
+    }
+
+    [TestMethod]
+    public void DisplayText_BuildType_ReturnsHostLabel()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Build,
+            Value = "https://dev.azure.com/org/proj/_build/results?buildId=123"
+        };
+
+        var result = LinkUriPolicy.DisplayText(link);
+        Assert.IsTrue(result.Contains("dev.azure.com"), $"Expected host in display text, got: {result}");
+    }
+
+    [TestMethod]
+    public void DisplayText_OtherType_ReturnsHostOrValue()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Other,
+            Value = "https://example.com/resource"
+        };
+
+        var result = LinkUriPolicy.DisplayText(link);
+        Assert.IsTrue(result.Contains("example.com"), $"Expected host in display text, got: {result}");
+    }
+}

--- a/tests/Glasswork.Tests/LinkUriPolicyTests.cs
+++ b/tests/Glasswork.Tests/LinkUriPolicyTests.cs
@@ -66,7 +66,7 @@ public class LinkUriPolicyTests
         var result = LinkUriPolicy.Resolve(link, "https://dev.azure.com/myorg/myproj");
 
         Assert.IsNotNull(result);
-        Assert.AreEqual("https://dev.azure.com/myorg/myproj/_git//pullrequest/456", result.ToString());
+        Assert.AreEqual("https://dev.azure.com/myorg/myproj/_git/pullrequest/456", result.ToString());
     }
 
     [TestMethod]
@@ -229,6 +229,34 @@ public class LinkUriPolicyTests
         };
 
         Assert.AreEqual("ADO #12345", LinkUriPolicy.DisplayText(link));
+    }
+
+    [TestMethod]
+    public void Resolve_IncidentType_EmbeddedDigits_ReturnsNull()
+    {
+        // Regex should reject "foo123bar" - digits must be standalone
+        var link = new TaskLink { Type = TaskLink.Types.Incident, Value = "foo123bar" };
+        var result = LinkUriPolicy.Resolve(link, null);
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void Resolve_IncidentType_DigitsWithExtraText_ReturnsNull()
+    {
+        // Regex should reject "ICM 123 with extra" - no trailing text allowed
+        var link = new TaskLink { Type = TaskLink.Types.Incident, Value = "ICM 123 with extra" };
+        var result = LinkUriPolicy.Resolve(link, null);
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void Resolve_PrType_Integer_NoDoubleSlash()
+    {
+        // Verify ADO PR URL doesn't have double slash after _git
+        var link = new TaskLink { Type = TaskLink.Types.Pr, Value = "456" };
+        var result = LinkUriPolicy.Resolve(link, "https://dev.azure.com/org/proj");
+        Assert.IsNotNull(result);
+        Assert.AreEqual("https://dev.azure.com/org/proj/_git/pullrequest/456", result.ToString());
     }
 
     [TestMethod]

--- a/tests/Glasswork.Tests/LinkUriPolicyTypeCoercionTests.cs
+++ b/tests/Glasswork.Tests/LinkUriPolicyTypeCoercionTests.cs
@@ -1,0 +1,73 @@
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class LinkUriPolicyTypeCoercionTests
+{
+    [TestMethod]
+    public void UnknownType_NonUrlValue_ReturnsNull()
+    {
+        var link = new TaskLink
+        {
+            Type = "future-unknown-type",
+            Value = "not a url"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+        Assert.IsNull(result, "Unknown type with non-URL value should return null (treated as 'other')");
+    }
+
+    [TestMethod]
+    public void UnknownType_EmptyValue_ReturnsNull()
+    {
+        var link = new TaskLink
+        {
+            Type = "future-unknown-type",
+            Value = ""
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void UnknownType_WhitespaceValue_ReturnsNull()
+    {
+        var link = new TaskLink
+        {
+            Type = "future-unknown-type",
+            Value = "   "
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void DisplayText_UnknownType_ValidUrl_ShowsHost()
+    {
+        var link = new TaskLink
+        {
+            Type = "future-unknown-type",
+            Value = "https://example.com/path"
+        };
+
+        var display = LinkUriPolicy.DisplayText(link);
+        Assert.IsTrue(display.Contains("example.com"), $"Unknown type should show host, got: {display}");
+    }
+
+    [TestMethod]
+    public void DisplayText_UnknownType_NonUrl_ShowsValue()
+    {
+        var link = new TaskLink
+        {
+            Type = "future-unknown-type",
+            Value = "some identifier"
+        };
+
+        var display = LinkUriPolicy.DisplayText(link);
+        Assert.AreEqual("some identifier", display);
+    }
+}

--- a/tests/Glasswork.Tests/LinkUriPolicyUriSafetyTests.cs
+++ b/tests/Glasswork.Tests/LinkUriPolicyUriSafetyTests.cs
@@ -1,0 +1,73 @@
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class LinkUriPolicyUriSafetyTests
+{
+    [TestMethod]
+    public void ResolveUrl_MalformedUrl_ReturnsNull()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Other,
+            Value = "ht!tp://not a valid url"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+        Assert.IsNull(result, "Malformed URL should return null");
+    }
+
+    [TestMethod]
+    public void ResolvePr_MalformedUrl_ReturnsNull()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Pr,
+            Value = "http://[invalid"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+        Assert.IsNull(result, "Malformed PR URL should return null");
+    }
+
+    [TestMethod]
+    public void ResolveIncident_MalformedUrl_ReturnsNull()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Incident,
+            Value = "http://[::1"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, null);
+        Assert.IsNull(result, "Malformed incident URL should return null");
+    }
+
+    [TestMethod]
+    public void ResolveAdo_MalformedBaseUrl_ReturnsNull()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Ado,
+            Value = "12345"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, "not a url at all!");
+        Assert.IsNull(result, "Malformed ADO base URL should return null");
+    }
+
+    [TestMethod]
+    public void ResolvePr_MalformedAdoBaseUrl_ReturnsNull()
+    {
+        var link = new TaskLink
+        {
+            Type = TaskLink.Types.Pr,
+            Value = "456"
+        };
+
+        var result = LinkUriPolicy.Resolve(link, "ht!tp://broken");
+        Assert.IsNull(result, "Malformed ADO base URL for PR should return null");
+    }
+}


### PR DESCRIPTION
# Slice 3: LinkUriPolicy deep module + per-type URI generation

Closes #128

## Summary

Implements `LinkUriPolicy` - a deep module that owns "given a TaskLink, where do I navigate." All per-type URI construction and display text formatting is localized in this single static class. Adding a future link type requires only a new branch in the switch + tests, with no UI or parser changes.

## Changes

**New module**:
- `Glasswork.Core.Services.LinkUriPolicy`
  - `Resolve(TaskLink, string? adoBaseUrl)` → `Uri?`
  - `DisplayText(TaskLink)` → `string`

**Per-type resolution logic**:
- **ADO**: Builds `https://dev.azure.com/{org}/_workitems/edit/{id}` from base URL (mirrors `AdoLinkResolver` pattern)
- **PR**: URL pass-through OR builds ADO PR URL for integers when ADO base configured
- **Incident**: Extracts IcM ID from "ICM 965114" or "965114" → builds IcM portal URL; URL pass-through for full URLs
- **Doc/build/other**: URL pass-through with `http(s)://` validation
- **Unknown types**: Treated as `other` (forward-compatible)
- **Malformed**: Returns `null` (no throw)

**Display text rules**:
- Label if non-empty
- ADO → `"ADO #{value}"`
- Incident → `"ICM {value}"` (normalizes prefix)
- PR → `"PR #{value}"` for integers, `"PR ({host})"` for URLs
- Doc/build → `"{Type} ({host})"`
- Other/unknown → host or value

**Tests**:
- 24 tests in `LinkUriPolicyTests.cs` + 3 new edge-case test files
- Happy path + malformed input for each recognized type
- Display text formatting for all patterns
- Unknown type coercion
- Null safety
- Regex anchoring validation
- URL construction correctness

## Validation

- ✅ Core build: `dotnet build src/Glasswork.Core/Glasswork.Core.csproj -nologo`
- ✅ Tests: 536 passed (excluded 2 known flaky timing tests)
- ✅ No UI/parser/model changes per acceptance criteria

## Decisions

**ADO base URL sourcing**: Passed as parameter (not injected) to keep the class static like `AdoLinkResolver`. Caller is responsible for reading `App.UiState.Get<string>(App.AdoBaseUrlKey)`.

**Regex for IcM**: Used `Regex.Match` to extract incident ID from "ICM 123456" format. Pattern is simple (`^(?:ICM\s+)?(\d+)$`) with anchors to require full-string match (no embedded digits).

**URL validation**: Used `Uri.TryCreate` for all URL pass-through paths. Returns `null` for non-parseable inputs rather than throwing.

## Review notes

**Dual-model code review** (GPT-5.5 + Claude Opus 4.7):

**Claude Opus**: No significant issues. Noted comprehensive test coverage with minor gaps (null parameters, whitespace-only values, case sensitivity) that are handled correctly by implementation but lack explicit tests.

**GPT-5.5**: Found 3 critical bugs - all fixed in second commit:
1. ✅ **Fixed**: Regex pattern allowed embedded digits (`"foo123bar"` → valid). Added anchors `^...$` to require full-string match.
2. ✅ **Fixed**: ADO PR URL had double slash (`/_git//pullrequest/`). Removed extra slash.
3. ✅ **Fixed**: Test coverage gaps. Added 3 edge-case tests + 2 new test files (TypeCoercion, UriSafety, EdgeCase).

All findings addressed. No remaining issues.