### PR TITLE
fix(workflows): fail loudly when COPILOT_ASSIGN_TOKEN is missing or rejected

### DIFF
--- a/.github/workflows/triage-user-reports.yml
+++ b/.github/workflows/triage-user-reports.yml
@@ -34,15 +34,30 @@ jobs:
           GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           ISSUE: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
-        # Best-effort: if the token is missing or lacks permission, we still post
-        # the triage comment below so a human can assign manually.
+        # Fails loudly when the token is missing OR rejected (e.g. expired PAT) so
+        # token-rotation problems show up as a red workflow run instead of a warning
+        # that gets swept under the rug. Other failures (transient network, GH outage)
+        # still fall through with a warning so the triage comment posts anyway.
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::warning::COPILOT_ASSIGN_TOKEN secret not set; skipping auto-assignment."
-            exit 0
+            echo "::error::COPILOT_ASSIGN_TOKEN secret not set. Triage will be posted but"
+            echo "::error::Copilot will NOT auto-start without an assignee. Set the secret to a PAT"
+            echo "::error::with repo:write scope (the default GITHUB_TOKEN cannot assign copilot-swe-agent)."
+            exit 1
           fi
-          gh issue edit "$ISSUE" --repo "$REPO" --add-assignee copilot-swe-agent || \
-            echo "::warning::Could not assign Copilot automatically; triage comment will still be posted."
+          set +e
+          out=$(gh issue edit "$ISSUE" --repo "$REPO" --add-assignee copilot-swe-agent 2>&1)
+          rc=$?
+          set -e
+          echo "$out"
+          if [ $rc -ne 0 ]; then
+            if echo "$out" | grep -qiE "401|bad credentials|unauthorized|expired"; then
+              echo "::error::COPILOT_ASSIGN_TOKEN appears to be invalid or expired."
+              echo "::error::Rotate the PAT and re-run failed user-report triages by removing+re-adding the 'user-report' label."
+              exit 1
+            fi
+            echo "::warning::Could not assign Copilot automatically (non-auth failure); triage comment will still be posted."
+          fi
 
       - name: Request triage
         env:


### PR DESCRIPTION
## Symptom

User-report issues posted today (#161, #165, #166) got the `@copilot` comment from the triage workflow but **no actual triage** ever happened. The workflow showed all-green in the Actions tab.

## Root cause

`gh issue edit --add-assignee copilot-swe-agent` returned `HTTP 401: Bad credentials` — the `COPILOT_ASSIGN_TOKEN` PAT has expired (or otherwise been invalidated). The workflow swallowed it as a soft warning and continued to post the triage comment.

But a `@copilot` mention without an assignee **does not start a coding-agent session** (per the existing comment on lines 32-33 of the workflow itself). So issues end up with a hopeful-looking comment and no triage activity, and the failure mode is only discoverable by reading workflow logs.

## Fix

Three behavior changes:

1. **Missing token** (`COPILOT_ASSIGN_TOKEN` not set): was `warning + exit 0`. Now `error + exit 1`. Workflow goes red; triage comment is NOT posted.
2. **Auth failures** (401, bad credentials, unauthorized, expired): now `error + exit 1`. Same rationale.
3. **Non-auth failures** (transient network, GitHub outage, etc.): still pass through with a warning so the triage comment posts and a human can manually assign. These are recoverable; auth isn't.

Error messages tell the operator exactly what to do — rotate the PAT, then remove + re-add the `user-report` label to retrigger.

## Why fail-NOT-post

The previous design rationale was "post the comment so a human can assign manually." In practice this never happened — the issue just sat there with a confusing comment. Better to surface "your triage automation is broken" as a red Actions tab and 0 comments than to leave a phantom-active issue.

## Verification

- YAML parses (`python -c "import yaml; yaml.safe_load(...)"` — clean).
- Existing `if: github.event.label.name == 'user-report'` guard preserved.
- Will be exercised the next time a user-report issue is filed (after the PAT is rotated). I'll re-trigger triage on #161, #165, #166 by remove+re-add of the `user-report` label once you've rotated.

## Followup

This PR doesn't fix the root cause (expired PAT) — that requires you to rotate at github.com/settings/tokens and `gh secret set COPILOT_ASSIGN_TOKEN`. Once that's done I can re-trigger triage on the three stuck issues.