### PR TITLE
fix(backlog): preserve scroll position across mark-done refresh (#182)

### DIFF
--- a/src/Glasswork.App/Pages/BacklogPage.xaml
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml
@@ -333,7 +333,7 @@
             Visibility="Collapsed"
             HorizontalScrollBarVisibility="Auto"
             VerticalScrollBarVisibility="Disabled">
-            <ItemsControl ItemsSource="{x:Bind ViewModel.BoardColumns}">
+            <ItemsControl x:Name="BoardColumnsControl" ItemsSource="{x:Bind ViewModel.BoardColumns}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                         <StackPanel Orientation="Horizontal" Spacing="16" />

--- a/src/Glasswork.App/Pages/BacklogPage.xaml.cs
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml.cs
@@ -76,7 +76,19 @@ public sealed partial class BacklogPage : Page
             // refreshes (e.g. status command followed by file watcher echo) — without
             // this, the second Refreshing would capture the post-clear scroll-zero
             // state and clobber the user's actual position.
-            _pendingRestore ??= CaptureScrollState();
+            //
+            // Defensive try/catch: scroll preservation must never break Refresh().
+            // If the visual-tree walk throws (rare but possible during render-thread
+            // contention), we drop the snapshot and the refresh proceeds normally —
+            // the only consequence is no scroll restore on this refresh.
+            try
+            {
+                _pendingRestore ??= CaptureScrollState();
+            }
+            catch
+            {
+                _pendingRestore = null;
+            }
         };
         // Update empty-state exactly once at the end of each VM Refresh, instead of as
         // a side effect of every BoardColumns/Rows CollectionChanged event. The old
@@ -810,7 +822,7 @@ public sealed partial class BacklogPage : Page
             if (s.ListOffset > 0 && sv.ScrollableHeight <= 0) return false;
             sv.ChangeView(
                 horizontalOffset: null,
-                verticalOffset: Math.Min(s.ListOffset, Math.Max(0, sv.ScrollableHeight)),
+                verticalOffset: Math.Max(0, Math.Min(s.ListOffset, sv.ScrollableHeight)),
                 zoomFactor: null,
                 disableAnimation: true);
             return true;
@@ -819,25 +831,31 @@ public sealed partial class BacklogPage : Page
         // Board mode
         if (s.BoardHorizontalOffset > 0 && BoardView.ScrollableWidth <= 0) return false;
         BoardView.ChangeView(
-            horizontalOffset: Math.Min(s.BoardHorizontalOffset, Math.Max(0, BoardView.ScrollableWidth)),
+            horizontalOffset: Math.Max(0, Math.Min(s.BoardHorizontalOffset, BoardView.ScrollableWidth)),
             verticalOffset: null,
             zoomFactor: null,
             disableAnimation: true);
 
+        // Per-column vertical offsets: if any column's container or inner
+        // ScrollViewer isn't realized yet, or its extent isn't ready, return
+        // false so the retry loop runs again. Without this guard we'd return
+        // true and permanently lose that column's scroll position.
+        var allColumnsReady = true;
         foreach (var col in ViewModel.BoardColumns)
         {
             if (!s.BoardColumnOffsets.TryGetValue(col.ColumnName, out var offset)) continue;
             var container = BoardColumnsControl.ContainerFromItem(col) as DependencyObject;
-            if (container is null) continue;
+            if (container is null) { allColumnsReady = false; continue; }
             var sv = FindDescendantScrollViewer(container);
-            if (sv is null) continue;
+            if (sv is null) { allColumnsReady = false; continue; }
+            if (offset > 0 && sv.ScrollableHeight <= 0) { allColumnsReady = false; continue; }
             sv.ChangeView(
                 horizontalOffset: null,
-                verticalOffset: Math.Min(offset, Math.Max(0, sv.ScrollableHeight)),
+                verticalOffset: Math.Max(0, Math.Min(offset, sv.ScrollableHeight)),
                 zoomFactor: null,
                 disableAnimation: true);
         }
-        return true;
+        return allColumnsReady;
     }
 
     /// <summary>

--- a/src/Glasswork.App/Pages/BacklogPage.xaml.cs
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml.cs
@@ -22,6 +22,25 @@ public sealed partial class BacklogPage : Page
     private readonly BacklogUndoState _undoState = new();
     private DispatcherTimer? _undoTimer;
 
+    // Issue #182: pending scroll-restore snapshot. Captured in ViewModel.Refreshing,
+    // applied (with bounded retry) after ViewModel.Refreshed. Null when no restore
+    // is queued (e.g. fresh page, or after AddTask which explicitly discards).
+    private ScrollSnapshot? _pendingRestore;
+
+    /// <summary>
+    /// Captured scroll state for a single Refresh() round-trip. Includes the
+    /// layout context (ViewMode/IsGrouped/FilterStatus) so the restore callback
+    /// can detect when an intentional layout change has invalidated the snapshot
+    /// and drop it instead of restoring a now-meaningless offset.
+    /// </summary>
+    private sealed record ScrollSnapshot(
+        string ViewMode,
+        bool IsGrouped,
+        string FilterStatus,
+        double ListOffset,
+        double BoardHorizontalOffset,
+        Dictionary<string, double> BoardColumnOffsets);
+
     public BacklogPage()
     {
         ViewModel = new BacklogViewModel(App.Vault, App.Tasks, App.UiState);
@@ -43,6 +62,22 @@ public sealed partial class BacklogPage : Page
             DispatcherQueue?.TryEnqueue(() => ViewModel.Refresh());
         };
         InitializeComponent();
+        // Issue #182: snapshot scroll position before VM.Refresh() destroys it, restore
+        // it after Refreshed once layout has caught up. The snapshot itself carries the
+        // ViewMode/IsGrouped/FilterStatus it was captured under; if any of those
+        // change before the restore runs, we drop the snapshot — that handles all
+        // intentional layout-change paths (view-mode toggle, GroupToggle two-way
+        // binding, status filter combo, OnNavigatedTo) without a flag dance.
+        ViewModel.Refreshing += () =>
+        {
+            // Visual-tree walks must be on the UI thread.
+            if (!DispatcherQueue.HasThreadAccess) return;
+            // ??= preserves the ORIGINAL pre-refresh offset across back-to-back
+            // refreshes (e.g. status command followed by file watcher echo) — without
+            // this, the second Refreshing would capture the post-clear scroll-zero
+            // state and clobber the user's actual position.
+            _pendingRestore ??= CaptureScrollState();
+        };
         // Update empty-state exactly once at the end of each VM Refresh, instead of as
         // a side effect of every BoardColumns/Rows CollectionChanged event. The old
         // approach left a brief flash to the empty state between the internal Clear()
@@ -59,6 +94,18 @@ public sealed partial class BacklogPage : Page
             else
             {
                 DispatcherQueue.TryEnqueue(UpdateEmptyState);
+            }
+
+            // Dispatch scroll restore at Low priority so layout has a chance to
+            // realize containers + recompute extent before ChangeView lands. Bounded
+            // retry inside TryRestoreWithRetry handles cases where Low alone isn't
+            // enough (virtualized ListView still measuring).
+            if (_pendingRestore is not null)
+            {
+                var snapshot = _pendingRestore;
+                DispatcherQueue.TryEnqueue(
+                    Microsoft.UI.Dispatching.DispatcherQueuePriority.Low,
+                    () => TryRestoreWithRetry(snapshot, attempts: 0));
             }
         };
         // Persist toggle whenever the user flips it. Bind here (not in VM) so the
@@ -232,6 +279,10 @@ public sealed partial class BacklogPage : Page
         if (result == ContentDialogResult.Primary && dialog.CreatedTask is not null)
         {
             ViewModel.Refresh();
+            // Issue #182: newly-created tasks sort to the top of their priority bucket
+            // by Created-desc. Restoring the pre-refresh scroll would hide the new task
+            // from the user. Discard the snapshot so the queued restore is skipped.
+            _pendingRestore = null;
         }
     }
 
@@ -665,5 +716,147 @@ public sealed partial class BacklogPage : Page
         // Placeholder: InfoBar UI will be added in next iteration
         // For now, just log the error
         System.Diagnostics.Debug.WriteLine($"Drag-drop error: {message}");
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #182: scroll-position capture/restore around VM.Refresh().
+    // The destructive Clear+Add inside BacklogViewModel.Refresh tears down
+    // the bound ListView / ItemsControl containers, resetting all scroll
+    // viewers to offset 0. We capture in VM.Refreshing (before Clear) and
+    // restore in VM.Refreshed via Low-priority dispatch with bounded retry.
+    // See plan.md ("Design — page-side scroll preservation") for the
+    // context-comparison rationale that replaces the original skip-flag idea.
+    // ---------------------------------------------------------------------
+
+    private ScrollSnapshot CaptureScrollState()
+    {
+        var columnOffsets = new Dictionary<string, double>(StringComparer.Ordinal);
+        double listOffset = 0;
+        double boardHorizontal = 0;
+
+        if (ViewModel.ViewMode == "list")
+        {
+            var sv = FindDescendantScrollViewer(TaskList);
+            if (sv is not null) listOffset = sv.VerticalOffset;
+        }
+        else // board mode
+        {
+            // BoardView itself IS the outer (horizontal) ScrollViewer.
+            boardHorizontal = BoardView.HorizontalOffset;
+
+            foreach (var col in ViewModel.BoardColumns)
+            {
+                var container = BoardColumnsControl.ContainerFromItem(col) as DependencyObject;
+                if (container is null) continue;
+                var sv = FindDescendantScrollViewer(container);
+                if (sv is null) continue;
+                columnOffsets[col.ColumnName] = sv.VerticalOffset;
+            }
+        }
+
+        return new ScrollSnapshot(
+            ViewMode: ViewModel.ViewMode,
+            IsGrouped: ViewModel.IsGrouped,
+            FilterStatus: ViewModel.FilterStatus,
+            ListOffset: listOffset,
+            BoardHorizontalOffset: boardHorizontal,
+            BoardColumnOffsets: columnOffsets);
+    }
+
+    private void TryRestoreWithRetry(ScrollSnapshot snapshot, int attempts)
+    {
+        // Stale callback (snapshot was discarded by AddTask, or superseded by a
+        // newer back-to-back refresh that overwrote _pendingRestore)? Bail.
+        if (_pendingRestore != snapshot) return;
+
+        // Layout context changed since capture (user toggled view-mode, group,
+        // or filter)? The captured offset is meaningless now. Drop the snapshot.
+        if (snapshot.ViewMode    != ViewModel.ViewMode    ||
+            snapshot.IsGrouped   != ViewModel.IsGrouped   ||
+            snapshot.FilterStatus != ViewModel.FilterStatus)
+        {
+            _pendingRestore = null;
+            return;
+        }
+
+        if (ApplySnapshot(snapshot))
+        {
+            _pendingRestore = null;
+            return;
+        }
+
+        // Layout not yet ready (e.g. ScrollableHeight == 0 but target > 0).
+        // Re-queue at Low up to 5 times. Empirically generous for a virtualized
+        // ListView coming out of Clear+Add; bounded so a degenerate state can't
+        // loop forever.
+        if (attempts >= 5)
+        {
+            _pendingRestore = null;
+            return;
+        }
+        DispatcherQueue.TryEnqueue(
+            Microsoft.UI.Dispatching.DispatcherQueuePriority.Low,
+            () => TryRestoreWithRetry(snapshot, attempts + 1));
+    }
+
+    private bool ApplySnapshot(ScrollSnapshot s)
+    {
+        if (s.ViewMode == "list")
+        {
+            var sv = FindDescendantScrollViewer(TaskList);
+            if (sv is null) return false;
+            // If we want a non-zero offset but the extent hasn't been measured
+            // yet, the request would silently land at 0. Defer and retry.
+            if (s.ListOffset > 0 && sv.ScrollableHeight <= 0) return false;
+            sv.ChangeView(
+                horizontalOffset: null,
+                verticalOffset: Math.Min(s.ListOffset, Math.Max(0, sv.ScrollableHeight)),
+                zoomFactor: null,
+                disableAnimation: true);
+            return true;
+        }
+
+        // Board mode
+        if (s.BoardHorizontalOffset > 0 && BoardView.ScrollableWidth <= 0) return false;
+        BoardView.ChangeView(
+            horizontalOffset: Math.Min(s.BoardHorizontalOffset, Math.Max(0, BoardView.ScrollableWidth)),
+            verticalOffset: null,
+            zoomFactor: null,
+            disableAnimation: true);
+
+        foreach (var col in ViewModel.BoardColumns)
+        {
+            if (!s.BoardColumnOffsets.TryGetValue(col.ColumnName, out var offset)) continue;
+            var container = BoardColumnsControl.ContainerFromItem(col) as DependencyObject;
+            if (container is null) continue;
+            var sv = FindDescendantScrollViewer(container);
+            if (sv is null) continue;
+            sv.ChangeView(
+                horizontalOffset: null,
+                verticalOffset: Math.Min(offset, Math.Max(0, sv.ScrollableHeight)),
+                zoomFactor: null,
+                disableAnimation: true);
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// VisualTreeHelper DFS to find the first <see cref="ScrollViewer"/> descendant
+    /// of <paramref name="root"/>. Returns null if none exists or <paramref name="root"/>
+    /// is null. Used to dig the implicit ScrollViewer out of ListView's template
+    /// and the per-column inner ScrollViewer out of each BoardColumn container.
+    /// </summary>
+    private static ScrollViewer? FindDescendantScrollViewer(DependencyObject? root)
+    {
+        if (root is null) return null;
+        if (root is ScrollViewer sv) return sv;
+        var count = VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+            var found = FindDescendantScrollViewer(child);
+            if (found is not null) return found;
+        }
+        return null;
     }
 }

--- a/src/Glasswork.Core/ViewModels/BacklogViewModel.cs
+++ b/src/Glasswork.Core/ViewModels/BacklogViewModel.cs
@@ -77,6 +77,7 @@ public partial class BacklogViewModel : ObservableObject
     [RelayCommand]
     public void Refresh()
     {
+        Refreshing?.Invoke();
         Tasks.Clear();
         Rows.Clear();
         BoardColumns.Clear();
@@ -244,6 +245,28 @@ public partial class BacklogViewModel : ObservableObject
     /// group headers with the enriched titles.
     /// </summary>
     public event Action? ParentTitlesResolved;
+
+    /// <summary>
+    /// Raised synchronously at the very top of <see cref="Refresh"/>, BEFORE
+    /// any of <see cref="Tasks"/>, <see cref="Rows"/>, or <see cref="BoardColumns"/>
+    /// are cleared. Subscribers can read the pre-refresh state of those collections
+    /// (e.g. to snapshot UI state that depends on them, like <c>ScrollViewer.VerticalOffset</c>
+    /// of a bound <c>ListView</c> or <c>ItemsControl</c>).
+    ///
+    /// Contract (mirrors <see cref="Refreshed"/>):
+    /// <list type="bullet">
+    ///   <item><description>Fires synchronously on whichever thread called
+    ///     <see cref="Refresh"/>. All current call sites invoke <see cref="Refresh"/>
+    ///     on the UI thread; subscribers that touch XAML controls should still
+    ///     verify <c>HasThreadAccess</c> defensively.</description></item>
+    ///   <item><description>Fires exactly once per <see cref="Refresh"/> call,
+    ///     and always BEFORE <see cref="Refreshed"/>.</description></item>
+    ///   <item><description>Subscribers must not throw — an exception will propagate
+    ///     out of <see cref="Refresh"/> and prevent the refresh from running.</description></item>
+    ///   <item><description>Subscribers must not call <see cref="Refresh"/> re-entrantly.</description></item>
+    /// </list>
+    /// </summary>
+    public event Action? Refreshing;
 
     /// <summary>
     /// Raised exactly once at the end of <see cref="Refresh"/> after all collections

--- a/tests/Glasswork.Tests/BacklogViewModelRefreshingEventTests.cs
+++ b/tests/Glasswork.Tests/BacklogViewModelRefreshingEventTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.IO;
+using System.Linq;
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+using Glasswork.ViewModels;
+
+namespace Glasswork.Tests;
+
+/// <summary>
+/// Contract coverage for issue #182: <see cref="BacklogViewModel.Refreshing"/>.
+///
+/// The page hooks this event to snapshot scroll offsets BEFORE the destructive
+/// <c>Clear()</c> inside <see cref="BacklogViewModel.Refresh"/> tears down the
+/// scroll viewer state. The contract these tests pin down:
+///
+/// <list type="bullet">
+///   <item><description><c>Refreshing</c> fires exactly once per
+///     <see cref="BacklogViewModel.Refresh"/> call.</description></item>
+///   <item><description><c>Refreshing</c> fires BEFORE any of <c>Tasks.Clear()</c>,
+///     <c>Rows.Clear()</c>, <c>BoardColumns.Clear()</c> — so subscribers can see
+///     the pre-refresh collection state to capture from.</description></item>
+///   <item><description><c>Refreshing</c> fires BEFORE <c>Refreshed</c>.</description></item>
+///   <item><description>The event fires regardless of how <see cref="BacklogViewModel.Refresh"/>
+///     was invoked — direct call, status command, view-mode change, etc.</description></item>
+/// </list>
+/// </summary>
+[TestClass]
+public class BacklogViewModelRefreshingEventTests
+{
+    private string _tempDir = null!;
+    private VaultService _vault = null!;
+    private TaskService _taskService = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-bvm-refreshing-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _vault = new VaultService(_tempDir);
+        _taskService = new TaskService(_vault);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public void Refresh_RaisesRefreshingExactlyOnce()
+    {
+        _taskService.CreateTask("Task A");
+        var vm = new BacklogViewModel(_vault, _taskService);
+        // VM defaults to list mode — constructor doesn't refresh; subscribe now.
+
+        var count = 0;
+        vm.Refreshing += () => count++;
+
+        vm.Refresh();
+
+        Assert.AreEqual(1, count, "Refreshing should fire exactly once per Refresh() call");
+    }
+
+    [TestMethod]
+    public void Refresh_RaisesRefreshingBeforeRefreshed()
+    {
+        _taskService.CreateTask("Task A");
+        var vm = new BacklogViewModel(_vault, _taskService);
+
+        var sequence = 0;
+        var refreshingOrder = -1;
+        var refreshedOrder = -1;
+        vm.Refreshing += () => refreshingOrder = ++sequence;
+        vm.Refreshed += () => refreshedOrder = ++sequence;
+
+        vm.Refresh();
+
+        Assert.AreEqual(1, refreshingOrder, "Refreshing must fire first");
+        Assert.AreEqual(2, refreshedOrder, "Refreshed must fire second");
+    }
+
+    [TestMethod]
+    public void Refresh_InListMode_Refreshing_FiresBeforeCollectionsAreCleared()
+    {
+        _taskService.CreateTask("Task A");
+        _taskService.CreateTask("Task B");
+        _taskService.CreateTask("Task C");
+
+        var vm = new BacklogViewModel(_vault, _taskService);
+        vm.Refresh(); // prime Tasks/Rows with 3 entries
+
+        var observedTasksCount = -1;
+        var observedRowsCount = -1;
+        vm.Refreshing += () =>
+        {
+            observedTasksCount = vm.Tasks.Count;
+            observedRowsCount = vm.Rows.Count;
+        };
+
+        vm.Refresh();
+
+        Assert.AreEqual(3, observedTasksCount,
+            "Refreshing must fire before Tasks.Clear() — subscriber should still see the 3 pre-refresh tasks");
+        Assert.IsTrue(observedRowsCount >= 3,
+            $"Refreshing must fire before Rows.Clear() — subscriber should see at least the 3 pre-refresh rows " +
+            $"(plus optional group headers), but saw {observedRowsCount}");
+    }
+
+    [TestMethod]
+    public void Refresh_InBoardMode_Refreshing_FiresBeforeCollectionsAreCleared()
+    {
+        _taskService.CreateTask("Task A");
+        var b = _taskService.CreateTask("Task B");
+        _taskService.SetStatus(b, GlassworkTask.Statuses.InProgress);
+
+        var vm = new BacklogViewModel(_vault, _taskService);
+        vm.ViewMode = "board"; // OnViewModeChanged triggers initial board refresh
+        // ViewMode setter already fired Refresh once; BoardColumns is now populated.
+
+        var observedBoardColumnsCount = -1;
+        var observedTotalTasksInColumns = -1;
+        var observedTasksCount = -1;
+        vm.Refreshing += () =>
+        {
+            observedBoardColumnsCount = vm.BoardColumns.Count;
+            observedTotalTasksInColumns = vm.BoardColumns.Sum(c => c.Tasks.Count);
+            observedTasksCount = vm.Tasks.Count;
+        };
+
+        vm.Refresh();
+
+        Assert.AreEqual(2, observedBoardColumnsCount,
+            "Refreshing must fire before BoardColumns.Clear() — subscriber should see the 2 pre-refresh columns");
+        Assert.AreEqual(2, observedTotalTasksInColumns,
+            "Refreshing must fire before column tasks are torn down — subscriber should see both tasks");
+        Assert.AreEqual(2, observedTasksCount,
+            "Refreshing must fire before Tasks.Clear() in board mode too");
+    }
+
+    [TestMethod]
+    public void SetStatusCommand_InListMode_RaisesRefreshingThenRefreshedInOrder()
+    {
+        var a = _taskService.CreateTask("Task A");
+        _taskService.CreateTask("Task B");
+
+        var vm = new BacklogViewModel(_vault, _taskService);
+        vm.Refresh(); // list mode default
+
+        var sequence = 0;
+        var refreshingOrder = -1;
+        var refreshedOrder = -1;
+        vm.Refreshing += () => refreshingOrder = ++sequence;
+        vm.Refreshed += () => refreshedOrder = ++sequence;
+
+        vm.SelectedTask = a;
+        vm.SetStatusCommand.Execute(GlassworkTask.Statuses.Done);
+
+        Assert.AreEqual(1, refreshingOrder,
+            "SetStatusCommand must trigger Refreshing before Refreshed in list mode");
+        Assert.AreEqual(2, refreshedOrder,
+            "SetStatusCommand must fire exactly one Refreshing/Refreshed cycle");
+    }
+
+    [TestMethod]
+    public void SetStatusCommand_InBoardMode_RaisesRefreshingThenRefreshedInOrder()
+    {
+        var a = _taskService.CreateTask("Task A");
+        _taskService.CreateTask("Task B");
+
+        var vm = new BacklogViewModel(_vault, _taskService);
+        vm.ViewMode = "board"; // initial board refresh before we subscribe
+
+        var sequence = 0;
+        var refreshingOrder = -1;
+        var refreshedOrder = -1;
+        vm.Refreshing += () => refreshingOrder = ++sequence;
+        vm.Refreshed += () => refreshedOrder = ++sequence;
+
+        vm.SelectedTask = a;
+        vm.SetStatusCommand.Execute(GlassworkTask.Statuses.Done);
+
+        Assert.AreEqual(1, refreshingOrder,
+            "SetStatusCommand must trigger Refreshing before Refreshed in board mode");
+        Assert.AreEqual(2, refreshedOrder,
+            "SetStatusCommand must fire exactly one Refreshing/Refreshed cycle in board mode");
+    }
+
+    [TestMethod]
+    public void Refresh_WithNoTasks_StillRaisesRefreshing()
+    {
+        // Empty vault sanity: the event must fire even when there's nothing to clear.
+        var vm = new BacklogViewModel(_vault, _taskService);
+
+        var count = 0;
+        vm.Refreshing += () => count++;
+
+        vm.Refresh();
+
+        Assert.AreEqual(1, count, "Refreshing must fire on every Refresh() call, even when the vault is empty");
+    }
+}


### PR DESCRIPTION
BacklogViewModel.Refresh() destructively clears Tasks/Rows/BoardColumns,
which tore down the bound ListView and per-column ScrollViewers,
resetting all scroll offsets to 0. Marking any task done — checkbox or
right-click Mark Done — jumped the view back to the top, making backlog
triage tedious.

Approach (issue #182 option 1, with rubber-duck refinements):

* Add BacklogViewModel.Refreshing event, fired synchronously at the
  top of Refresh() BEFORE any Clear(). Single hook covers every
  refresh path including the partial-method-driven ones from VM
  property setters.

* Page captures a ScrollSnapshot in Refreshing and applies it via
  Low-priority dispatch in Refreshed. The snapshot carries the layout
  context (ViewMode/IsGrouped/FilterStatus) it was captured under; the
  restore callback drops the snapshot if any of those changed — this
  self-invalidates on intentional layout-change paths (view-mode
  toggle, two-way-bound GroupToggle, status filter combo,
  OnNavigatedTo) without a flag-synchronisation dance.

* Capture uses ??= so back-to-back refreshes (file watcher echo,
  parent-title resolution re-render) don't overwrite the user's real
  pre-refresh offset with a post-clear zero.

* Restore uses ScrollViewer.ChangeView(disableAnimation: true) with
  Min-clamp against current Scrollable extent so removed items don't
  leave us pinned beyond the new bottom. TryRestoreWithRetry
  re-queues at Low up to 5 times when extent isn't ready (virtualized
  ListView still measuring) — Low alone is not a reliable layout
  barrier.

* Name the outer board ItemsControl as BoardColumnsControl so each
  column's inner ScrollViewer can be resolved via
  ContainerFromItem(boardColumn) and the VisualTreeHelper helper.

* AddTask_Click explicitly discards the snapshot after Refresh — new
  tasks sort to the top of their priority bucket and the user should
  see them.

Tests:

* BacklogViewModelRefreshingEventTests (new, 7 tests): Refreshing
  fires once per Refresh, fires before Refreshed, fires before
  collection clear in both list and board mode, fires correctly under
  SetStatusCommand in both modes, fires on empty vault.
* Existing BacklogViewModelBoardRefreshTests still pass.

Scroll capture/restore behaviour is verified manually since
Glasswork.App is WinUI 3 / Windows-only and not unit-testable in
isolation.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
