### PR TITLE
chore: stop auto-assigning Copilot for user-report triage

### DIFF
--- a/.github/workflows/triage-user-reports.yml
+++ b/.github/workflows/triage-user-reports.yml
@@ -1,17 +1,14 @@
-name: Auto-triage user reports
+name: Notify on user reports
 
 # Fires when the 'user-report' label is applied to an issue (typically by the
-# in-app feedback dialog, which tags every issue it files). Assigns the Copilot
-# coding agent to investigate and posts a structured triage prompt.
+# in-app feedback dialog, which tags every issue it files). Posts a structured
+# triage hint comment for whoever picks the issue up next.
 #
-# The prompt asks Copilot to flesh the issue out (root cause, ADR links, TDD
-# fix plan, acceptance criteria) but explicitly forbids opening a PR or pushing
-# a branch. The agent appends the triage to the issue body below a
-# <!-- triage:begin --> marker, leaving the user's original report intact
-# above it, so the spec lives in the body where ralph-loop sessions can find
-# it without scrolling through comments. Mirrors the local triage-issue skill
-# so issues filed from the feedback dialog reach the same shape as issues
-# triaged interactively.
+# This used to also auto-assign the Copilot cloud coding agent. That was
+# removed because the cloud agent's default behavior is to open a draft PR
+# (it ignores the "investigation only" prompt), which conflicts with the
+# triage-only design. Triage now runs locally on demand via the local
+# 'triage' skill — assign Copilot manually when you actually want a PR.
 
 on:
   issues:
@@ -25,123 +22,38 @@ jobs:
       issues: write
 
     steps:
-      - name: Assign Copilot
-        env:
-          # Must be a PAT (or GitHub App token) — the default GITHUB_TOKEN cannot
-          # invoke replaceActorsForAssignable for the Copilot bot, so assignment
-          # silently fails and the @copilot mention in the comment alone does NOT
-          # start a coding-agent session. See issue #85 triage history.
-          GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
-          ISSUE: ${{ github.event.issue.number }}
-          REPO: ${{ github.repository }}
-        # Fails loudly when the token is missing OR rejected (e.g. expired PAT) so
-        # token-rotation problems show up as a red workflow run instead of a warning
-        # that gets swept under the rug. Other failures (transient network, GH outage)
-        # still fall through with a warning so the triage comment posts anyway.
-        run: |
-          if [ -z "$GH_TOKEN" ]; then
-            echo "::error::COPILOT_ASSIGN_TOKEN secret not set. Triage will be posted but"
-            echo "::error::Copilot will NOT auto-start without an assignee. Set the secret to a PAT"
-            echo "::error::with repo:write scope (the default GITHUB_TOKEN cannot assign copilot-swe-agent)."
-            exit 1
-          fi
-          set +e
-          out=$(gh issue edit "$ISSUE" --repo "$REPO" --add-assignee copilot-swe-agent 2>&1)
-          rc=$?
-          set -e
-          echo "$out"
-          if [ $rc -ne 0 ]; then
-            if echo "$out" | grep -qiE "401|bad credentials|unauthorized|expired"; then
-              echo "::error::COPILOT_ASSIGN_TOKEN appears to be invalid or expired."
-              echo "::error::Rotate the PAT and re-run failed user-report triages by removing+re-adding the 'user-report' label."
-              exit 1
-            fi
-            echo "::warning::Could not assign Copilot automatically (non-auth failure); triage comment will still be posted."
-          fi
-
-      - name: Request triage
+      - name: Post triage hint comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
           gh issue comment "$ISSUE" --repo "$REPO" --body "$(cat <<'EOF'
-          @copilot This is a user-reported issue filed from the Glasswork in-app feedback dialog. Your job is to **flesh it out into a fully-actionable issue** so a human (or another agent) can pick it up and implement it without having to re-investigate.
+          ## Triage hint
 
-          ## Hard constraints
+          This was filed from the Glasswork in-app feedback dialog. To triage:
+          run the local `triage` skill in your Copilot CLI session pointed at
+          this issue. It will read the canonical references (`.github/copilot-instructions.md`,
+          `CONTEXT.md`, `UBIQUITOUS_LANGUAGE.md`, relevant ADRs), trace the
+          affected code path, and append a `<!-- triage:begin -->` block to
+          the issue body with classification, root-cause analysis, and a TDD
+          fix plan.
 
-          - **Do NOT open a pull request.** Do NOT push a branch. Do NOT modify any files in the repo. This is investigation only.
-          - **Append** your triage to the issue body using the marker scheme below. **Never overwrite or rewrite** the user's original report — it must remain intact, verbatim, above the marker. Do not post the triage as a comment.
-          - Do NOT attempt to build \`Glasswork.App\` — it is WinUI 3 / Windows-only and will not build on the Linux runner. Investigate statically (read code, trace call sites, grep). \`Glasswork.Core\` builds on Linux if you need to exercise domain logic.
+          Hard constraints when triaging:
 
-          ## Process
+          - **Do not open a pull request.** Investigation only.
+          - **Do not modify any files in the repo.** Only update this issue body.
+          - **Do not attempt to build `Glasswork.App`** if you're on a non-Windows
+            runner — it's WinUI 3 and Windows-only. `Glasswork.Core` builds
+            cross-platform.
+          - **Do not overwrite** the user's original report. Append below a
+            `<!-- triage:begin -->` marker.
 
-          1. **Classify** — Bug, Feature Request, or General Feedback. The first line of the issue body (\`**Bug**\`, \`**Feature Request**\`, \`**General Feedback**\`) is the user's stated category; confirm or correct it based on what the report actually describes.
-          2. **Read the canonical references first**, in this order:
-             - \`.github/copilot-instructions.md\` — repo conventions, hard rules, build constraints
-             - \`CONTEXT.md\` — bounded contexts and cross-cutting rules
-             - \`UBIQUITOUS_LANGUAGE.md\` — use these terms exactly
-             - Any ADRs in \`docs/adr/\` that touch the affected subsystem
-          3. **Locate the subsystem and concrete files** involved. Trace the code path end-to-end (entry point → service → vault/UI write).
-          4. **For bugs**: find the **root cause**, not just the symptom. Quote the offending code. Note related code (similar patterns elsewhere, existing tests, recent commits via \`git log\` on the affected files).
-          5. **For feature requests**: identify where it would fit, what scaffolding already exists, and whether any ADR constrains or conflicts with it.
-          6. **Design a TDD fix plan** as a numbered list of RED → GREEN vertical slices (one test + minimal code change per slice). See the template. Tests must assert on **observable behavior** (public APIs, UI state, file contents), not internal structure — so the plan survives refactors. Use MSTest (do not introduce other test frameworks).
-          7. **Suggest labels** from the existing set: \`bug\`, \`feature\`, \`backlinks\`, \`markdown-rendering\`, \`artifacts\`, \`prd\`.
+          Suggested labels from the existing set: `bug`, `feature`, `backlinks`,
+          `markdown-rendering`, `artifacts`, `prd`.
 
-          ## How to update the issue body
-
-          1. Fetch the current body: \`gh issue view <number> --repo <owner/repo> --json body -q .body\`
-          2. If the body already contains the line \`<!-- triage:begin -->\`, **stop** — the issue has already been triaged. Post a short comment instead noting that triage already exists and you didn't re-run it.
-          3. Otherwise, append the following block (literally including the HTML comment markers) to the existing body, separated by a blank line, then write it back with \`gh issue edit <number> --repo <owner/repo> --body-file -\` (or \`--body\`):
-
-          \`\`\`markdown
-
-          ---
-
-          <!-- triage:begin -->
-          <!-- Auto-generated by .github/workflows/triage-user-reports.yml. The content
-               above this marker is the user's original report — do not modify it. -->
-
-          ## Triage
-
-          **Classification:** Bug | Feature Request | General Feedback
-          **Subsystem:** <bounded context from CONTEXT.md>
-          **Suggested labels:** \`label1\`, \`label2\`
-
-          ## Problem
-
-          - **What happens** (actual behavior, restated clearly)
-          - **What should happen** (expected behavior)
-          - **Reproduction** (steps; infer from code if the user didn't give them)
-
-          ## Root Cause Analysis
-
-          Describe the code path involved, why it fails (or why the feature is missing), and any contributing factors. Reference modules and behaviors, not just file paths — the analysis should remain useful after a refactor. File/line references are fine as anchors but should not be the substance of the explanation.
-
-          ## Relevant ADRs
-
-          - \`docs/adr/NNNN-title.md\` — how it constrains this issue (or "none")
-
-          ## TDD Fix Plan
-
-          1. **RED:** Write a test that <describes expected behavior in user-visible terms>.
-             **GREEN:** <Minimal change to make it pass.>
-          2. **RED:** ...
-             **GREEN:** ...
-
-          **REFACTOR:** <any cleanup once all tests pass, or "none">
-
-          ## Acceptance Criteria
-
-          - [ ] <Behavior 1 verifiable from outside>
-          - [ ] <Behavior 2>
-          - [ ] All new tests pass
-          - [ ] Existing tests still pass
-          <!-- triage:end -->
-          \`\`\`
-
-          For **General Feedback** that isn't actionable (a thank-you, a vague impression, etc.), still append the block but only fill in **Classification**, **Subsystem**, **Suggested labels**, and a short **Problem** summary — skip the TDD plan and acceptance criteria, and note whether the issue should be closed.
-
-          After updating the body, post a brief comment (one or two sentences) summarizing the classification and root cause so the update shows up in notifications.
+          When ready for an agent to actually implement the fix, manually
+          assign `copilot-swe-agent` (or run Ralph against a properly-titled
+          `Slice N:` issue) — the workflow no longer does this automatically.
           EOF
           )"


### PR DESCRIPTION
## Why

The Copilot cloud agent's default behavior when assigned to an issue is **to draft a PR** — it doesn't respect the "investigation only" constraint in the `@copilot` prompt comment. Confirmed immediately after the `COPILOT_ASSIGN_TOKEN` rotation: triages on #161, #165, #166 produced draft PRs #168, #169, #170 instead of the `<!-- triage:begin -->` issue-body block the workflow asks for.

The `@copilot` comment mechanism is advisory; the assignment is what dictates action. There's no way to assign the cloud agent and also tell it "don't open a PR" — that's a GitHub product behavior, not something the workflow prompt can override.

## What

Drop the assignment step. The workflow now posts a short triage-hint comment pointing at the local `triage` skill. Local agents (Copilot CLI sessions on this machine) actually respect the prompt because the skill controls their behavior end-to-end, not just the initial mention.

When a human or local agent has triaged the issue and decided it's ready for cloud-agent implementation, they can manually assign `copilot-swe-agent` (or feed it to Ralph via a properly-titled `Slice N:` issue).

## Side benefits

- `COPILOT_ASSIGN_TOKEN` secret is no longer load-bearing for this workflow. It can stay set for other uses or be removed.
- The fail-loudly logic from PR #167 isn't needed for this workflow anymore — token expiry won't break anything triage-related. Removed.
- No more 401 false alarms when the PAT expires.

## What stays the same

- Same `if: github.event.label.name == 'user-report'` trigger condition.
- Same intent: surface a triage-shaped prompt the moment a user-report issue is filed.
- Same suggested labels.
- The user's original report is still preserved verbatim — that's now the operator's responsibility to honor (no agent will overwrite it because no agent is auto-running).

## Verification

`python -c "import yaml; yaml.safe_load(open('.github/workflows/triage-user-reports.yml'))"` — parses clean.

The next time a user-report issue is filed (or one of #161 / #165 / #166 is re-labeled), it'll get the new hint comment, and triage will happen via local skill on demand instead of automatically.