### PR TITLE
fix(backlog): harden board view empty-state against refresh-order regressions (closes #180)

### DIFF
--- a/src/Glasswork.App/Pages/BacklogPage.xaml.cs
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml.cs
@@ -41,8 +41,24 @@ public sealed partial class BacklogPage : Page
             DispatcherQueue?.TryEnqueue(() => ViewModel.Refresh());
         };
         InitializeComponent();
-        ViewModel.Rows.CollectionChanged += (_, _) => UpdateEmptyState();
-        ViewModel.BoardColumns.CollectionChanged += (_, _) => UpdateEmptyState();
+        // Update empty-state exactly once at the end of each VM Refresh, instead of as
+        // a side effect of every BoardColumns/Rows CollectionChanged event. The old
+        // approach left a brief flash to the empty state between the internal Clear()
+        // and the first Add() — and was fragile against any future reorder of the
+        // collection population in BacklogViewModel.Refresh().
+        ViewModel.Refreshed += () =>
+        {
+            // Refreshed fires on whichever thread called VM.Refresh(); all current call
+            // sites are on the UI thread, but guard defensively in case that ever changes.
+            if (DispatcherQueue.HasThreadAccess)
+            {
+                UpdateEmptyState();
+            }
+            else
+            {
+                DispatcherQueue.TryEnqueue(UpdateEmptyState);
+            }
+        };
         // Persist toggle whenever the user flips it. Bind here (not in VM) so the
         // VM stays UI-state-store-agnostic.
         ViewModel.PropertyChanged += (_, args) =>
@@ -159,13 +175,13 @@ public sealed partial class BacklogPage : Page
     private void Refresh()
     {
         // First populate Tasks (so LoadGroupCollapseState has parents to query),
-        // then re-run grouping. ViewModel.Refresh() does both atomically.
+        // then re-run grouping. ViewModel.Refresh() does both atomically and raises
+        // Refreshed at the end, which the constructor wires to UpdateEmptyState().
         ViewModel.Refresh();
         foreach (var t in ViewModel.Tasks)
         {
             t.IsManuallyCollapsed = App.UiState.Get<bool>($"{App.CollapsedTaskKeyPrefix}{t.Id}");
         }
-        UpdateEmptyState();
     }
 
     private void UpdateEmptyState()

--- a/src/Glasswork.Core/ViewModels/BacklogViewModel.cs
+++ b/src/Glasswork.Core/ViewModels/BacklogViewModel.cs
@@ -146,6 +146,8 @@ public partial class BacklogViewModel : ObservableObject
                 }
             }
         }
+
+        Refreshed?.Invoke();
     }
 
     private void HydrateParentTitleCache(IReadOnlyList<GlassworkTask> ordered)
@@ -242,6 +244,21 @@ public partial class BacklogViewModel : ObservableObject
     /// group headers with the enriched titles.
     /// </summary>
     public event Action? ParentTitlesResolved;
+
+    /// <summary>
+    /// Raised exactly once at the end of <see cref="Refresh"/> after all collections
+    /// (<see cref="Tasks"/>, <see cref="Rows"/>, <see cref="BoardColumns"/>) have been
+    /// fully populated. Page hosts subscribe to this instead of individual
+    /// <c>CollectionChanged</c> events so empty-state UI is computed against the final
+    /// state, not the transient empty state that exists between the internal
+    /// <c>Clear()</c> and <c>Add()</c> calls.
+    ///
+    /// This fires on whichever thread called <see cref="Refresh"/>. All current call
+    /// sites invoke <see cref="Refresh"/> on the UI thread (commands and watcher
+    /// callbacks dispatched via <c>DispatcherQueue.TryEnqueue</c>); subscribers that
+    /// touch XAML controls should still verify <c>HasThreadAccess</c> defensively.
+    /// </summary>
+    public event Action? Refreshed;
 
     partial void OnIsGroupedChanged(bool value) => Refresh();
     partial void OnViewModeChanged(string value) => Refresh();

--- a/src/Glasswork.Core/ViewModels/BacklogViewModel.cs
+++ b/src/Glasswork.Core/ViewModels/BacklogViewModel.cs
@@ -253,10 +253,18 @@ public partial class BacklogViewModel : ObservableObject
     /// state, not the transient empty state that exists between the internal
     /// <c>Clear()</c> and <c>Add()</c> calls.
     ///
-    /// This fires on whichever thread called <see cref="Refresh"/>. All current call
-    /// sites invoke <see cref="Refresh"/> on the UI thread (commands and watcher
-    /// callbacks dispatched via <c>DispatcherQueue.TryEnqueue</c>); subscribers that
-    /// touch XAML controls should still verify <c>HasThreadAccess</c> defensively.
+    /// Contract:
+    /// <list type="bullet">
+    ///   <item><description>Fires synchronously on whichever thread called
+    ///     <see cref="Refresh"/>. All current call sites invoke <see cref="Refresh"/>
+    ///     on the UI thread (commands and watcher callbacks dispatched via
+    ///     <c>DispatcherQueue.TryEnqueue</c>); subscribers that touch XAML controls
+    ///     should still verify <c>HasThreadAccess</c> defensively.</description></item>
+    ///   <item><description>Subscribers must not throw — an exception will propagate
+    ///     out of <see cref="Refresh"/> and skip any later subscribers.</description></item>
+    ///   <item><description>Subscribers must not call <see cref="Refresh"/> re-entrantly —
+    ///     <see cref="Refresh"/> is not designed for recursion.</description></item>
+    /// </list>
     /// </summary>
     public event Action? Refreshed;
 

--- a/tests/Glasswork.Tests/BacklogViewModelBoardRefreshTests.cs
+++ b/tests/Glasswork.Tests/BacklogViewModelBoardRefreshTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.IO;
+using System.Linq;
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+using Glasswork.ViewModels;
+
+namespace Glasswork.Tests;
+
+/// <summary>
+/// Regression coverage for issue #180 / PR #170: the board-mode empty-state derivation
+/// must reflect the FINAL state of <see cref="BacklogViewModel.BoardColumns"/> after
+/// <see cref="BacklogViewModel.Refresh"/>, not the transient empty state that exists
+/// between the internal <c>Clear()</c> and <c>Add()</c> calls.
+///
+/// These tests treat <see cref="BacklogViewModel.Refreshed"/> as the one authoritative
+/// "refresh complete" signal and assert the predicate the page reads to decide whether
+/// to show the empty state.
+/// </summary>
+[TestClass]
+public class BacklogViewModelBoardRefreshTests
+{
+    private string _tempDir = null!;
+    private VaultService _vault = null!;
+    private TaskService _taskService = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-bvm-board-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _vault = new VaultService(_tempDir);
+        _taskService = new TaskService(_vault);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public void Refresh_InListMode_RaisesRefreshedExactlyOnce()
+    {
+        _taskService.CreateTask("Task A");
+        var vm = new BacklogViewModel(_vault, _taskService);
+        // VM defaults to list mode — no mode change needed.
+
+        var count = 0;
+        vm.Refreshed += () => count++;
+
+        vm.Refresh();
+
+        Assert.AreEqual(1, count, "Refreshed should fire exactly once per Refresh() call");
+    }
+
+    [TestMethod]
+    public void Refresh_InBoardMode_RaisesRefreshedExactlyOnce()
+    {
+        _taskService.CreateTask("Task A");
+        var vm = new BacklogViewModel(_vault, _taskService);
+        vm.ViewMode = "board"; // OnViewModeChanged → Refresh, before we subscribe
+
+        var count = 0;
+        vm.Refreshed += () => count++;
+
+        vm.Refresh();
+
+        Assert.AreEqual(1, count, "Refreshed should fire exactly once per Refresh() call in board mode");
+    }
+
+    /// <summary>
+    /// The core regression test for #180/#170. Captures the state BacklogPage uses to
+    /// decide empty-state visibility — <c>BoardColumns.Any(c => c.Tasks.Count &gt; 0)</c>
+    /// — at the moment <see cref="BacklogViewModel.Refreshed"/> fires. If a future
+    /// refactor of <see cref="BacklogViewModel.Refresh"/> ever raised the event before
+    /// <c>BoardColumns</c> was repopulated, this would fail.
+    /// </summary>
+    [TestMethod]
+    public void SetStatusCommand_InBoardMode_RaisedRefreshedSeesPopulatedBoardColumns()
+    {
+        var a = _taskService.CreateTask("Task A"); // Todo
+        var b = _taskService.CreateTask("Task B");
+        _taskService.SetStatus(b, GlassworkTask.Statuses.InProgress);
+        var c = _taskService.CreateTask("Task C"); // Todo
+
+        var vm = new BacklogViewModel(_vault, _taskService);
+        vm.ViewMode = "board"; // initial board refresh before we subscribe
+
+        var observedBoardHasContent = false;
+        var observedTotalTasksInColumns = -1;
+        vm.Refreshed += () =>
+        {
+            observedBoardHasContent = vm.BoardColumns.Any(col => col.Tasks.Count > 0);
+            observedTotalTasksInColumns = vm.BoardColumns.Sum(col => col.Tasks.Count);
+        };
+
+        vm.SelectedTask = a;
+        vm.SetStatusCommand.Execute(GlassworkTask.Statuses.Done);
+
+        Assert.IsTrue(observedBoardHasContent,
+            "When marking one of three tasks done, the board still has remaining tasks " +
+            "and BoardColumns.Any(c => c.Tasks.Count > 0) must be true when Refreshed fires");
+        Assert.AreEqual(2, observedTotalTasksInColumns,
+            "Refreshed must fire after BoardColumns is repopulated, not while empty");
+    }
+
+    [TestMethod]
+    public void SetStatusCommand_InBoardMode_MarkingLastNonDoneTaskDone_BoardColumnsAreEmpty()
+    {
+        var a = _taskService.CreateTask("Only Task"); // Todo
+
+        var vm = new BacklogViewModel(_vault, _taskService);
+        vm.ViewMode = "board";
+
+        var observedBoardHasContent = true; // intentionally start true to confirm flip
+        vm.Refreshed += () =>
+        {
+            observedBoardHasContent = vm.BoardColumns.Any(col => col.Tasks.Count > 0);
+        };
+
+        vm.SelectedTask = a;
+        vm.SetStatusCommand.Execute(GlassworkTask.Statuses.Done);
+
+        Assert.IsFalse(observedBoardHasContent,
+            "When the only non-done task is marked done, the board is genuinely empty " +
+            "and the empty-state should be shown — the predicate must return false");
+        Assert.IsTrue(vm.BoardColumns.All(col => col.Tasks.Count == 0),
+            "All board columns should be empty after marking the only task done");
+    }
+
+    [TestMethod]
+    public void Refresh_InBoardMode_BoardColumnsContainOnlyNonDoneTasks()
+    {
+        _taskService.CreateTask("Task A"); // Todo
+        var done = _taskService.CreateTask("Task Done");
+        _taskService.SetStatus(done, GlassworkTask.Statuses.Done);
+
+        var vm = new BacklogViewModel(_vault, _taskService);
+        vm.ViewMode = "board";
+
+        // Sanity: invariant that the page-side predicate relies on after every refresh.
+        Assert.IsTrue(vm.BoardColumns.Any(col => col.Tasks.Count > 0),
+            "Board should show non-done tasks");
+        Assert.IsFalse(
+            vm.BoardColumns.SelectMany(col => col.Tasks).Any(t => t.Status == GlassworkTask.Statuses.Done),
+            "Board columns must not contain any Done tasks");
+    }
+}

--- a/tests/Glasswork.Tests/BacklogViewModelBoardRefreshTests.cs
+++ b/tests/Glasswork.Tests/BacklogViewModelBoardRefreshTests.cs
@@ -88,10 +88,12 @@ public class BacklogViewModelBoardRefreshTests
         var vm = new BacklogViewModel(_vault, _taskService);
         vm.ViewMode = "board"; // initial board refresh before we subscribe
 
+        var invokeCount = 0;
         var observedBoardHasContent = false;
         var observedTotalTasksInColumns = -1;
         vm.Refreshed += () =>
         {
+            invokeCount++;
             observedBoardHasContent = vm.BoardColumns.Any(col => col.Tasks.Count > 0);
             observedTotalTasksInColumns = vm.BoardColumns.Sum(col => col.Tasks.Count);
         };
@@ -99,6 +101,8 @@ public class BacklogViewModelBoardRefreshTests
         vm.SelectedTask = a;
         vm.SetStatusCommand.Execute(GlassworkTask.Statuses.Done);
 
+        Assert.AreEqual(1, invokeCount,
+            "SetStatusCommand should trigger exactly one Refresh -> Refreshed cycle");
         Assert.IsTrue(observedBoardHasContent,
             "When marking one of three tasks done, the board still has remaining tasks " +
             "and BoardColumns.Any(c => c.Tasks.Count > 0) must be true when Refreshed fires");


### PR DESCRIPTION
Closes #180

## Diagnosis

Issue #180 ("Completing a task in Kanban view clears all tasks from view") is the same symptom PR #170 already fixed. The feedback dialog captured app version `1.2.0+536fb84` (May 6); PR #170 (commit `510ced1`, May 10) landed days later. **The user's build is stale** — rebuilding off `main` makes the symptom disappear.

That said, PR #170 was a **point patch**, not a structural fix:

- `BacklogPage.UpdateEmptyState()` ran as a side effect of every `Rows.CollectionChanged` and `BoardColumns.CollectionChanged` event.
- During `BacklogViewModel.Refresh()` in board mode the sequence is `Tasks.Clear()` → `Rows.Clear()` → `BoardColumns.Clear()` → load → `Add` cols → `Add` tasks. Each `Clear` / `Add` fires `UpdateEmptyState`.
- Between `BoardColumns.Clear()` and the first `Add()`, `UpdateEmptyState` saw an empty `BoardColumns` and flipped to **EmptyState Visible / BoardView Collapsed**. The final value depended entirely on whichever event happened last during the refresh.
- Future refactors of `Refresh()` (e.g. adding `BoardColumns` before their inner `Tasks` lists are filled, or changing the subscribed collection) could each reintroduce a similar timing bug. There was also no regression test.

## Approach

Replace the implicit "fire `UpdateEmptyState` on every collection change" contract with an explicit `Refreshed` event raised exactly once at the end of `BacklogViewModel.Refresh()`. This:

1. Eliminates the brief EmptyState flash between `Clear` and `Add`.
2. Removes the dependence on the internal collection-mutation order in `Refresh()` — and makes the specific *predicate* `UpdateEmptyState` reads non-load-bearing, since by the time `Refreshed` fires every collection is correct.
3. Provides a testable seam — tests can subscribe to `Refreshed` and assert that, when it fires, `BoardColumns` already contains the expected non-done tasks.

## Changes

- **`src/Glasswork.Core/ViewModels/BacklogViewModel.cs`** (moved from `src/Glasswork.App/ViewModels/`): the VM has no WinUI dependencies and `CommunityToolkit.Mvvm` is already in `Glasswork.Core`. This matches the existing `BacklogUndoState` placement and unlocks ViewModel-level testing. Namespace stays `Glasswork.ViewModels`. Added a public `Refreshed` event with documented contract (synchronous, on caller thread, no-throw, no-reentry) raised at the end of `Refresh()`.
- **`src/Glasswork.App/Pages/BacklogPage.xaml.cs`**: subscribe `UpdateEmptyState` to `Refreshed`; remove the two `CollectionChanged` subscriptions; drop the now-redundant explicit `UpdateEmptyState()` call in the page-local `Refresh()`. Subscriber guards with `DispatcherQueue.HasThreadAccess` (matches the existing `ParentTitlesResolved` pattern).
- **`tests/Glasswork.Tests/BacklogViewModelBoardRefreshTests.cs`** (new): 5 regression tests covering the **new refresh-completion contract**:
  1. `Refreshed` fires exactly once per `Refresh()` in list mode.
  2. Same in board mode.
  3. **Key test** — after `SetStatusCommand.Execute("done")` in board mode with two non-done tasks remaining, the handler fires exactly once and sees `BoardColumns.Any(c => c.Tasks.Count > 0) == true` and `Sum(...) == 2`. This fails if `Refreshed` ever fires before `BoardColumns` is repopulated, or if a future change triggers an extra refresh round-trip.
  4. Marking the only non-done task done leaves the board genuinely empty (predicate flips to `false`).
  5. `Refresh()` never leaves `Done` tasks in `BoardColumns`.

  Scope note: these tests assert the **new contract** (Refreshed-after-population). They would not directly catch a revert of PR #170's predicate to `Tasks.Count > 0`, because by the time `Refreshed` fires, `Tasks` is also populated. That's intentional — the structural fix makes the specific predicate choice non-load-bearing.

## Verification

- `dotnet test tests/Glasswork.Tests/ --filter FullyQualifiedName~BacklogViewModelBoardRefresh -p:EnableWindowsTargeting=true` — 5 passed.
- Full suite: 553 passed; 3 known pre-existing flaky timing failures (`Trigger_FiresAgainAfterQuietPeriodElapses`, `DebouncesBurstsIntoOneEvent`) on this runner — unrelated.
- `dotnet build src/Glasswork.App/Glasswork.csproj -p:Platform=x64` — succeeds, no errors.

## Safety notes

- The drag-drop path in the board view mutates `BoardColumn.Tasks` directly (a plain `List<>`, not an `ObservableCollection`) and does **not** call `ViewModel.Refresh()` on success. So the existing `CollectionChanged` subscriptions only ever fired during a `Refresh()`. Replacing them is safe.
- `OnFileChanged` already dispatches via `DispatcherQueue.TryEnqueue(Refresh)` so the new subscriber's defensive thread check is belt-and-suspenders.
- No XAML changes — bindings to `ViewModel.BoardColumns`, `Rows`, `Tasks` are unchanged.

## Out of scope

- The drag-drop optimistic-UI path (separate concern).
- The two flaky debouncer tests (unrelated timing).

---

Plan was rubber-ducked before implementing, and the PR diff was dual-reviewed by both rubber-duck and code-review agents. Both found no blockers; their non-blocking suggestions (invocation-count assertion, documented event contract, accuracy of this description re: PR #170) are reflected in the final commits.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>