### PR TITLE
Add load_context MCP tool (issue #137)

### DIFF
--- a/src/Glasswork.Mcp/CHANGELOG.md
+++ b/src/Glasswork.Mcp/CHANGELOG.md
@@ -5,6 +5,21 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.4.0] — 2026-05-15
+
+### Added
+
+- **`load_context` tool** (M4, issue #137): single-call replacement for chaining `get_task` + N artifact reads + `list_tasks(parent_id)` + backlink discovery. Returns `{ task, artifacts[], subtasks[], backlinks[] }` for the given `task_id`:
+  - `artifacts[]` — every artifact in the task's `<task-id>.artifacts/` folder, with `filename`, vault-relative `path`, and full `content` body inlined.
+  - `subtasks[]` — every direct child task (and recursively their children to `depth`, default `1`, clamped to `[0, 3]`). Each subtree entry has the same `{ task, artifacts[], subtasks[] }` shape. `depth > 3` is silently clamped, not errored.
+  - `backlinks[]` — every wiki page outside `wiki/todo/` that links to this task via `[[task-id]]`. Reuses `Glasswork.Core.Services.BacklinkIndex` (ADR 0005); no scanner re-implementation. Built per call against the vault root (stateless, ADR 0007 §6). v1 tradeoff: backlinks are root-only — subtree payloads do NOT carry a `backlinks` field, to keep latency and payload size bounded.
+  - Returns the structured `{ "error": "not_found", "message": ... }` shape when `task_id` does not exist; the not-found check runs BEFORE the expensive backlink `Build` to keep misses cheap.
+  - Cycle-safe BFS via a visited-id set, so hand-edited vaults with `a.parent = b ∧ b.parent = a` do not stack-overflow.
+  - Under `GLASSWORK_MCP_TRACE=1`, emits per-phase timings `load_task`, `load_artifacts`, `load_subtasks`, `load_backlinks`.
+- **`GlassworkToolsTests.LoadContext_*`** — MSTest coverage: leaf task, artifact body inlining, depth=1/2/0/clamp-to-3, backlinks via a wiki-concept page, `not_found` short-circuit, cycle safety, subtree shape (artifacts + nested subtasks but no `backlinks` field), and `McpLoggerTests.TraceEnabled_LoadContext_PhasesContainExpectedKeys` for the four phase keys.
+
+---
+
 ## [0.3.0] — 2026-04-25
 
 ### Fixed

--- a/src/Glasswork.Mcp/Glasswork.Mcp.csproj
+++ b/src/Glasswork.Mcp/Glasswork.Mcp.csproj
@@ -8,7 +8,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>glasswork-mcp</ToolCommandName>
     <PackageId>glasswork-mcp</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Description>Glasswork MCP server — typed agent access to an Obsidian-backed task vault.</Description>
     <Authors>Glasswork</Authors>
     <RollForward>LatestMajor</RollForward>

--- a/src/Glasswork.Mcp/Program.cs
+++ b/src/Glasswork.Mcp/Program.cs
@@ -20,7 +20,7 @@ builder.Services
         options.ServerInfo = new Implementation
         {
             Name = "glasswork-mcp",
-            Version = "0.3.0",
+            Version = "0.4.0",
         };
     })
     .WithStdioServerTransport()

--- a/src/Glasswork.Mcp/README.md
+++ b/src/Glasswork.Mcp/README.md
@@ -2,7 +2,7 @@
 
 `glasswork-mcp` is a standalone [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that gives AI agents typed read/write access to a [Glasswork](https://github.com/tjegbejimba/Glasswork) task vault. It communicates over stdio and requires no running Glasswork app instance.
 
-> **v0.3.0 — M3**: `get_task` and `add_artifact` are now implemented. See [Tool reference](#tool-reference) for schemas.
+> **v0.4.0 — M4**: `load_context` is now implemented — one-call full-context fetch for agent handoff. See [Tool reference](#tool-reference) for the schema.
 
 ---
 
@@ -106,6 +106,7 @@ The `command` field must resolve to the `glasswork-mcp` binary on `PATH` (i.e., 
 | `list_tasks` | v0.2.0 | List task summaries |
 | `get_task` | v0.3.0 | Return full task content |
 | `add_artifact` | v0.3.0 | Create a task artifact file |
+| `load_context` | v0.4.0 | One-call full-context fetch: task + artifact bodies + recursive subtasks + backlinks |
 
 ### `add_task`
 
@@ -232,6 +233,122 @@ Re-reads the vault and artifact folder on every call (no cache). The `artifacts`
 | `conflict` | A file with that name already exists — `add_artifact` is create-only in v1 |
 
 Artifacts are stored under `<vault>/<task-id>.artifacts/<filename>`. The write is registered with `SelfWriteCoordinator` so the running Glasswork app does not raise a spurious "external change" banner.
+
+---
+
+### `load_context`
+
+Returns a task's complete context bundle — task content, every artifact's body, all subtasks recursively to `depth`, and all backlinks — in a single call. Built for agent handoffs (e.g. Ralph loop) where chaining `get_task` + N artifact reads + `list_tasks` + backlink discovery is expensive and error-prone.
+
+**Input**
+
+```json
+{
+  "task_id": "string (required) — task ID to load",
+  "depth": "int (optional, default 1) — subtask recursion depth, clamped to [0, 3]"
+}
+```
+
+`depth` semantics: `0` returns no subtasks; `1` (default) returns direct children only; `2`/`3` recurse further. Values `> 3` are silently clamped (no error). Negative values are treated as `0`.
+
+**Output (success)**
+
+```json
+{
+  "task": {
+    "id": "string",
+    "title": "string",
+    "status": "\"todo\" | \"doing\" | \"done\"",
+    "parent_id": "string | null",
+    "description": "string",
+    "notes": "string"
+  },
+  "artifacts": [
+    {
+      "filename": "string — e.g. plan.md",
+      "path": "string — vault-relative, e.g. task-id.artifacts/plan.md",
+      "content": "string — full file body"
+    }
+  ],
+  "subtasks": [
+    {
+      "task": { "id": "...", "title": "...", "...": "same shape as task above" },
+      "artifacts": [ { "filename": "...", "path": "...", "content": "..." } ],
+      "subtasks": [ "...further subtrees to remaining depth..." ]
+    }
+  ],
+  "backlinks": [
+    {
+      "source_path": "string — vault-relative path to the linking page",
+      "source_title": "string — H1 or first non-empty line",
+      "page_type": "\"concept\" | \"decision\" | \"incident\" | \"system\" | \"other\""
+    }
+  ]
+}
+```
+
+**Output (not found)**
+
+```json
+{
+  "error": "not_found",
+  "message": "string"
+}
+```
+
+**Design notes**
+
+- **Backlinks are root-only.** Subtask payloads include their own artifacts and nested subtasks but NOT a `backlinks` field. The backlink scan is the dominant cost; running it per subtree would blow up payload size and latency without clear agent value. Agents that need a subtask's backlinks can issue a follow-up `load_context` rooted at that subtask.
+- **Stateless re-read.** The backlink index is rebuilt per call (ADR 0007 §6). ADR 0005 measures this at well under 2s on a 10k-file vault on cold start.
+- **Cycle-safe.** A visited-set guards the BFS so hand-edited vaults with parent loops do not stack-overflow.
+- **`not_found` short-circuits the backlink build** to avoid the scan cost on misses.
+
+**Example payload**
+
+For task `issue-137-mcp-load-context` with one artifact `plan.md`, one direct child `child-task-a`, and one concept page referencing it:
+
+```json
+{
+  "task": {
+    "id": "issue-137-mcp-load-context",
+    "title": "MCP: load_context tool",
+    "status": "doing",
+    "parent_id": null,
+    "description": "Single-call full-context fetch for agent handoff.",
+    "notes": ""
+  },
+  "artifacts": [
+    {
+      "filename": "plan.md",
+      "path": "issue-137-mcp-load-context.artifacts/plan.md",
+      "content": "# Plan\n\nReuse VaultService, BacklinkIndex..."
+    }
+  ],
+  "subtasks": [
+    {
+      "task": {
+        "id": "child-task-a",
+        "title": "Child A",
+        "status": "todo",
+        "parent_id": "issue-137-mcp-load-context",
+        "description": "",
+        "notes": ""
+      },
+      "artifacts": [],
+      "subtasks": []
+    }
+  ],
+  "backlinks": [
+    {
+      "source_path": "wiki/concepts/agent-handoff.md",
+      "source_title": "Agent Handoff",
+      "page_type": "concept"
+    }
+  ]
+}
+```
+
+Under `GLASSWORK_MCP_TRACE=1`, the log line for a `load_context` call includes per-phase timings: `load_task`, `load_artifacts`, `load_subtasks`, `load_backlinks`.
 
 ---
 

--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -10,8 +10,8 @@ using ModelContextProtocol.Server;
 namespace Glasswork.Mcp.Tools;
 
 /// <summary>
-/// MCP tool implementations for add_task, list_tasks, get_task, and add_artifact (M2/M3).
-/// See ADR 0007 §3 for the tool surface design.
+/// MCP tool implementations for add_task, list_tasks, get_task, add_artifact (M2/M3),
+/// and load_context (M4). See ADR 0007 §3 for the tool surface design.
 /// </summary>
 [McpServerToolType]
 public sealed class GlassworkTools
@@ -19,10 +19,12 @@ public sealed class GlassworkTools
     private readonly VaultService _vault;
     private readonly SelfWriteCoordinator _selfWrites;
     private readonly string _vaultPath;
+    private readonly string _vaultRoot;
     private readonly McpLogger? _logger;
 
     public GlassworkTools(VaultContext vaultContext, McpLogger? logger = null)
     {
+        _vaultRoot = vaultContext.VaultPath;
         _vaultPath = Path.Combine(vaultContext.VaultPath, "wiki", "todo");
         _selfWrites = new SelfWriteCoordinator(_vaultPath);
         _vault = new VaultService(_vaultPath, _selfWrites);
@@ -222,6 +224,164 @@ public sealed class GlassworkTools
         return JsonSerializer.Serialize(new AddArtifactResult(Path: vaultRelative));
     }
 
+    [McpServerTool(Name = "load_context")]
+    [Description("Return a task's complete context bundle: task content + artifact bodies + recursive subtasks (to depth) + backlinks. Single-call replacement for chaining get_task + N artifact reads + list_tasks + backlink discovery. Read-only.")]
+    public string LoadContext(
+        [Description("Task ID to load context for.")] string task_id,
+        [Description("How many subtask levels to recurse (0 = no subtasks, 1 = direct children, default). Clamped to [0, 3]; values > 3 are clamped, not errored.")] int depth = 1)
+    {
+        using var scope = _logger?.BeginCall("load_context");
+        try
+        {
+            var clampedDepth = Math.Max(0, Math.Min(3, depth));
+
+            var safeId = SanitizeId(task_id);
+            if (safeId is null)
+            {
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("not_found", $"Task '{task_id}' not found."));
+            }
+
+            // Phase: load_task — single Load for the root, full LoadAll for the BFS lookup.
+            var taskSw = Stopwatch.StartNew();
+            var rootTask = _vault.Load(safeId);
+            if (rootTask is null)
+            {
+                scope?.RecordPhase("load_task", taskSw.ElapsedMilliseconds);
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("not_found", $"Task '{task_id}' not found."));
+            }
+
+            var all = _vault.LoadAll();
+            var byParent = all
+                .Where(t => !string.IsNullOrEmpty(t.Parent))
+                .GroupBy(t => t.Parent!, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.Ordinal);
+            scope?.RecordPhase("load_task", taskSw.ElapsedMilliseconds);
+
+            // Phase: load_artifacts — for the root only; recursive snapshots load
+            // their own artifacts inside BuildSubtree but the timing here covers
+            // the root's pass which is the single largest contributor in the
+            // common (leaf) case.
+            var artifactsSw = Stopwatch.StartNew();
+            var rootArtifacts = LoadArtifactsWithBodies(safeId);
+            scope?.RecordPhase("load_artifacts", artifactsSw.ElapsedMilliseconds);
+
+            // Phase: load_subtasks — BFS-style recursion bounded by clampedDepth
+            // and a visited set to keep cycles from blowing the stack.
+            var subtasksSw = Stopwatch.StartNew();
+            var visited = new HashSet<string>(StringComparer.Ordinal) { safeId };
+            var subtasks = BuildSubtrees(safeId, clampedDepth, byParent, visited);
+            scope?.RecordPhase("load_subtasks", subtasksSw.ElapsedMilliseconds);
+
+            // Phase: load_backlinks — fresh build per call (ADR 0007 §6 stateless).
+            // Built against the *vault root*, not _vaultPath (which is wiki/todo).
+            var backlinksSw = Stopwatch.StartNew();
+            var backlinkIndex = new BacklinkIndex();
+            backlinkIndex.Build(_vaultRoot);
+            var backlinks = backlinkIndex
+                .GetBacklinks(safeId)
+                .Select(b => new BacklinkInfo(
+                    SourcePath: ToVaultRelative(b.LinkingPagePath),
+                    SourceTitle: b.LinkingPageTitle,
+                    PageType: b.PageType.ToString().ToLowerInvariant()))
+                .ToList();
+            scope?.RecordPhase("load_backlinks", backlinksSw.ElapsedMilliseconds);
+
+            scope?.SetCount("subtask_count", CountSubtree(subtasks));
+            scope?.SetCount("artifact_count", rootArtifacts.Count);
+            scope?.SetCount("backlink_count", backlinks.Count);
+
+            var result = new LoadContextResult(
+                Task: BuildTaskCore(rootTask),
+                Artifacts: rootArtifacts,
+                Subtasks: subtasks,
+                Backlinks: backlinks);
+
+            return JsonSerializer.Serialize(result);
+        }
+        catch
+        {
+            scope?.SetResult("error");
+            throw;
+        }
+    }
+
+    private List<LoadContextSubtree> BuildSubtrees(
+        string parentId,
+        int remainingDepth,
+        Dictionary<string, List<GlassworkTask>> byParent,
+        HashSet<string> visited)
+    {
+        if (remainingDepth <= 0) return new List<LoadContextSubtree>();
+        if (!byParent.TryGetValue(parentId, out var children)) return new List<LoadContextSubtree>();
+
+        var result = new List<LoadContextSubtree>(children.Count);
+        foreach (var child in children.OrderBy(c => c.Created).ThenBy(c => c.Id, StringComparer.Ordinal))
+        {
+            if (!visited.Add(child.Id)) continue; // cycle guard
+
+            var artifacts = LoadArtifactsWithBodies(child.Id);
+            var grandchildren = BuildSubtrees(child.Id, remainingDepth - 1, byParent, visited);
+
+            result.Add(new LoadContextSubtree(
+                Task: BuildTaskCore(child),
+                Artifacts: artifacts,
+                Subtasks: grandchildren));
+        }
+        return result;
+    }
+
+    private List<ArtifactWithBody> LoadArtifactsWithBodies(string safeId)
+    {
+        var artifactFolder = Path.Combine(_vaultPath, safeId + ".artifacts");
+        var artifacts = new List<ArtifactWithBody>();
+        if (!Directory.Exists(artifactFolder)) return artifacts;
+
+        foreach (var file in Directory.EnumerateFiles(artifactFolder, "*.md", SearchOption.TopDirectoryOnly))
+        {
+            var filename = Path.GetFileName(file);
+            var vaultRelative = Path.Combine(safeId + ".artifacts", filename);
+            string content;
+            try { content = File.ReadAllText(file); }
+            catch { content = string.Empty; }
+            artifacts.Add(new ArtifactWithBody(filename, vaultRelative, content));
+        }
+        artifacts.Sort((a, b) => string.Compare(a.Filename, b.Filename, StringComparison.OrdinalIgnoreCase));
+        return artifacts;
+    }
+
+    private TaskCore BuildTaskCore(GlassworkTask task) => new(
+        Id: task.Id,
+        Title: task.Title,
+        Status: MapToExternalStatus(task.Status),
+        ParentId: task.Parent,
+        Description: task.Description,
+        Notes: task.Notes);
+
+    private string ToVaultRelative(string fullPath)
+    {
+        try
+        {
+            return Path.GetRelativePath(_vaultRoot, fullPath);
+        }
+        catch
+        {
+            return fullPath;
+        }
+    }
+
+    private static int CountSubtree(List<LoadContextSubtree> trees)
+    {
+        int n = 0;
+        foreach (var t in trees)
+        {
+            n += 1;
+            n += CountSubtree(t.Subtasks);
+        }
+        return n;
+    }
+
     private static string MapToInternalStatus(string? status) => status switch
     {
         "todo" or null => GlassworkTask.Statuses.Todo,
@@ -280,4 +440,33 @@ public sealed class GlassworkTools
     private sealed record ErrorResult(
         [property: JsonPropertyName("error")] string Error,
         [property: JsonPropertyName("message")] string Message);
+
+    private sealed record TaskCore(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("title")] string Title,
+        [property: JsonPropertyName("status")] string Status,
+        [property: JsonPropertyName("parent_id")] string? ParentId,
+        [property: JsonPropertyName("description")] string Description,
+        [property: JsonPropertyName("notes")] string Notes);
+
+    private sealed record ArtifactWithBody(
+        [property: JsonPropertyName("filename")] string Filename,
+        [property: JsonPropertyName("path")] string Path,
+        [property: JsonPropertyName("content")] string Content);
+
+    private sealed record LoadContextSubtree(
+        [property: JsonPropertyName("task")] TaskCore Task,
+        [property: JsonPropertyName("artifacts")] List<ArtifactWithBody> Artifacts,
+        [property: JsonPropertyName("subtasks")] List<LoadContextSubtree> Subtasks);
+
+    private sealed record BacklinkInfo(
+        [property: JsonPropertyName("source_path")] string SourcePath,
+        [property: JsonPropertyName("source_title")] string SourceTitle,
+        [property: JsonPropertyName("page_type")] string PageType);
+
+    private sealed record LoadContextResult(
+        [property: JsonPropertyName("task")] TaskCore Task,
+        [property: JsonPropertyName("artifacts")] List<ArtifactWithBody> Artifacts,
+        [property: JsonPropertyName("subtasks")] List<LoadContextSubtree> Subtasks,
+        [property: JsonPropertyName("backlinks")] List<BacklinkInfo> Backlinks);
 }

--- a/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
@@ -523,4 +523,199 @@ public class GlassworkToolsTests
         Assert.AreEqual(1, artifacts.GetArrayLength());
         Assert.AreEqual("research.md", artifacts[0].GetProperty("filename").GetString());
     }
+
+    // ───────────────────────────── load_context ──────────────────────────
+
+    [TestMethod]
+    public void LoadContext_LeafTask_ReturnsEmptyChildrenArrays()
+    {
+        var addJson = _tools.AddTask("Leaf", description: "Leaf desc.");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var json = _tools.LoadContext(taskId);
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual(taskId, doc.RootElement.GetProperty("task").GetProperty("id").GetString());
+        Assert.AreEqual("Leaf", doc.RootElement.GetProperty("task").GetProperty("title").GetString());
+        Assert.AreEqual("Leaf desc.", doc.RootElement.GetProperty("task").GetProperty("description").GetString());
+        Assert.AreEqual(0, doc.RootElement.GetProperty("artifacts").GetArrayLength());
+        Assert.AreEqual(0, doc.RootElement.GetProperty("subtasks").GetArrayLength());
+        Assert.AreEqual(0, doc.RootElement.GetProperty("backlinks").GetArrayLength());
+    }
+
+    [TestMethod]
+    public void LoadContext_IncludesArtifactBodies()
+    {
+        var addJson = _tools.AddTask("With Artifacts");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var artifactFolder = Path.Combine(TasksDir, taskId + ".artifacts");
+        Directory.CreateDirectory(artifactFolder);
+        File.WriteAllText(Path.Combine(artifactFolder, "plan.md"), "# Plan\n\nThe plan.");
+        File.WriteAllText(Path.Combine(artifactFolder, "design.md"), "# Design\n\nThe design.");
+
+        var json = _tools.LoadContext(taskId);
+        var artifacts = JsonDocument.Parse(json).RootElement.GetProperty("artifacts");
+
+        Assert.AreEqual(2, artifacts.GetArrayLength());
+
+        // OrdinalIgnoreCase filename order: design.md then plan.md
+        Assert.AreEqual("design.md", artifacts[0].GetProperty("filename").GetString());
+        StringAssert.Contains(artifacts[0].GetProperty("path").GetString()!, taskId + ".artifacts");
+        Assert.AreEqual("# Design\n\nThe design.", artifacts[0].GetProperty("content").GetString());
+
+        Assert.AreEqual("plan.md", artifacts[1].GetProperty("filename").GetString());
+        Assert.AreEqual("# Plan\n\nThe plan.", artifacts[1].GetProperty("content").GetString());
+    }
+
+    [TestMethod]
+    public void LoadContext_WalksSubtasksToDepthOne()
+    {
+        var parentId = JsonDocument.Parse(_tools.AddTask("Parent")).RootElement.GetProperty("task_id").GetString()!;
+        var childAId = JsonDocument.Parse(_tools.AddTask("Child A", parent_task_id: parentId)).RootElement.GetProperty("task_id").GetString()!;
+        var childBId = JsonDocument.Parse(_tools.AddTask("Child B", parent_task_id: parentId)).RootElement.GetProperty("task_id").GetString()!;
+        _tools.AddTask("Grandchild A1", parent_task_id: childAId);
+        _tools.AddTask("Grandchild B1", parent_task_id: childBId);
+
+        var json = _tools.LoadContext(parentId); // depth defaults to 1
+        var subtasks = JsonDocument.Parse(json).RootElement.GetProperty("subtasks");
+
+        Assert.AreEqual(2, subtasks.GetArrayLength(), "Default depth=1 must return direct children only.");
+        foreach (var i in Enumerable.Range(0, subtasks.GetArrayLength()))
+        {
+            Assert.AreEqual(0, subtasks[i].GetProperty("subtasks").GetArrayLength(),
+                "Grandchildren must NOT appear at depth=1.");
+        }
+    }
+
+    [TestMethod]
+    public void LoadContext_WalksSubtasksToDepthTwo()
+    {
+        var parentId = JsonDocument.Parse(_tools.AddTask("Parent")).RootElement.GetProperty("task_id").GetString()!;
+        var childId = JsonDocument.Parse(_tools.AddTask("Child", parent_task_id: parentId)).RootElement.GetProperty("task_id").GetString()!;
+        _tools.AddTask("Grandchild", parent_task_id: childId);
+
+        var json = _tools.LoadContext(parentId, depth: 2);
+        var subtasks = JsonDocument.Parse(json).RootElement.GetProperty("subtasks");
+
+        Assert.AreEqual(1, subtasks.GetArrayLength());
+        var grandchildren = subtasks[0].GetProperty("subtasks");
+        Assert.AreEqual(1, grandchildren.GetArrayLength(), "Grandchildren must appear at depth=2.");
+        Assert.AreEqual("Grandchild", grandchildren[0].GetProperty("task").GetProperty("title").GetString());
+    }
+
+    [TestMethod]
+    public void LoadContext_DepthZero_ReturnsNoSubtasks()
+    {
+        var parentId = JsonDocument.Parse(_tools.AddTask("Parent")).RootElement.GetProperty("task_id").GetString()!;
+        _tools.AddTask("Child", parent_task_id: parentId);
+
+        var json = _tools.LoadContext(parentId, depth: 0);
+        var subtasks = JsonDocument.Parse(json).RootElement.GetProperty("subtasks");
+
+        Assert.AreEqual(0, subtasks.GetArrayLength());
+    }
+
+    [TestMethod]
+    public void LoadContext_DepthGreaterThanThree_Clamps()
+    {
+        var parentId = JsonDocument.Parse(_tools.AddTask("Parent")).RootElement.GetProperty("task_id").GetString()!;
+        var childId = JsonDocument.Parse(_tools.AddTask("Child", parent_task_id: parentId)).RootElement.GetProperty("task_id").GetString()!;
+        var gcId = JsonDocument.Parse(_tools.AddTask("Grandchild", parent_task_id: childId)).RootElement.GetProperty("task_id").GetString()!;
+        var ggcId = JsonDocument.Parse(_tools.AddTask("GGC", parent_task_id: gcId)).RootElement.GetProperty("task_id").GetString()!;
+        // Great-great-grandchild at depth 4 must NOT appear even at depth=99 (clamp to 3).
+        _tools.AddTask("GGGC", parent_task_id: ggcId);
+
+        var json = _tools.LoadContext(parentId, depth: 99);
+        var doc = JsonDocument.Parse(json);
+
+        Assert.IsFalse(doc.RootElement.TryGetProperty("error", out _),
+            "depth > 3 must clamp silently, not error.");
+
+        // Walk: child -> grandchild -> GGC (3 levels). Then GGC.subtasks must be empty.
+        var ggcSubtree = doc.RootElement
+            .GetProperty("subtasks")[0]
+            .GetProperty("subtasks")[0]
+            .GetProperty("subtasks")[0];
+        Assert.AreEqual("GGC", ggcSubtree.GetProperty("task").GetProperty("title").GetString());
+        Assert.AreEqual(0, ggcSubtree.GetProperty("subtasks").GetArrayLength(),
+            "Depth must clamp at 3; level-4 descendants must NOT appear.");
+    }
+
+    [TestMethod]
+    public void LoadContext_IncludesBacklinks()
+    {
+        var taskId = JsonDocument.Parse(_tools.AddTask("Linked Task")).RootElement.GetProperty("task_id").GetString()!;
+
+        // BacklinkIndex scans the vault root for files outside wiki/todo.
+        var conceptDir = Path.Combine(_vaultDir, "wiki", "concepts");
+        Directory.CreateDirectory(conceptDir);
+        File.WriteAllText(Path.Combine(conceptDir, "foo.md"),
+            $"# Foo Concept\n\nReferences [[{taskId}]] inline.");
+
+        var json = _tools.LoadContext(taskId);
+        var backlinks = JsonDocument.Parse(json).RootElement.GetProperty("backlinks");
+
+        Assert.AreEqual(1, backlinks.GetArrayLength());
+        var entry = backlinks[0];
+        StringAssert.Contains(entry.GetProperty("source_path").GetString()!, "foo.md");
+        Assert.AreEqual("concept", entry.GetProperty("page_type").GetString());
+        Assert.IsTrue(entry.TryGetProperty("source_title", out _), "Backlink entry must include source_title.");
+    }
+
+    [TestMethod]
+    public void LoadContext_NonExistent_ReturnsNotFound()
+    {
+        var json = _tools.LoadContext("does-not-exist");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("not_found", doc.RootElement.GetProperty("error").GetString());
+        Assert.IsTrue(doc.RootElement.TryGetProperty("message", out _));
+    }
+
+    [TestMethod]
+    public void LoadContext_CycleSafe()
+    {
+        // Manually craft a parent cycle (the App enforces parent integrity, but
+        // external writers don't — the MCP server must not stack-overflow).
+        var aPath = Path.Combine(TasksDir, "task-a.md");
+        var bPath = Path.Combine(TasksDir, "task-b.md");
+        Directory.CreateDirectory(TasksDir);
+        File.WriteAllText(aPath, "---\nid: task-a\ntitle: A\nstatus: todo\nparent: task-b\n---\n");
+        File.WriteAllText(bPath, "---\nid: task-b\ntitle: B\nstatus: todo\nparent: task-a\n---\n");
+
+        // depth=3 with a cycle would infinite-recurse without the visited set.
+        var json = _tools.LoadContext("task-a", depth: 3);
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("task-a", doc.RootElement.GetProperty("task").GetProperty("id").GetString());
+        // The subtree must terminate. (A's children include B; B's children would
+        // include A, but A is already visited, so the recursion stops there.)
+    }
+
+    [TestMethod]
+    public void LoadContext_Subtree_HasArtifactsAndNestedSubtasks_ButNoBacklinks()
+    {
+        var parentId = JsonDocument.Parse(_tools.AddTask("Parent")).RootElement.GetProperty("task_id").GetString()!;
+        var childId = JsonDocument.Parse(_tools.AddTask("Child", parent_task_id: parentId)).RootElement.GetProperty("task_id").GetString()!;
+        _tools.AddTask("Grandchild", parent_task_id: childId);
+
+        // Give the child an artifact to confirm subtree artifacts are inlined.
+        var childArtifacts = Path.Combine(TasksDir, childId + ".artifacts");
+        Directory.CreateDirectory(childArtifacts);
+        File.WriteAllText(Path.Combine(childArtifacts, "child-plan.md"), "child plan body");
+
+        var json = _tools.LoadContext(parentId, depth: 2);
+        var child = JsonDocument.Parse(json).RootElement.GetProperty("subtasks")[0];
+
+        // Subtree carries task + artifacts + subtasks
+        Assert.AreEqual("Child", child.GetProperty("task").GetProperty("title").GetString());
+        Assert.AreEqual(1, child.GetProperty("artifacts").GetArrayLength());
+        Assert.AreEqual("child plan body", child.GetProperty("artifacts")[0].GetProperty("content").GetString());
+        Assert.AreEqual(1, child.GetProperty("subtasks").GetArrayLength());
+
+        // But NOT backlinks — those are root-only in v1.
+        Assert.IsFalse(child.TryGetProperty("backlinks", out _),
+            "Subtask payloads must not carry a 'backlinks' field (root-only in v1).");
+    }
 }

--- a/tests/Glasswork.Mcp.Tests/McpLoggerTests.cs
+++ b/tests/Glasswork.Mcp.Tests/McpLoggerTests.cs
@@ -289,6 +289,27 @@ public class McpLoggerTests
             Assert.IsTrue(phase.Value.GetInt64() >= 0, $"Phase '{phase.Name}' must be >= 0 ms.");
     }
 
+    [TestMethod]
+    public void TraceEnabled_LoadContext_PhasesContainExpectedKeys()
+    {
+        var sink = new StringBuilder();
+        var tools = MakeTools(MakeLogger(sink, traceEnabled: true));
+
+        var addJson = tools.AddTask("Trace LoadContext Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+        sink.Clear();
+
+        tools.LoadContext(taskId);
+
+        var doc = JsonDocument.Parse(sink.ToString().Trim());
+        var phases = doc.RootElement.GetProperty("phases");
+
+        Assert.IsTrue(phases.TryGetProperty("load_task", out _), "Must have 'load_task' phase.");
+        Assert.IsTrue(phases.TryGetProperty("load_artifacts", out _), "Must have 'load_artifacts' phase.");
+        Assert.IsTrue(phases.TryGetProperty("load_subtasks", out _), "Must have 'load_subtasks' phase.");
+        Assert.IsTrue(phases.TryGetProperty("load_backlinks", out _), "Must have 'load_backlinks' phase.");
+    }
+
     // ─────────────────────── helpers ─────────────────────────────────────
 
     private static bool IsValidJson(string s)


### PR DESCRIPTION
Closes #137.

## Summary

Adds `load_context(task_id, depth=1)` — a single MCP call that returns a task's complete context bundle: task content + artifact bodies + recursive subtasks (to `depth`) + backlinks. Replaces the `get_task` → N × artifact reads → `list_tasks(parent_id)` → backlink discovery chain agents previously needed. Highest-leverage tool for Ralph-loop handoffs.

## What's in the bundle

```json
{
  "task":      { "id", "title", "status", "parent_id", "description", "notes" },
  "artifacts": [ { "filename", "path" (vault-relative), "content" } ],
  "subtasks":  [ { "task", "artifacts", "subtasks" } ],  // recursive to depth
  "backlinks": [ { "source_path", "source_title", "page_type" } ]
}
```

## Key design decisions

- **`depth` clamped to `[0, 3]`** — `depth > 3` is silently clamped, not errored (per issue spec). Default `depth = 1` returns direct children only; `depth = 0` returns no subtasks.
- **Backlinks scoped to root only** — subtree payloads carry their own artifacts and nested subtasks but no `backlinks` field. The backlink scan is the dominant cost; running it per subtree would explode latency and payload size without clear agent value. Agents that need a subtask's backlinks can issue a follow-up `load_context` rooted at that subtask.
- **Backlinks reuse `Glasswork.Core.Services.BacklinkIndex`** (ADR 0005) — no scanner re-implementation. Built per call against `vaultContext.VaultPath` (the vault root), **not** `wiki/todo` (stateless, ADR 0007 §6).
- **`not_found` short-circuits the backlink `Build`** — keeps misses cheap.
- **Cycle-safe BFS** — a visited-id set guards re-entry, so hand-edited vaults with `a.parent = b ∧ b.parent = a` do not stack-overflow.
- **Tracing** — `GLASSWORK_MCP_TRACE=1` emits per-phase timings `load_task`, `load_artifacts`, `load_subtasks`, `load_backlinks`.

## Tests

`tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs`:

- `LoadContext_LeafTask_ReturnsEmptyChildrenArrays`
- `LoadContext_IncludesArtifactBodies`
- `LoadContext_WalksSubtasksToDepthOne`
- `LoadContext_WalksSubtasksToDepthTwo`
- `LoadContext_DepthZero_ReturnsNoSubtasks`
- `LoadContext_DepthGreaterThanThree_Clamps`
- `LoadContext_IncludesBacklinks`
- `LoadContext_NonExistent_ReturnsNotFound`
- `LoadContext_CycleSafe`
- `LoadContext_Subtree_HasArtifactsAndNestedSubtasks_ButNoBacklinks`

Plus `McpLoggerTests.TraceEnabled_LoadContext_PhasesContainExpectedKeys` for the four phase keys.

## Files changed

- `src/Glasswork.Mcp/Tools/GlassworkTools.cs` — `LoadContext` method + private BFS/projection helpers + new record types (`TaskCore`, `ArtifactWithBody`, `LoadContextSubtree`, `BacklinkInfo`, `LoadContextResult`)
- `src/Glasswork.Mcp/Program.cs`, `Glasswork.Mcp.csproj` — version bumped `0.3.0` → `0.4.0`
- `src/Glasswork.Mcp/README.md` — tool reference table entry + full `### load_context` section with example payload
- `src/Glasswork.Mcp/CHANGELOG.md` — `[0.4.0]` heading
- Tests as above

## Acceptance criteria checklist (from #137)

- [x] Single call returns task + artifact bodies + subtasks (to `depth`) + backlinks
- [x] `depth` capped at 3, values > 3 clamped (not errored)
- [x] `{ error: "not_found" }` for missing tasks
- [x] Backlinks via `IBacklinkIndex` (no re-implementation)
- [x] `GLASSWORK_MCP_TRACE=1` emits the four phase keys
- [x] README documents the tool with an example payload
- [x] Tests cover: leaf, artifacts, parent with subtasks, backlinks, depth=0, depth>3 clamp (+ extras: cycle safety, subtree shape, not_found)

## Notes

- Could not run `dotnet build` / `dotnet test` locally (no .NET SDK on this macOS environment). CI will validate. Rubber-duck review found no blocking issues — three non-blocking notes (phase-timing scope, artifact-read failure swallowing, "subtree node" vs "get_task shape" nomenclature) accepted as v1 tradeoffs.
- `BacklinkIndex` is constructed concretely rather than injected via `IBacklinkIndex`. If we add caching across MCP calls, switching to injection is a clean follow-up.