### PR TITLE
perf(index): deepen IndexService into in-memory aggregate with delta channel (#184)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,12 +60,31 @@ The in-memory shape of a task and its subtasks. Pure C# in
 
 ### 3. Index
 
-In-memory aggregate over all tasks. Computes views ("today's tasks",
-"backlog", "completed"), counts, and lookups by id.
+In-memory aggregate over all tasks. Hydrated once at startup from
+`VaultService.LoadAll()`; kept fresh thereafter via two parallel channels:
 
-- **Owns**: `IndexService`, debounced regen on vault change.
-- **Speaks to**: Task Model (consumes), Presentation (queried by pages).
-- **Does not own**: the tasks themselves.
+- **Same-process writes** → `VaultService.TaskWritten` / `TaskDeleted` domain
+  events.
+- **External edits (Obsidian / agents / MCP)** → `FileWatcherService.TaskFileChange`
+  routed to `IndexService.OnFileChangedOnDisk`, which re-parses just the
+  affected file and replaces that one entry. Parse failures keep the prior
+  snapshot intact so partial in-flight writes don't blow away valid state.
+
+Both paths emit a single typed `TasksChanged` delta carrying `Old` + `New`
+snapshots per affected task, so filtered views (My Day, Backlog) can detect
+removal-from-set as well as add and replace. Every query method returns
+**defensive clones** (`GlassworkTask.Clone()`); the canonical store is never
+exposed by reference. The `_index.md` / `_today.md` agent-facing markdown
+surfaces are subscribers on the delta channel (debounced ~500ms), not
+initiators. See ADR 0010 and issue #184.
+
+- **Owns**: `IndexService`, the `TasksChanged` delta channel, the
+  `_index.md` / `_today.md` writers, and the carryover / completed-between /
+  by-id query surface that view models share.
+- **Speaks to**: Task Model (consumes), Vault Sync (subscribes to events,
+  reads on demand), Presentation (queried by pages, raises deltas to them).
+- **Does not own**: the tasks themselves (Vault Sync owns disk truth), nor
+  any UI state.
 
 ### 4. UI State *(new — this slice)*
 

--- a/docs/adr/0010-index-in-memory-aggregate.md
+++ b/docs/adr/0010-index-in-memory-aggregate.md
@@ -1,0 +1,165 @@
+# ADR 0010: Index is an in-memory aggregate with a typed delta channel
+
+**Status**: Accepted
+**Context slice**: `IndexService`, `VaultService`, `FileWatcherService`,
+`SelfWriteCoordinator`, every view model that used to call `VaultService.LoadAll()`.
+
+## Context
+
+Before this slice, `IndexService.Refresh()` was a pass-through: it called
+`VaultService.LoadAll()` and wrote two agent-facing markdown surfaces
+(`_index.md`, `_today.md`). The deep behaviour CONTEXT.md §3 already claimed —
+"here is the current set of tasks, plus deltas when they change" — was nowhere.
+
+The cost showed up in two ways:
+
+1. **Eleven call sites of `LoadAll()`** — every status-bar refresh, every view
+   model `Refresh`, every UI-state GC pass, the MCP server, and the
+   `_indexDebouncer` itself each walked the directory, re-read every `*.md`,
+   and ran `FrontmatterParser.Parse` on each. At ~100 tasks, hundreds of file
+   reads and YAML+markdown parses per call.
+
+2. **Watcher fan-out** — one external task-file change fired
+   `FileWatcherService.TaskFileChanged`, which triggered `_indexDebouncer`
+   *and* fanned out `TaskFileChangedExternally` to every subscribed page.
+   Each page then called its own `Refresh()` → another `LoadAll()`. A single
+   subtask checkbox toggle in Obsidian could produce **4–5 full vault
+   re-reads** on the UI thread or its continuations, even when nothing
+   user-visible had changed.
+
+## Decision
+
+Deepen `IndexService` into the in-memory aggregate it always claimed to be.
+
+### Snapshot store, never shared references
+
+`IndexService` owns `Dictionary<TaskId, GlassworkTask>` guarded by a single
+lock. Every query (`All`, `ById`, `Carryover`, `CompletedBetween`) returns
+**defensive clones** via the new `GlassworkTask.Clone()` method. `GlassworkTask`
+is mutable, `TaskDetailPage` two-way binds to it, and view models hydrate
+transient UI fields (`IsManuallyCollapsed`, `TodaysSubtasks`) onto it —
+sharing the canonical references would let those mutations corrupt the index
+and the delta comparisons. `Clone()` also resets the transient UI fields so
+they never pollute the aggregate.
+
+### Dependency inversion: vault → index, not index → vault.Save
+
+`VaultService` raises `TaskWritten` and `TaskDeleted` domain events after each
+successful disk write (Save and all five targeted edits, plus delete and
+migration). `IndexService` subscribes in app composition (`App.InitVaultServices`).
+
+Persistence is never failed or hung by indexing — `RaiseTaskWritten` /
+`RaiseTaskDeleted` catch subscriber exceptions and log via `Debug.WriteLine`.
+This direction also keeps `VaultService` decoupled from `IndexService` (no
+back-pointer cycle, no nullable injection weakening the boundary).
+
+### Richer watcher seam
+
+`FileWatcherService` now emits a typed `TaskFileChange` payload alongside the
+legacy `TaskFileChanged` string event:
+
+```csharp
+public sealed record TaskFileChange(
+    TaskFileChangeKind Kind, // CreatedOrChanged | Deleted | Renamed
+    string? OldFileName,      // populated for Renamed
+    string  NewFileName);
+```
+
+The Index's `OnFileChangedOnDisk(change)` handles Created/Changed (replace),
+Renamed (remove old id + add new id in a single delta), and Deleted (remove).
+Parse failures from in-flight writes are caught and the prior snapshot is
+left intact.
+
+### MCP coherence — split `SelfWriteCoordinator` predicate
+
+`SelfWriteCoordinator` historically treated **all** recent writes (same-process
+in-memory + cross-process marker file) as suppressed. With an in-memory Index
+in place, cross-process MCP writes would never reach the desktop UI.
+
+The predicate is now split:
+
+- **`IsOwnProcessWrite(path)`** — checks **only** the in-memory dictionary.
+- **`IsSuppressed(path)`** — unchanged broader behaviour (in-memory ∪ marker file).
+
+The Index path consumes the unsuppressed watcher signal so MCP writes refresh
+the UI via the watcher round-trip. The existing "external-edit / conflict
+banner" path keeps using `IsSuppressed` and so still suppresses banners on
+our own cross-process writes.
+
+### Delta payload with `Old` + `New`
+
+```csharp
+public sealed record TaskChange(GlassworkTask? Old, GlassworkTask? New);
+public sealed class TasksChangedEventArgs : EventArgs
+{
+    public required IReadOnlyList<TaskChange> Changes { get; init; }
+    public IEnumerable<GlassworkTask> Added   => ...;
+    public IEnumerable<GlassworkTask> Removed => ...;
+    public IEnumerable<TaskChange>    Changed => ...;
+}
+```
+
+Coarse Added/Changed/Removed lets a filtered view (e.g. My Day) miss a
+removal-from-set when a task's `my_day` is cleared — the new snapshot no
+longer matches the predicate but the page sees no `Removed`. The `Old` + `New`
+shape lets a future optimisation skip pages whose predicate matches neither
+side. v1 view models re-run their predicate on any delta.
+
+### Startup order
+
+`App.InitVaultServices` now:
+
+1. Constructs `VaultService` (no Index dependency).
+2. Runs `Vault.MigrateAllToV2()` — **before** seeding so the Index never
+   holds pre-migration parse artefacts.
+3. Constructs `IndexService(vault)` and `EnsureLoaded()`s it. `EnsureLoaded`
+   does **not** emit a delta — it's a snapshot, not a change.
+4. Constructs `TaskService(Vault, Index)`.
+5. UI-state GC iterates `Index.All` (no disk scan).
+6. Wires `_indexDebouncer` to fire on `Index.TasksChanged` (debounced
+   `_*.md` regeneration).
+7. Starts the watcher; `FileWatcherService.TaskFileChange` →
+   `Index.OnFileChangedOnDisk`.
+
+The legacy `TaskFileChangedExternally` event still fires (driven by the
+string-payload watcher event) so existing page subscribers — `MyDayPage`,
+`BacklogPage`, `TaskDetailPage`, `MainWindow` — keep working. Migrating those
+subscribers to `Index.TasksChanged` directly is a follow-up.
+
+## Consequences
+
+**Leverage** — eleven `LoadAll()` call sites collapsed to in-memory queries.
+Page navigation no longer does disk I/O. The status-bar count is O(1).
+
+**Locality** — "completed-this-week" and "carryover" predicates moved from
+duplicated view-model code into named methods on `IndexService`.
+
+**Testability** — the seam for "which tasks are on My Day" can now be
+seeded in-memory (`new IndexService(vault); idx.EnsureLoaded();` for
+disk-bound tests, or future fixtures that bypass the vault entirely).
+
+**No regression for MCP** — ADR 0007 is unchanged. MCP remains stateless and
+disk-bound; cross-process coherence with the desktop Index is deliberately
+not attempted.
+
+**Concurrency** — the in-memory dictionary is guarded by a single lock;
+queries snapshot + clone under the lock; the `TasksChanged` event is raised
+after the lock is released to avoid re-entrancy deadlocks.
+
+## Alternatives considered
+
+- **Index calls into `VaultService.OnSelfWrite(id)`** — rejected. Creates a
+  cycle, couples persistence success to indexing success, and makes the
+  layering harder to reason about. Domain events go the other way.
+- **Coarse Added/Changed/Removed payload** — rejected. Filtered views need
+  both `Old` and `New` to detect removal-from-set.
+- **Share the Index with MCP via IPC** — rejected (or rather, deferred).
+  Out-of-process coherence is a separate problem; ADR 0007's stateless
+  re-read-per-call model stays intact.
+
+## References
+
+- Issue #184 — "Deepen Index into an in-memory aggregate with delta channel"
+- ADR 0007 — MCP server (kept disk-bound)
+- ADR 0008 — My Day virtual promotion (`MyDayPromotionPolicy` consumes
+  `Index.All`)

--- a/src/Glasswork.App/App.xaml.cs
+++ b/src/Glasswork.App/App.xaml.cs
@@ -241,8 +241,6 @@ public partial class App : Application
 
         SelfWrites = new SelfWriteCoordinator(vaultPath);
         Vault = new VaultService(vaultPath, SelfWrites);
-        Tasks = new TaskService(Vault);
-        Index = new IndexService(Vault);
 
         // FileSystemArtifactStore wants the vault root (the folder containing wiki/todo/),
         // not the todo folder itself. This same path is the root the user has registered
@@ -260,15 +258,26 @@ public partial class App : Application
 
         // One-shot V1 → V2 migration of any pre-existing files. Idempotent: V2 files
         // are skipped, so re-running on every launch is cheap.
+        // IMPORTANT (issue #184): migration MUST run before Index.EnsureLoaded so the
+        // in-memory aggregate is never seeded with pre-migration parse artefacts.
         try { Vault.MigrateAllToV2(); }
         catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"V2 migration failed: {ex.Message}"); }
 
+        // In-memory aggregate (issue #184). Subscribe to vault domain events
+        // BEFORE EnsureLoaded so we still capture writes that happen on the seed
+        // pass (defensive — none expected in practice). EnsureLoaded does not
+        // emit TasksChanged: it's a snapshot, not a delta.
+        Index = new IndexService(Vault);
+        Index.EnsureLoaded();
+        Tasks = new TaskService(Vault, Index);
+
         // GC stale per-task UI state entries (e.g. collapse overrides for tasks the
-        // user has since deleted from the vault). Cheap: O(state) + one vault scan.
+        // user has since deleted from the vault). Cheap: O(state) + one in-memory
+        // index walk (no longer a disk scan, per issue #184).
         try
         {
             var liveIds = new System.Collections.Generic.HashSet<string>(
-                System.Linq.Enumerable.Select(Vault.LoadAll(), t => t.Id),
+                System.Linq.Enumerable.Select(Index.All, t => t.Id),
                 StringComparer.Ordinal);
             uiStateImpl.RemoveKeysNotIn(CollapsedTaskKeyPrefix, liveIds);
             uiStateImpl.Save();
@@ -278,15 +287,29 @@ public partial class App : Application
             System.Diagnostics.Debug.WriteLine($"UI state GC failed: {ex.Message}");
         }
 
-        // File watcher: external (Obsidian / agent) edits to task files trigger
-        // a debounced index regeneration and notify any open page.
+        // _index.md / _today.md regeneration: debounce TasksChanged across rapid
+        // edits and let Index.Refresh re-pull from disk + rewrite the agent-facing
+        // markdown surfaces. Subscribing to Index.TasksChanged (rather than the
+        // raw watcher) means we naturally pick up both same-process writes and
+        // external edits without duplicating the suppression logic.
         _indexDebouncer = new Debouncer(TimeSpan.FromMilliseconds(500), () =>
         {
             try { Index.Refresh(); }
             catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Index refresh failed: {ex.Message}"); }
         });
+        Index.TasksChanged += (_, _) => _indexDebouncer?.Trigger();
 
+        // File watcher: external (Obsidian / agent) edits to task files feed
+        // into Index via the typed event. The legacy string-payload event is
+        // also re-raised on TaskFileChangedExternally so existing page
+        // subscribers (MyDayPage / BacklogPage / TaskDetailPage / MainWindow)
+        // keep working until they migrate to Index.TasksChanged directly.
         Watcher = new FileWatcherService(vaultPath, SelfWrites);
+        Watcher.TaskFileChange += (_, change) =>
+        {
+            try { Index.OnFileChangedOnDisk(change); }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Index.OnFileChangedOnDisk failed: {ex.Message}"); }
+        };
         Watcher.TaskFileChanged += OnTaskFileChanged;
         Watcher.Start();
 
@@ -395,9 +418,9 @@ public partial class App : Application
 
     private static void OnTaskFileChanged(object? sender, string fileName)
     {
-        // Always coalesce index regen across rapid edits.
-        _indexDebouncer?.Trigger();
-        // Fan out to UI subscribers (BacklogPage / MyDayPage / TaskDetailPage).
+        // Index updates are driven via the typed TaskFileChange event handler
+        // (wired in InitVaultServices). This handler only fans out to the
+        // legacy string-payload subscribers (pages) until they migrate.
         TaskFileChangedExternally?.Invoke(sender, fileName);
     }
 }

--- a/src/Glasswork.App/MainWindow.xaml.cs
+++ b/src/Glasswork.App/MainWindow.xaml.cs
@@ -93,7 +93,9 @@ public sealed partial class MainWindow : Window
     {
         try
         {
-            var count = App.Vault?.LoadAll().Count ?? 0;
+            // Status-bar count from the in-memory aggregate (issue #184) —
+            // no disk scan, O(1).
+            var count = App.Index?.Count ?? 0;
             StatusTaskCountText.Text = count == 1 ? "1 task" : $"{count} tasks";
         }
         catch

--- a/src/Glasswork.App/Pages/BacklogPage.xaml.cs
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml.cs
@@ -43,7 +43,7 @@ public sealed partial class BacklogPage : Page
 
     public BacklogPage()
     {
-        ViewModel = new BacklogViewModel(App.Vault, App.Tasks, App.UiState);
+        ViewModel = new BacklogViewModel(App.Vault, App.Tasks, App.Index, App.UiState);
         // Load persisted ViewMode (default "list") BEFORE InitializeComponent
         ViewModel.ViewMode = App.UiState.Get<string>(App.BacklogViewModeKey) ?? "list";
         // Load persisted toggle (default true) BEFORE InitializeComponent so the

--- a/src/Glasswork.App/Pages/MyDayPage.xaml.cs
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml.cs
@@ -18,7 +18,7 @@ public sealed partial class MyDayPage : Page
 
     public MyDayPage()
     {
-        ViewModel = new MyDayViewModel(App.Vault, App.Tasks, App.UiState);
+        ViewModel = new MyDayViewModel(App.Vault, App.Tasks, App.Index, App.UiState);
         InitializeComponent();
     }
 

--- a/src/Glasswork.App/Pages/SettingsPage.xaml.cs
+++ b/src/Glasswork.App/Pages/SettingsPage.xaml.cs
@@ -43,8 +43,8 @@ public sealed partial class SettingsPage : Page
 
         try
         {
-            // Delegate counting to VaultService so the filtering rules stay in one place.
-            var taskCount = App.Vault?.LoadAll().Count ?? 0;
+            // Count via the in-memory aggregate (issue #184) — no disk scan.
+            var taskCount = App.Index?.Count ?? 0;
             var lastWrite = Directory.GetLastWriteTime(path);
             VaultInfoText.Text = $"{taskCount} task file{(taskCount == 1 ? "" : "s")} · last modified {lastWrite:g}";
         }

--- a/src/Glasswork.App/Pages/WorkLogPage.xaml.cs
+++ b/src/Glasswork.App/Pages/WorkLogPage.xaml.cs
@@ -15,7 +15,7 @@ public sealed partial class WorkLogPage : Page
 
     public WorkLogPage()
     {
-        _workLog = new WorkLogService(App.Vault);
+        _workLog = new WorkLogService(App.Vault, App.Index);
         InitializeComponent();
     }
 

--- a/src/Glasswork.App/ViewModels/MyDayViewModel.cs
+++ b/src/Glasswork.App/ViewModels/MyDayViewModel.cs
@@ -11,6 +11,7 @@ public partial class MyDayViewModel : ObservableObject
 {
     private readonly TaskService _taskService;
     private readonly VaultService _vault;
+    private readonly IndexService _index;
     private readonly IUiStateService? _uiState;
 
     public ObservableCollection<GlassworkTask> TodayTasks { get; } = [];
@@ -20,10 +21,21 @@ public partial class MyDayViewModel : ObservableObject
     [ObservableProperty] public partial bool ShowSuggestions { get; set; }
 
     public MyDayViewModel(VaultService vault, TaskService taskService, IUiStateService? uiState = null)
+        : this(vault, taskService, EnsureSeededIndex(vault), uiState) { }
+
+    public MyDayViewModel(VaultService vault, TaskService taskService, IndexService index, IUiStateService? uiState = null)
     {
         _vault = vault;
         _taskService = taskService;
+        _index = index;
         _uiState = uiState;
+    }
+
+    private static IndexService EnsureSeededIndex(VaultService vault)
+    {
+        var idx = new IndexService(vault);
+        idx.EnsureLoaded();
+        return idx;
     }
 
     /// <summary>
@@ -47,7 +59,7 @@ public partial class MyDayViewModel : ObservableObject
         RecentlyCompletedTasks.Clear();
         Suggestions.Clear();
 
-        var all = _vault.LoadAll();
+        var all = _index.All;
         var today = System.DateOnly.FromDateTime(System.DateTime.Today);
 
         // Build the dismissed-today set once so the predicate stays pure.

--- a/src/Glasswork.Core/Models/GlassworkTask.cs
+++ b/src/Glasswork.Core/Models/GlassworkTask.cs
@@ -195,6 +195,77 @@ public partial class GlassworkTask : ObservableObject
     public bool HasTodaysSubtasks => TodaysSubtasks is { Count: > 0 };
 
     /// <summary>
+    /// Returns a deep, defensive copy of this task suitable for storing in (or
+    /// returning from) the in-memory <c>IndexService</c> snapshot store
+    /// (see issue #184). Subtasks, Links, RelatedLinks, Tags, ContextLinks, and
+    /// each subtask's Metadata dictionary are all deep-copied so that mutating
+    /// the clone never affects the original.
+    ///
+    /// Transient UI fields are intentionally **reset** on the clone:
+    /// <list type="bullet">
+    ///   <item><description><see cref="IsManuallyCollapsed"/> — per-page UI state
+    ///     tracked separately in <c>IUiStateService</c>; the Index must not
+    ///     leak it across pages or hydrate stale values into the canonical
+    ///     snapshot.</description></item>
+    ///   <item><description><see cref="TodaysSubtasks"/> — recomputed per
+    ///     My Day refresh from <c>MyDayPromotionPolicy.TodaysSubtasks</c>;
+    ///     storing it on the snapshot would freeze yesterday's promotion
+    ///     into today's view.</description></item>
+    /// </list>
+    /// </summary>
+    public GlassworkTask Clone()
+    {
+        var copy = new GlassworkTask
+        {
+            Id = Id,
+            Title = Title,
+            Status = Status,
+            Priority = Priority,
+            Created = Created,
+            CompletedAt = CompletedAt,
+            Due = Due,
+            MyDay = MyDay,
+            Parent = Parent,
+            Description = Description,
+            Notes = Notes,
+            IsV1Format = IsV1Format,
+            // Transient UI state intentionally not copied — see remarks above.
+        };
+
+        // TaskLink is an immutable record; the references can be shared, but the
+        // List wrapper must be a new instance.
+        copy.Links = [.. Links];
+
+        copy.Tags = [.. Tags];
+        copy.ContextLinks = [.. ContextLinks];
+
+        copy.Subtasks = new List<SubTask>(Subtasks.Count);
+        foreach (var sub in Subtasks)
+        {
+            copy.Subtasks.Add(new SubTask
+            {
+                Text = sub.Text,
+                IsCompleted = sub.IsCompleted,
+                Status = sub.Status,
+                Notes = sub.Notes,
+                Metadata = new Dictionary<string, string>(sub.Metadata),
+            });
+        }
+
+        copy.RelatedLinks = new List<RelatedLink>(RelatedLinks.Count);
+        foreach (var rl in RelatedLinks)
+        {
+            copy.RelatedLinks.Add(new RelatedLink
+            {
+                Slug = rl.Slug,
+                DisplayName = rl.DisplayName,
+            });
+        }
+
+        return copy;
+    }
+
+    /// <summary>
     /// Derived property: reads/writes the first ADO-typed link in <see cref="Links"/>.
     /// Preserves backward compatibility with existing consumers that reference AdoLink directly.
     /// Setting to null removes the ADO link; setting to a value adds or updates it.

--- a/src/Glasswork.Core/Services/FileWatcherService.cs
+++ b/src/Glasswork.Core/Services/FileWatcherService.cs
@@ -14,7 +14,20 @@ public class FileWatcherService : IDisposable
     private readonly string _vaultPath;
     private readonly SelfWriteCoordinator? _selfWrites;
 
+    /// <summary>
+    /// Legacy filename-only event. Fires for create/change/delete/rename of any
+    /// non-underscore <c>*.md</c> file in the vault root that is not currently
+    /// suppressed by the <see cref="SelfWriteCoordinator"/>. New code should
+    /// prefer <see cref="TaskFileChange"/> which carries kind + old name.
+    /// </summary>
     public event EventHandler<string>? TaskFileChanged;
+
+    /// <summary>
+    /// Typed change event (issue #184): carries <see cref="TaskFileChangeKind"/>
+    /// and, for renames, the prior filename. Fires alongside
+    /// <see cref="TaskFileChanged"/> under the same suppression rules.
+    /// </summary>
+    public event EventHandler<TaskFileChange>? TaskFileChange;
 
     public FileWatcherService(string vaultPath) : this(vaultPath, null) { }
 
@@ -32,10 +45,10 @@ public class FileWatcherService : IDisposable
             IncludeSubdirectories = false
         };
 
-        _watcher.Changed += OnFileEvent;
-        _watcher.Created += OnFileEvent;
-        _watcher.Deleted += OnFileEvent;
-        _watcher.Renamed += (s, e) => RaiseEvent(e.FullPath);
+        _watcher.Changed += (s, e) => RaiseEvent(TaskFileChangeKind.CreatedOrChanged, oldPath: null, e.FullPath);
+        _watcher.Created += (s, e) => RaiseEvent(TaskFileChangeKind.CreatedOrChanged, oldPath: null, e.FullPath);
+        _watcher.Deleted += (s, e) => RaiseEvent(TaskFileChangeKind.Deleted, oldPath: null, e.FullPath);
+        _watcher.Renamed += (s, e) => RaiseEvent(TaskFileChangeKind.Renamed, e.OldFullPath, e.FullPath);
     }
 
     public void Start() => _watcher.EnableRaisingEvents = true;
@@ -44,19 +57,24 @@ public class FileWatcherService : IDisposable
 
     public bool IsWatching => _watcher.EnableRaisingEvents;
 
-    private void OnFileEvent(object sender, FileSystemEventArgs e) => RaiseEvent(e.FullPath);
-
-    private void RaiseEvent(string fullPath)
+    private void RaiseEvent(TaskFileChangeKind kind, string? oldPath, string newPath)
     {
-        var fileName = Path.GetFileName(fullPath);
+        var newFileName = Path.GetFileName(newPath);
         // Skip index/schema files
-        if (fileName.StartsWith("_")) return;
+        if (newFileName.StartsWith('_')) return;
 
         // Skip events caused by our own writes (e.g. VaultService.Save) — otherwise
         // every Field_LostFocus → Save round-trips into a false-positive reload banner.
-        if (_selfWrites?.IsSuppressed(fullPath) == true) return;
+        if (_selfWrites?.IsSuppressed(newPath) == true) return;
 
-        TaskFileChanged?.Invoke(this, fileName);
+        var oldFileName = oldPath is null ? null : Path.GetFileName(oldPath);
+        // Rename: if the old name was suppressed (rare — typically only the new
+        // path is registered), still consider the new-path suppression rule the
+        // authoritative one. Old-name suppression alone shouldn't prevent the
+        // event because the new path is the live one.
+
+        TaskFileChanged?.Invoke(this, newFileName);
+        TaskFileChange?.Invoke(this, new TaskFileChange(kind, oldFileName, newFileName));
     }
 
     public void Dispose()

--- a/src/Glasswork.Core/Services/FileWatcherService.cs
+++ b/src/Glasswork.Core/Services/FileWatcherService.cs
@@ -63,18 +63,26 @@ public class FileWatcherService : IDisposable
         // Skip index/schema files
         if (newFileName.StartsWith('_')) return;
 
-        // Skip events caused by our own writes (e.g. VaultService.Save) — otherwise
-        // every Field_LostFocus → Save round-trips into a false-positive reload banner.
-        if (_selfWrites?.IsSuppressed(newPath) == true) return;
-
         var oldFileName = oldPath is null ? null : Path.GetFileName(oldPath);
-        // Rename: if the old name was suppressed (rare — typically only the new
-        // path is registered), still consider the new-path suppression rule the
-        // authoritative one. Old-name suppression alone shouldn't prevent the
-        // event because the new path is the live one.
 
-        TaskFileChanged?.Invoke(this, newFileName);
-        TaskFileChange?.Invoke(this, new TaskFileChange(kind, oldFileName, newFileName));
+        // Two suppression rules — see ADR 0010 §"SelfWriteCoordinator split":
+        //
+        //  * IsOwnProcessWrite — only same-process VaultService.Save echoes. Used
+        //    to gate the typed TaskFileChange event so the IndexService still sees
+        //    cross-process MCP edits and refreshes the UI via the watcher path.
+        //
+        //  * IsSuppressed — same-process AND cross-process (marker-file) writes.
+        //    Used to gate the legacy TaskFileChanged event whose downstream
+        //    consumers (conflict banner, "external edit" reload prompt) must NOT
+        //    fire for coordinated MCP writes.
+        var isOwn = _selfWrites?.IsOwnProcessWrite(newPath) == true;
+        var isSuppressed = _selfWrites?.IsSuppressed(newPath) == true;
+
+        if (!isSuppressed)
+            TaskFileChanged?.Invoke(this, newFileName);
+
+        if (!isOwn)
+            TaskFileChange?.Invoke(this, new TaskFileChange(kind, oldFileName, newFileName));
     }
 
     public void Dispose()

--- a/src/Glasswork.Core/Services/IndexService.cs
+++ b/src/Glasswork.Core/Services/IndexService.cs
@@ -272,25 +272,20 @@ public class IndexService
     // ── Legacy disk-writer surface (preserved for existing callers) ───────
 
     /// <summary>
-    /// Regenerate both <c>_index.md</c> and <c>_today.md</c> from a freshly-reloaded
-    /// view of the vault. Pre-issue-#184 behaviour. Existing callers
-    /// (notably <c>App._indexDebouncer</c>) drive this; new code should rely on
-    /// <see cref="TasksChanged"/> instead.
+    /// Regenerate both <c>_index.md</c> and <c>_today.md</c> from the current
+    /// in-memory snapshot. The in-memory store is now authoritative (issue #184),
+    /// so this method no longer reloads from disk — that would risk silently
+    /// dropping tasks that failed to parse mid-write while emitting no delta.
+    /// If the store has not been hydrated yet, <see cref="EnsureLoaded"/> runs
+    /// first. Existing callers (notably <c>App._indexDebouncer</c>) drive this;
+    /// new code should rely on <see cref="TasksChanged"/> instead.
     /// </summary>
     public void Refresh()
     {
-        // Force a full reload from disk — the in-memory store may be stale relative
-        // to cross-process edits if the watcher path is racing with this call.
+        EnsureLoaded();
         List<GlassworkTask> snapshot;
         lock (_gate)
         {
-            _store.Clear();
-            foreach (var t in _vault.LoadAll())
-            {
-                if (!string.IsNullOrEmpty(t.Id))
-                    _store[t.Id] = t;
-            }
-            _loaded = true;
             snapshot = _store.Values.Select(t => t.Clone()).ToList();
         }
         WriteIndex(snapshot);

--- a/src/Glasswork.Core/Services/IndexService.cs
+++ b/src/Glasswork.Core/Services/IndexService.cs
@@ -8,27 +8,293 @@ using Glasswork.Core.Models;
 namespace Glasswork.Core.Services;
 
 /// <summary>
-/// Auto-generates _index.md (full task manifest) and _today.md (My Day snapshot)
-/// in the vault directory. These files are the agent-readable surfaces.
+/// In-memory aggregate over all tasks in the vault (issue #184).
+///
+/// Owns the canonical <c>Dictionary&lt;TaskId, GlassworkTask&gt;</c> snapshot
+/// store and a typed delta channel (<see cref="TasksChanged"/>). Hydrated once
+/// at startup via <see cref="EnsureLoaded"/> from <see cref="VaultService.LoadAll"/>;
+/// kept fresh thereafter via two parallel paths:
+///
+/// <list type="bullet">
+///   <item><description><b>Same-process writes</b> arrive via the
+///   <see cref="VaultService.TaskWritten"/> and <see cref="VaultService.TaskDeleted"/>
+///   domain events. The index re-parses the file (or removes the entry) and
+///   emits a delta.</description></item>
+///   <item><description><b>Cross-process / external edits</b> arrive via
+///   <see cref="OnFileChangedOnDisk"/>, which the app wires to
+///   <see cref="FileWatcherService.TaskFileChange"/>. The same re-parse-and-delta
+///   path runs, with kind-aware handling for Created/Changed/Renamed/Deleted
+///   and a parse-failure policy that <b>keeps the prior snapshot</b> so partial
+///   in-flight writes don't blow away valid state.</description></item>
+/// </list>
+///
+/// Every query method returns <b>defensive clones</b> via
+/// <see cref="GlassworkTask.Clone"/>; subscribers and view models may mutate the
+/// returned objects (and they do — UI two-way bindings, transient promotion
+/// state, etc.) without ever affecting the canonical store.
+///
+/// The legacy <see cref="Refresh"/> entry point — which re-reads from disk and
+/// regenerates <c>_index.md</c> / <c>_today.md</c> — is preserved for existing
+/// callers and tests.
 /// </summary>
 public class IndexService
 {
     private readonly VaultService _vault;
+    private readonly Dictionary<string, GlassworkTask> _store = new(StringComparer.Ordinal);
+    private readonly object _gate = new();
+    private bool _loaded;
+
+    /// <summary>
+    /// Raised after the in-memory store has been mutated by a vault event or
+    /// a watcher-observed file change. Carries old+new snapshots so filtered
+    /// views can detect removal-from-set. Subscribers may throw — exceptions
+    /// are caught and logged.
+    /// </summary>
+    public event EventHandler<TasksChangedEventArgs>? TasksChanged;
 
     public IndexService(VaultService vault)
     {
         _vault = vault;
+        _vault.TaskWritten += OnVaultTaskWritten;
+        _vault.TaskDeleted += OnVaultTaskDeleted;
+    }
+
+    /// <summary>Number of tasks currently held in the in-memory store.</summary>
+    public int Count
+    {
+        get { lock (_gate) { return _store.Count; } }
     }
 
     /// <summary>
-    /// Regenerate both _index.md and _today.md from the current task files.
-    /// Call this after any task create/update/delete.
+    /// Snapshot of every task in the index, as defensive clones. Mutating any
+    /// element does not affect the canonical store.
+    /// </summary>
+    public IReadOnlyList<GlassworkTask> All
+    {
+        get
+        {
+            lock (_gate)
+            {
+                var list = new List<GlassworkTask>(_store.Count);
+                foreach (var t in _store.Values) list.Add(t.Clone());
+                return list;
+            }
+        }
+    }
+
+    /// <summary>Defensive-clone lookup; <c>null</c> when the id is unknown.</summary>
+    public GlassworkTask? ById(string id)
+    {
+        lock (_gate)
+        {
+            return _store.TryGetValue(id, out var t) ? t.Clone() : null;
+        }
+    }
+
+    /// <summary>
+    /// Hydrate the in-memory store from <see cref="VaultService.LoadAll"/>.
+    /// Idempotent. Intentionally does <b>not</b> raise <see cref="TasksChanged"/> —
+    /// this is a snapshot, not a delta. Call once during app startup
+    /// (<c>App.InitVaultServices</c>) after migration completes and before any
+    /// page subscribes.
+    /// </summary>
+    public void EnsureLoaded()
+    {
+        lock (_gate)
+        {
+            if (_loaded) return;
+            _store.Clear();
+            foreach (var t in _vault.LoadAll())
+            {
+                if (!string.IsNullOrEmpty(t.Id))
+                    _store[t.Id] = t;
+            }
+            _loaded = true;
+        }
+    }
+
+    /// <summary>
+    /// Apply a watcher-observed task-file change to the in-memory store and emit
+    /// the corresponding <see cref="TasksChanged"/> delta. Safe to call before
+    /// <see cref="EnsureLoaded"/> — it will trigger the load first.
+    /// </summary>
+    public void OnFileChangedOnDisk(TaskFileChange change)
+    {
+        EnsureLoaded();
+
+        var newId = Path.GetFileNameWithoutExtension(change.NewFileName);
+        var changes = new List<TaskChange>();
+
+        switch (change.Kind)
+        {
+            case TaskFileChangeKind.Deleted:
+                RemoveSnapshot(newId, changes);
+                break;
+
+            case TaskFileChangeKind.Renamed:
+                var oldId = change.OldFileName is null
+                    ? null
+                    : Path.GetFileNameWithoutExtension(change.OldFileName);
+                if (!string.IsNullOrEmpty(oldId) && oldId != newId)
+                    RemoveSnapshot(oldId, changes);
+                ReplaceSnapshotFromDisk(newId, changes);
+                break;
+
+            case TaskFileChangeKind.CreatedOrChanged:
+            default:
+                ReplaceSnapshotFromDisk(newId, changes);
+                break;
+        }
+
+        if (changes.Count > 0)
+            RaiseTasksChanged(changes);
+    }
+
+    private void OnVaultTaskWritten(object? sender, string taskId)
+    {
+        EnsureLoaded();
+        var changes = new List<TaskChange>();
+        ReplaceSnapshotFromDisk(taskId, changes);
+        if (changes.Count > 0)
+            RaiseTasksChanged(changes);
+    }
+
+    private void OnVaultTaskDeleted(object? sender, string taskId)
+    {
+        EnsureLoaded();
+        var changes = new List<TaskChange>();
+        RemoveSnapshot(taskId, changes);
+        if (changes.Count > 0)
+            RaiseTasksChanged(changes);
+    }
+
+    /// <summary>
+    /// Parse the file for <paramref name="taskId"/> via <see cref="VaultService.Load"/>
+    /// and replace the snapshot. Parse failures are caught and the prior
+    /// snapshot is left intact (handles partial in-flight writes from Obsidian /
+    /// agents). Appends a <see cref="TaskChange"/> entry on success.
+    /// </summary>
+    private void ReplaceSnapshotFromDisk(string taskId, List<TaskChange> changes)
+    {
+        if (string.IsNullOrEmpty(taskId)) return;
+
+        GlassworkTask? parsed;
+        try
+        {
+            parsed = _vault.Load(taskId);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"IndexService: failed to parse '{taskId}', keeping prior snapshot: {ex.Message}");
+            return;
+        }
+
+        if (parsed is null) return;
+
+        GlassworkTask? oldEntry;
+        GlassworkTask newEntry;
+        lock (_gate)
+        {
+            _store.TryGetValue(taskId, out oldEntry);
+            _store[taskId] = parsed;
+            // Clone OUTSIDE the lock? Cheap enough to do under it; avoids racing
+            // with another mutation. Then we hand the clones out.
+            newEntry = parsed.Clone();
+        }
+        changes.Add(new TaskChange(oldEntry?.Clone(), newEntry));
+    }
+
+    private void RemoveSnapshot(string taskId, List<TaskChange> changes)
+    {
+        if (string.IsNullOrEmpty(taskId)) return;
+
+        GlassworkTask? oldEntry;
+        lock (_gate)
+        {
+            if (!_store.TryGetValue(taskId, out oldEntry)) return;
+            _store.Remove(taskId);
+        }
+        changes.Add(new TaskChange(oldEntry.Clone(), null));
+    }
+
+    private void RaiseTasksChanged(IReadOnlyList<TaskChange> changes)
+    {
+        try
+        {
+            TasksChanged?.Invoke(this, new TasksChangedEventArgs { Changes = changes });
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"IndexService.TasksChanged subscriber threw: {ex}");
+        }
+    }
+
+    // ── Query helpers (move targets for the existing LoadAll fan-out) ─────
+
+    /// <summary>
+    /// Tasks that were pinned to a previous day's <c>my_day</c> and are still not done
+    /// today. Used by the My Day "carry over yesterday's stragglers" affordance.
+    /// </summary>
+    public IReadOnlyList<GlassworkTask> Carryover(DateTime today)
+    {
+        var todayDate = today.Date;
+        lock (_gate)
+        {
+            return _store.Values
+                .Where(t => t.MyDay.HasValue
+                         && t.MyDay.Value.Date < todayDate
+                         && t.Status != GlassworkTask.Statuses.Done)
+                .Select(t => t.Clone())
+                .ToList();
+        }
+    }
+
+    /// <summary>
+    /// Tasks completed within the half-open range <c>[from, to)</c>. Powers
+    /// <see cref="WorkLogService"/>'s weekly digest.
+    /// </summary>
+    public IReadOnlyList<GlassworkTask> CompletedBetween(DateTime from, DateTime to)
+    {
+        lock (_gate)
+        {
+            return _store.Values
+                .Where(t => t.Status == GlassworkTask.Statuses.Done
+                         && t.CompletedAt.HasValue
+                         && t.CompletedAt.Value >= from
+                         && t.CompletedAt.Value < to)
+                .OrderBy(t => t.CompletedAt)
+                .Select(t => t.Clone())
+                .ToList();
+        }
+    }
+
+    // ── Legacy disk-writer surface (preserved for existing callers) ───────
+
+    /// <summary>
+    /// Regenerate both <c>_index.md</c> and <c>_today.md</c> from a freshly-reloaded
+    /// view of the vault. Pre-issue-#184 behaviour. Existing callers
+    /// (notably <c>App._indexDebouncer</c>) drive this; new code should rely on
+    /// <see cref="TasksChanged"/> instead.
     /// </summary>
     public void Refresh()
     {
-        var tasks = _vault.LoadAll();
-        WriteIndex(tasks);
-        WriteToday(tasks);
+        // Force a full reload from disk — the in-memory store may be stale relative
+        // to cross-process edits if the watcher path is racing with this call.
+        List<GlassworkTask> snapshot;
+        lock (_gate)
+        {
+            _store.Clear();
+            foreach (var t in _vault.LoadAll())
+            {
+                if (!string.IsNullOrEmpty(t.Id))
+                    _store[t.Id] = t;
+            }
+            _loaded = true;
+            snapshot = _store.Values.Select(t => t.Clone()).ToList();
+        }
+        WriteIndex(snapshot);
+        WriteToday(snapshot);
     }
 
     private void WriteIndex(List<GlassworkTask> tasks)
@@ -46,7 +312,6 @@ public class IndexService
         sb.AppendLine("> Auto-generated by Glasswork. Do not edit manually.");
         sb.AppendLine();
 
-        // Group by status
         WriteStatusSection(sb, "In Progress", tasks.Where(t => t.Status == GlassworkTask.Statuses.InProgress));
         WriteStatusSection(sb, "Todo", tasks.Where(t => t.Status == GlassworkTask.Statuses.Todo));
         WriteStatusSection(sb, "Done (Recent)", tasks
@@ -132,9 +397,6 @@ public class IndexService
         sb.AppendLine();
     }
 
-    /// <summary>
-    /// Compact progress hint per parent task (e.g. "4/8 subtasks done"). Empty when no subtasks.
-    /// </summary>
     private static string SubtaskProgress(GlassworkTask t)
     {
         var total = t.Subtasks.Count;

--- a/src/Glasswork.Core/Services/SelfWriteCoordinator.cs
+++ b/src/Glasswork.Core/Services/SelfWriteCoordinator.cs
@@ -62,16 +62,33 @@ public class SelfWriteCoordinator
         if (string.IsNullOrEmpty(fullPath)) return false;
 
         // Fast path: check in-memory dictionary first (same-process writes).
+        if (IsOwnProcessWrite(fullPath)) return true;
+
+        // Cross-process path: consult the vault-local marker file.
+        if (_markerFilePath != null)
+            return CheckMarkerFile(fullPath);
+
+        return false;
+    }
+
+    /// <summary>
+    /// True only if **this process** registered the write (within TTL); ignores the
+    /// cross-process marker file. Use this for callers that need to update their
+    /// in-memory state from cross-process writes (e.g. <c>IndexService</c> consuming
+    /// watcher events from MCP edits) while leaving the broader
+    /// <see cref="IsSuppressed"/> predicate available for the existing
+    /// external-edit / conflict-banner suppression path. See issue #184.
+    /// </summary>
+    public bool IsOwnProcessWrite(string fullPath)
+    {
+        if (string.IsNullOrEmpty(fullPath)) return false;
+
         if (_recentWrites.TryGetValue(fullPath, out var when))
         {
             if (DateTime.UtcNow - when <= _ttl) return true;
             // Expired — drop it so the dictionary doesn't grow unbounded.
             _recentWrites.TryRemove(fullPath, out _);
         }
-
-        // Cross-process path: consult the vault-local marker file.
-        if (_markerFilePath != null)
-            return CheckMarkerFile(fullPath);
 
         return false;
     }

--- a/src/Glasswork.Core/Services/TaskFileChange.cs
+++ b/src/Glasswork.Core/Services/TaskFileChange.cs
@@ -1,0 +1,30 @@
+namespace Glasswork.Core.Services;
+
+/// <summary>
+/// Kind of task-file change observed by <see cref="FileWatcherService"/>.
+/// Surfaced via <see cref="FileWatcherService.TaskFileChange"/> so consumers
+/// (notably <c>IndexService</c>, issue #184) can react correctly to deletes
+/// and renames instead of having to infer them from a bare filename.
+/// </summary>
+public enum TaskFileChangeKind
+{
+    /// <summary>File was created or modified.</summary>
+    CreatedOrChanged,
+
+    /// <summary>File was deleted.</summary>
+    Deleted,
+
+    /// <summary>File was renamed. <see cref="TaskFileChange.OldFileName"/> carries the prior name.</summary>
+    Renamed,
+}
+
+/// <summary>
+/// A typed task-file change event payload. <see cref="OldFileName"/> is only set
+/// for <see cref="TaskFileChangeKind.Renamed"/>; for create/change/delete it is
+/// <c>null</c>. <see cref="NewFileName"/> is the current filename (post-rename
+/// for renames, the deleted filename for deletes).
+/// </summary>
+public sealed record TaskFileChange(
+    TaskFileChangeKind Kind,
+    string? OldFileName,
+    string NewFileName);

--- a/src/Glasswork.Core/Services/TaskService.cs
+++ b/src/Glasswork.Core/Services/TaskService.cs
@@ -12,10 +12,14 @@ namespace Glasswork.Core.Services;
 public class TaskService
 {
     private readonly VaultService _vault;
+    private readonly IndexService? _index;
 
-    public TaskService(VaultService vault)
+    public TaskService(VaultService vault) : this(vault, null) { }
+
+    public TaskService(VaultService vault, IndexService? index)
     {
         _vault = vault;
+        _index = index;
     }
 
     /// <summary>
@@ -84,6 +88,11 @@ public class TaskService
     /// </summary>
     public List<GlassworkTask> GetCarryoverTasks()
     {
+        // Prefer the in-memory aggregate (issue #184). Fall back to the disk
+        // scan when no Index was provided (legacy unit-test paths).
+        if (_index is not null)
+            return _index.Carryover(DateTime.Today).ToList();
+
         return _vault.LoadAll()
             .Where(t => t.MyDay.HasValue
                         && t.MyDay.Value.Date < DateTime.Today

--- a/src/Glasswork.Core/Services/TasksChangedEventArgs.cs
+++ b/src/Glasswork.Core/Services/TasksChangedEventArgs.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Glasswork.Core.Models;
+
+namespace Glasswork.Core.Services;
+
+/// <summary>
+/// A single task-level change observed by <see cref="IndexService"/>:
+/// <list type="bullet">
+///   <item><description><see cref="Old"/> = <c>null</c>, <see cref="New"/> = task ⇒ <b>added</b>.</description></item>
+///   <item><description><see cref="Old"/> = task, <see cref="New"/> = <c>null</c> ⇒ <b>removed</b>.</description></item>
+///   <item><description>Both non-null ⇒ <b>changed</b>.</description></item>
+/// </list>
+/// Both <see cref="Old"/> and <see cref="New"/> are <b>defensive clones</b> from the
+/// index store; subscribers may inspect (and even mutate) them without affecting
+/// the canonical aggregate.
+/// </summary>
+public sealed record TaskChange(GlassworkTask? Old, GlassworkTask? New);
+
+/// <summary>
+/// Event payload for <see cref="IndexService.TasksChanged"/>. A single fire can
+/// carry multiple <see cref="TaskChange"/> entries (e.g. a rename emits one
+/// removal of the old id + one addition of the new id together).
+/// </summary>
+public sealed class TasksChangedEventArgs : EventArgs
+{
+    public required IReadOnlyList<TaskChange> Changes { get; init; }
+
+    /// <summary>Tasks that did not exist in the index before this delta.</summary>
+    public IEnumerable<GlassworkTask> Added =>
+        Changes.Where(c => c.Old is null && c.New is not null).Select(c => c.New!);
+
+    /// <summary>Tasks that were removed from the index by this delta. Ids only via <c>Old.Id</c>.</summary>
+    public IEnumerable<GlassworkTask> Removed =>
+        Changes.Where(c => c.New is null && c.Old is not null).Select(c => c.Old!);
+
+    /// <summary>Tasks that already existed and were replaced. Carry both <c>Old</c> and <c>New</c> snapshots.</summary>
+    public IEnumerable<TaskChange> Changed =>
+        Changes.Where(c => c.Old is not null && c.New is not null);
+}

--- a/src/Glasswork.Core/Services/VaultService.cs
+++ b/src/Glasswork.Core/Services/VaultService.cs
@@ -31,6 +31,38 @@ public class VaultService
     public string VaultPath => _vaultPath;
 
     /// <summary>
+    /// Raised after a successful task-file write (Save or any targeted edit).
+    /// Argument is the task id. Subscribers may throw — exceptions are caught
+    /// and logged so persistence is never affected by indexing or other
+    /// downstream failures (issue #184).
+    /// </summary>
+    public event EventHandler<string>? TaskWritten;
+
+    /// <summary>
+    /// Raised after a successful task-file deletion. Argument is the task id.
+    /// Same exception-isolation contract as <see cref="TaskWritten"/>.
+    /// </summary>
+    public event EventHandler<string>? TaskDeleted;
+
+    private void RaiseTaskWritten(string taskId)
+    {
+        try { TaskWritten?.Invoke(this, taskId); }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"TaskWritten subscriber threw for {taskId}: {ex}");
+        }
+    }
+
+    private void RaiseTaskDeleted(string taskId)
+    {
+        try { TaskDeleted?.Invoke(this, taskId); }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"TaskDeleted subscriber threw for {taskId}: {ex}");
+        }
+    }
+
+    /// <summary>
     /// Load all tasks from the vault directory.
     /// Skips files starting with _ (index, today, schema).
     /// </summary>
@@ -92,6 +124,7 @@ public class VaultService
         {
             _selfWrites?.RegisterWrite(path);
             File.WriteAllText(path, updated);
+            RaiseTaskWritten(taskId);
         }
     }
 
@@ -156,6 +189,7 @@ public class VaultService
             rebuilt += newline;
         _selfWrites?.RegisterWrite(path);
         File.WriteAllText(path, rebuilt);
+        RaiseTaskWritten(taskId);
     }
 
     /// <summary>
@@ -225,6 +259,7 @@ public class VaultService
             rebuilt += newline;
         _selfWrites?.RegisterWrite(path);
         File.WriteAllText(path, rebuilt);
+        RaiseTaskWritten(taskId);
     }
 
     /// <summary>
@@ -294,6 +329,7 @@ public class VaultService
 
         _selfWrites?.RegisterWrite(path);
         File.WriteAllText(path, output);
+        RaiseTaskWritten(taskId);
     }
 
     /// <summary>
@@ -353,6 +389,7 @@ public class VaultService
 
         _selfWrites?.RegisterWrite(path);
         File.WriteAllText(path, output);
+        RaiseTaskWritten(taskId);
     }
 
     /// <summary>
@@ -476,6 +513,7 @@ public class VaultService
 
         _selfWrites?.RegisterWrite(path);
         File.WriteAllText(path, rebuilt);
+        RaiseTaskWritten(taskId);
     }
 
     /// <summary>
@@ -490,6 +528,7 @@ public class VaultService
         var path = GetFilePath(task.Id);
         _selfWrites?.RegisterWrite(path);
         File.WriteAllText(path, content);
+        RaiseTaskWritten(task.Id);
     }
 
     /// <summary>
@@ -541,6 +580,7 @@ public class VaultService
 
         _selfWrites?.RegisterWrite(path);
         File.WriteAllText(path, migrated);
+        RaiseTaskWritten(taskId);
         return true;
     }
 
@@ -570,6 +610,7 @@ public class VaultService
 
             _selfWrites?.RegisterWrite(path);
             File.WriteAllText(path, migratedContent);
+            RaiseTaskWritten(Path.GetFileNameWithoutExtension(path));
             migrated++;
         }
         return migrated;
@@ -585,6 +626,7 @@ public class VaultService
 
         _selfWrites?.RegisterWrite(filePath);
         File.Delete(filePath);
+        RaiseTaskDeleted(taskId);
         return true;
     }
 

--- a/src/Glasswork.Core/Services/WorkLogService.cs
+++ b/src/Glasswork.Core/Services/WorkLogService.cs
@@ -13,10 +13,14 @@ namespace Glasswork.Core.Services;
 public class WorkLogService
 {
     private readonly VaultService _vault;
+    private readonly IndexService? _index;
 
-    public WorkLogService(VaultService vault)
+    public WorkLogService(VaultService vault) : this(vault, null) { }
+
+    public WorkLogService(VaultService vault, IndexService? index)
     {
         _vault = vault;
+        _index = index;
     }
 
     /// <summary>
@@ -27,13 +31,18 @@ public class WorkLogService
     {
         var weekEnd = weekStart.AddDays(7);
 
-        var completed = _vault.LoadAll()
-            .Where(t => t.Status == GlassworkTask.Statuses.Done
-                        && t.CompletedAt.HasValue
-                        && t.CompletedAt.Value >= weekStart
-                        && t.CompletedAt.Value < weekEnd)
-            .OrderBy(t => t.CompletedAt)
-            .ToList();
+        // Prefer the in-memory aggregate (issue #184). The Index returns the
+        // completed window already filtered + ordered. Fall back to a disk
+        // scan when running in a legacy ctor (e.g. unit tests).
+        var completed = _index is not null
+            ? _index.CompletedBetween(weekStart, weekEnd).ToList()
+            : _vault.LoadAll()
+                .Where(t => t.Status == GlassworkTask.Statuses.Done
+                            && t.CompletedAt.HasValue
+                            && t.CompletedAt.Value >= weekStart
+                            && t.CompletedAt.Value < weekEnd)
+                .OrderBy(t => t.CompletedAt)
+                .ToList();
 
         var sb = new StringBuilder();
         sb.AppendLine($"# Work Log: Week of {weekStart:yyyy-MM-dd}");

--- a/src/Glasswork.Core/ViewModels/BacklogViewModel.cs
+++ b/src/Glasswork.Core/ViewModels/BacklogViewModel.cs
@@ -67,11 +67,24 @@ public partial class BacklogViewModel : ObservableObject
     [ObservableProperty] public partial bool IsGrouped { get; set; } = true;
     [ObservableProperty] public partial string ViewMode { get; set; } = "list"; // "list" | "board"
 
+    private readonly IndexService _index;
+
     public BacklogViewModel(VaultService vault, TaskService taskService, IUiStateService? uiState = null)
+        : this(vault, taskService, EnsureSeededIndex(vault), uiState) { }
+
+    public BacklogViewModel(VaultService vault, TaskService taskService, IndexService index, IUiStateService? uiState = null)
     {
         _vault = vault;
         _taskService = taskService;
+        _index = index;
         _parentTitleStore = uiState is null ? null : new AdoParentTitleCacheStore(uiState);
+    }
+
+    private static IndexService EnsureSeededIndex(VaultService vault)
+    {
+        var idx = new IndexService(vault);
+        idx.EnsureLoaded();
+        return idx;
     }
 
     [RelayCommand]
@@ -81,7 +94,7 @@ public partial class BacklogViewModel : ObservableObject
         Tasks.Clear();
         Rows.Clear();
         BoardColumns.Clear();
-        var all = _vault.LoadAll();
+        var all = _index.All;
 
         if (ViewMode == "board")
         {

--- a/tests/Glasswork.Tests/FileWatcherServiceTests.cs
+++ b/tests/Glasswork.Tests/FileWatcherServiceTests.cs
@@ -262,8 +262,51 @@ public class FileWatcherServiceTests
         File.WriteAllText(path, "x");
 
         Assert.IsFalse(signal.Wait(TimeSpan.FromSeconds(2)),
-            "Typed event must respect SelfWriteCoordinator suppression like the legacy event.");
+            "Typed event must suppress same-process writes (IsOwnProcessWrite).");
         Assert.IsNull(observed);
+    }
+
+    [TestMethod]
+    public void TypedEvent_FiresForCrossProcessWrites_RegisteredOnlyInMarkerFile()
+    {
+        // Two coordinators sharing the same vault simulate two processes
+        // (e.g. desktop app + MCP server). Process B's RegisterWrite updates
+        // the marker file but NOT process A's in-memory dictionary, so
+        // A's watcher should still emit the typed event so its IndexService
+        // can refresh.
+        var coordA = new SelfWriteCoordinator(_tempDir, TimeSpan.FromSeconds(2));
+        var coordB = new SelfWriteCoordinator(_tempDir, TimeSpan.FromSeconds(2));
+        using var watcher = new FileWatcherService(_tempDir, coordA);
+
+        TaskFileChange? typedObserved = null;
+        string? legacyObserved = null;
+        var typedSignal = new ManualResetEventSlim(false);
+        var legacySignal = new ManualResetEventSlim(false);
+
+        watcher.TaskFileChange += (_, change) =>
+        {
+            typedObserved = change;
+            typedSignal.Set();
+        };
+        watcher.TaskFileChanged += (_, name) =>
+        {
+            legacyObserved = name;
+            legacySignal.Set();
+        };
+
+        watcher.Start();
+        var path = Path.Combine(_tempDir, "cross-process.md");
+        coordB.RegisterWrite(path); // updates marker file only, not coordA's memory
+        File.WriteAllText(path, "x");
+
+        Assert.IsTrue(typedSignal.Wait(TimeSpan.FromSeconds(2)),
+            "Typed TaskFileChange must fire for cross-process writes so IndexService can refresh.");
+        Assert.IsNotNull(typedObserved);
+        Assert.AreEqual("cross-process.md", typedObserved!.NewFileName);
+
+        Assert.IsFalse(legacySignal.Wait(TimeSpan.FromMilliseconds(500)),
+            "Legacy TaskFileChanged must remain suppressed for coordinated cross-process writes so the conflict banner does not fire.");
+        Assert.IsNull(legacyObserved);
     }
 
     [TestMethod]

--- a/tests/Glasswork.Tests/FileWatcherServiceTests.cs
+++ b/tests/Glasswork.Tests/FileWatcherServiceTests.cs
@@ -153,4 +153,136 @@ public class FileWatcherServiceTests
         Assert.IsFalse(signal.Wait(TimeSpan.FromSeconds(2)), "Should NOT fire for _ prefixed files");
         Assert.IsNull(changedFile);
     }
+
+    // ── Typed TaskFileChange event (issue #184) ─────────────────────────────
+    //
+    // The new typed event surfaces enough information for IndexService to
+    // distinguish Created / Changed / Deleted / Renamed, including the old
+    // file name on rename. The legacy string event continues to fire in
+    // parallel until all callers migrate.
+
+    [TestMethod]
+    public void TypedEvent_FiresWithCreatedOrChangedKind_ForCreate()
+    {
+        using var watcher = new FileWatcherService(_tempDir);
+        TaskFileChange? observed = null;
+        var signal = new ManualResetEventSlim(false);
+
+        watcher.TaskFileChange += (_, change) =>
+        {
+            observed = change;
+            signal.Set();
+        };
+
+        watcher.Start();
+        File.WriteAllText(Path.Combine(_tempDir, "typed-task.md"), "---\ntitle: T\n---");
+
+        Assert.IsTrue(signal.Wait(TimeSpan.FromSeconds(5)));
+        Assert.IsNotNull(observed);
+        Assert.AreEqual(TaskFileChangeKind.CreatedOrChanged, observed!.Kind);
+        Assert.AreEqual("typed-task.md", observed.NewFileName);
+        Assert.IsNull(observed.OldFileName);
+    }
+
+    [TestMethod]
+    public void TypedEvent_FiresWithDeletedKind_ForDelete()
+    {
+        var path = Path.Combine(_tempDir, "to-delete.md");
+        File.WriteAllText(path, "x");
+
+        using var watcher = new FileWatcherService(_tempDir);
+        TaskFileChange? deletion = null;
+        var signal = new ManualResetEventSlim(false);
+
+        watcher.TaskFileChange += (_, change) =>
+        {
+            if (change.Kind == TaskFileChangeKind.Deleted)
+            {
+                deletion = change;
+                signal.Set();
+            }
+        };
+
+        watcher.Start();
+        File.Delete(path);
+
+        Assert.IsTrue(signal.Wait(TimeSpan.FromSeconds(5)), "Delete event must fire.");
+        Assert.IsNotNull(deletion);
+        Assert.AreEqual(TaskFileChangeKind.Deleted, deletion!.Kind);
+        Assert.AreEqual("to-delete.md", deletion.NewFileName);
+    }
+
+    [TestMethod]
+    public void TypedEvent_FiresWithRenamedKind_AndCarriesOldFileName()
+    {
+        var oldPath = Path.Combine(_tempDir, "old-name.md");
+        var newPath = Path.Combine(_tempDir, "new-name.md");
+        File.WriteAllText(oldPath, "x");
+
+        using var watcher = new FileWatcherService(_tempDir);
+        TaskFileChange? rename = null;
+        var signal = new ManualResetEventSlim(false);
+
+        watcher.TaskFileChange += (_, change) =>
+        {
+            if (change.Kind == TaskFileChangeKind.Renamed)
+            {
+                rename = change;
+                signal.Set();
+            }
+        };
+
+        watcher.Start();
+        File.Move(oldPath, newPath);
+
+        Assert.IsTrue(signal.Wait(TimeSpan.FromSeconds(5)), "Rename event must fire.");
+        Assert.IsNotNull(rename);
+        Assert.AreEqual(TaskFileChangeKind.Renamed, rename!.Kind);
+        Assert.AreEqual("old-name.md", rename.OldFileName);
+        Assert.AreEqual("new-name.md", rename.NewFileName);
+    }
+
+    [TestMethod]
+    public void TypedEvent_SuppressedBySelfWriteCoordinator()
+    {
+        var coord = new SelfWriteCoordinator(TimeSpan.FromSeconds(2));
+        using var watcher = new FileWatcherService(_tempDir, coord);
+        TaskFileChange? observed = null;
+        var signal = new ManualResetEventSlim(false);
+
+        watcher.TaskFileChange += (_, change) =>
+        {
+            observed = change;
+            signal.Set();
+        };
+
+        watcher.Start();
+        var path = Path.Combine(_tempDir, "self-typed.md");
+        coord.RegisterWrite(path);
+        File.WriteAllText(path, "x");
+
+        Assert.IsFalse(signal.Wait(TimeSpan.FromSeconds(2)),
+            "Typed event must respect SelfWriteCoordinator suppression like the legacy event.");
+        Assert.IsNull(observed);
+    }
+
+    [TestMethod]
+    public void TypedEvent_DoesNotFire_ForUnderscorePrefixedFiles()
+    {
+        using var watcher = new FileWatcherService(_tempDir);
+        TaskFileChange? observed = null;
+        var signal = new ManualResetEventSlim(false);
+
+        watcher.TaskFileChange += (_, change) =>
+        {
+            observed = change;
+            signal.Set();
+        };
+
+        watcher.Start();
+        File.WriteAllText(Path.Combine(_tempDir, "_today.md"), "x");
+
+        Assert.IsFalse(signal.Wait(TimeSpan.FromSeconds(2)));
+        Assert.IsNull(observed);
+    }
 }

--- a/tests/Glasswork.Tests/GlassworkTaskCloneTests.cs
+++ b/tests/Glasswork.Tests/GlassworkTaskCloneTests.cs
@@ -1,0 +1,141 @@
+using Glasswork.Core.Models;
+
+namespace Glasswork.Tests;
+
+/// <summary>
+/// Tests for <see cref="GlassworkTask.Clone"/> — the defensive-copy primitive the
+/// in-memory Index uses to hand out task snapshots without aliasing its canonical
+/// store (issue #184). Mutating a returned clone must never affect the original,
+/// and the clone must reset transient UI fields (<see cref="GlassworkTask.IsManuallyCollapsed"/>,
+/// <see cref="GlassworkTask.TodaysSubtasks"/>) that should not survive an index snapshot.
+/// </summary>
+[TestClass]
+public class GlassworkTaskCloneTests
+{
+    [TestMethod]
+    public void Clone_CopiesScalarFields()
+    {
+        var src = new GlassworkTask
+        {
+            Id = "t1",
+            Title = "Original",
+            Status = GlassworkTask.Statuses.InProgress,
+            Priority = GlassworkTask.Priorities.High,
+            Created = new DateTime(2024, 1, 2),
+            CompletedAt = new DateTime(2024, 5, 1),
+            Due = new DateTime(2024, 6, 1),
+            MyDay = new DateTime(2024, 5, 1),
+            Parent = "parent-id",
+            Description = "desc",
+            Notes = "notes",
+            IsV1Format = true,
+        };
+
+        var copy = src.Clone();
+
+        Assert.AreEqual("t1", copy.Id);
+        Assert.AreEqual("Original", copy.Title);
+        Assert.AreEqual(GlassworkTask.Statuses.InProgress, copy.Status);
+        Assert.AreEqual(GlassworkTask.Priorities.High, copy.Priority);
+        Assert.AreEqual(new DateTime(2024, 1, 2), copy.Created);
+        Assert.AreEqual(new DateTime(2024, 5, 1), copy.CompletedAt);
+        Assert.AreEqual(new DateTime(2024, 6, 1), copy.Due);
+        Assert.AreEqual(new DateTime(2024, 5, 1), copy.MyDay);
+        Assert.AreEqual("parent-id", copy.Parent);
+        Assert.AreEqual("desc", copy.Description);
+        Assert.AreEqual("notes", copy.Notes);
+        Assert.IsTrue(copy.IsV1Format);
+    }
+
+    [TestMethod]
+    public void Clone_DeepCopiesSubtasksList_MutationIsolated()
+    {
+        var src = new GlassworkTask { Id = "t1", Title = "T" };
+        src.Subtasks.Add(new SubTask { Text = "step 1", Status = "in_progress" });
+        src.Subtasks[0].Metadata["blocker"] = "waiting on Alice";
+
+        var copy = src.Clone();
+
+        // Different list instance.
+        Assert.AreNotSame(src.Subtasks, copy.Subtasks);
+        Assert.AreEqual(1, copy.Subtasks.Count);
+        // Different SubTask instance.
+        Assert.AreNotSame(src.Subtasks[0], copy.Subtasks[0]);
+        Assert.AreEqual("step 1", copy.Subtasks[0].Text);
+        Assert.AreEqual("in_progress", copy.Subtasks[0].Status);
+        // Different Metadata dict instance.
+        Assert.AreNotSame(src.Subtasks[0].Metadata, copy.Subtasks[0].Metadata);
+        Assert.AreEqual("waiting on Alice", copy.Subtasks[0].Metadata["blocker"]);
+
+        // Mutating the clone leaves the source untouched.
+        copy.Subtasks.Add(new SubTask { Text = "added" });
+        copy.Subtasks[0].Text = "MUTATED";
+        copy.Subtasks[0].Metadata["blocker"] = "MUTATED";
+        Assert.AreEqual(1, src.Subtasks.Count);
+        Assert.AreEqual("step 1", src.Subtasks[0].Text);
+        Assert.AreEqual("waiting on Alice", src.Subtasks[0].Metadata["blocker"]);
+    }
+
+    [TestMethod]
+    public void Clone_DeepCopiesLinks_MutationIsolated()
+    {
+        var src = new GlassworkTask { Id = "t1", Title = "T" };
+        src.Links.Add(new TaskLink { Type = TaskLink.Types.Ado, Value = "1234", Label = "ADO #1234" });
+
+        var copy = src.Clone();
+
+        Assert.AreNotSame(src.Links, copy.Links);
+        Assert.AreEqual(1, copy.Links.Count);
+        Assert.AreEqual("1234", copy.Links[0].Value);
+
+        copy.Links.Add(new TaskLink { Type = TaskLink.Types.Pr, Value = "https://pr" });
+        Assert.AreEqual(1, src.Links.Count);
+    }
+
+    [TestMethod]
+    public void Clone_DeepCopiesRelatedLinks_MutationIsolated()
+    {
+        var src = new GlassworkTask { Id = "t1", Title = "T" };
+        src.RelatedLinks.Add(new RelatedLink { Slug = "decisions/foo", DisplayName = "Foo" });
+
+        var copy = src.Clone();
+
+        Assert.AreNotSame(src.RelatedLinks, copy.RelatedLinks);
+        Assert.AreNotSame(src.RelatedLinks[0], copy.RelatedLinks[0]);
+        Assert.AreEqual("decisions/foo", copy.RelatedLinks[0].Slug);
+
+        copy.RelatedLinks[0].DisplayName = "MUTATED";
+        Assert.AreEqual("Foo", src.RelatedLinks[0].DisplayName);
+    }
+
+    [TestMethod]
+    public void Clone_DeepCopiesTagsAndContextLinks_MutationIsolated()
+    {
+        var src = new GlassworkTask { Id = "t1", Title = "T" };
+        src.Tags.Add("eng");
+        src.ContextLinks.Add("ctx-1");
+
+        var copy = src.Clone();
+
+        Assert.AreNotSame(src.Tags, copy.Tags);
+        Assert.AreNotSame(src.ContextLinks, copy.ContextLinks);
+        copy.Tags.Add("MUTATED");
+        copy.ContextLinks.Add("MUTATED");
+        Assert.AreEqual(1, src.Tags.Count);
+        Assert.AreEqual(1, src.ContextLinks.Count);
+    }
+
+    [TestMethod]
+    public void Clone_ResetsTransientUiFields()
+    {
+        var src = new GlassworkTask { Id = "t1", Title = "T", IsManuallyCollapsed = true };
+        src.TodaysSubtasks = new[] { new SubTask { Text = "today" } };
+
+        var copy = src.Clone();
+
+        // The index should never expose UI-only collapse state or My-Day-virtual
+        // promotion attachments — those are recomputed per page render.
+        Assert.IsFalse(copy.IsManuallyCollapsed);
+        Assert.IsNull(copy.TodaysSubtasks);
+    }
+}

--- a/tests/Glasswork.Tests/IndexServiceAggregateTests.cs
+++ b/tests/Glasswork.Tests/IndexServiceAggregateTests.cs
@@ -282,4 +282,35 @@ public class IndexServiceAggregateTests
 
         CollectionAssert.AreEquivalent(new[] { "in" }, completed.Select(t => t.Id).ToList());
     }
+
+    // ── Refresh decoupling (issue #184 review fix) ─────────────────────────
+
+    [TestMethod]
+    public void Refresh_WritesSurfacesFromInMemoryStore_NotFromDisk()
+    {
+        // The in-memory store is authoritative; Refresh() must not reload from
+        // disk because that path would silently drop tasks that fail to parse
+        // mid-write and emit no delta. We prove the decoupling by writing a
+        // task file directly to disk (bypassing VaultService.Save, so no event
+        // fires and the in-memory store never sees it) and asserting that
+        // Refresh()'s output does NOT include it.
+        _vault.Save(new GlassworkTask { Id = "known", Title = "Known" });
+        _index.EnsureLoaded();
+
+        // Bypass VaultService entirely — drop a valid task file on disk that
+        // the in-memory store has never been told about.
+        File.WriteAllText(
+            Path.Combine(_tempDir, "ghost.md"),
+            "---\nid: ghost\ntitle: Ghost\nstatus: todo\n---\n");
+
+        _index.Refresh();
+
+        var indexMd = File.ReadAllText(Path.Combine(_tempDir, "_index.md"));
+        StringAssert.Contains(indexMd, "Known");
+        Assert.IsFalse(indexMd.Contains("Ghost"),
+            "Refresh() must regenerate _index.md from the in-memory snapshot, " +
+            "not by re-reading the vault. Tasks the store does not know about " +
+            "must arrive via OnFileChangedOnDisk / vault events, not via a " +
+            "silent full reload that bypasses the delta channel.");
+    }
 }

--- a/tests/Glasswork.Tests/IndexServiceAggregateTests.cs
+++ b/tests/Glasswork.Tests/IndexServiceAggregateTests.cs
@@ -1,0 +1,285 @@
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+/// <summary>
+/// Tests for the in-memory aggregate behaviour added to <see cref="IndexService"/>
+/// for issue #184. These exercise the snapshot store, the typed delta channel,
+/// the watcher seam (<see cref="IndexService.OnFileChangedOnDisk"/>), and the
+/// query surface (<c>All</c>, <c>ById</c>, <c>Count</c>, <c>Carryover</c>,
+/// <c>CompletedBetween</c>). The legacy <c>Refresh()</c>+ on-disk writer behaviour
+/// is covered by <see cref="IndexServiceTests"/>.
+/// </summary>
+[TestClass]
+public class IndexServiceAggregateTests
+{
+    private string _tempDir = null!;
+    private VaultService _vault = null!;
+    private IndexService _index = null!;
+    private List<TasksChangedEventArgs> _deltas = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-idxagg-" + Guid.NewGuid().ToString("N")[..8]);
+        _vault = new VaultService(_tempDir);
+        _index = new IndexService(_vault);
+        _deltas = new List<TasksChangedEventArgs>();
+        _index.TasksChanged += (_, e) => _deltas.Add(e);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // ── EnsureLoaded ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void EnsureLoaded_PopulatesStoreFromVault()
+    {
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Alpha" });
+        _vault.Save(new GlassworkTask { Id = "b", Title = "Beta" });
+        // Vault Save raises TaskWritten so the index was hydrated reactively;
+        // clear deltas before we exercise the seed path.
+        _deltas.Clear();
+        var fresh = new IndexService(new VaultService(_tempDir));
+        var freshDeltas = new List<TasksChangedEventArgs>();
+        fresh.TasksChanged += (_, e) => freshDeltas.Add(e);
+
+        fresh.EnsureLoaded();
+
+        Assert.AreEqual(2, fresh.Count);
+        Assert.AreEqual(0, freshDeltas.Count, "EnsureLoaded must not fire TasksChanged — it is a snapshot, not a delta.");
+    }
+
+    [TestMethod]
+    public void EnsureLoaded_IsIdempotent()
+    {
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Alpha" });
+        var fresh = new IndexService(new VaultService(_tempDir));
+
+        fresh.EnsureLoaded();
+        fresh.EnsureLoaded();
+
+        Assert.AreEqual(1, fresh.Count);
+    }
+
+    // ── All / ById return clones ───────────────────────────────────────────
+
+    [TestMethod]
+    public void All_ReturnsClones_NotSharedReferences()
+    {
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Original" });
+        _index.EnsureLoaded();
+
+        var all = _index.All;
+        all[0].Title = "MUTATED";
+
+        // A second read must show the canonical title — the first call returned
+        // a defensive clone.
+        Assert.AreEqual("Original", _index.All[0].Title);
+    }
+
+    [TestMethod]
+    public void ById_ReturnsClone_NotSharedReference()
+    {
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Original" });
+        _index.EnsureLoaded();
+
+        var copy = _index.ById("a");
+        Assert.IsNotNull(copy);
+        copy!.Title = "MUTATED";
+
+        Assert.AreEqual("Original", _index.ById("a")!.Title);
+    }
+
+    [TestMethod]
+    public void ById_ReturnsNull_ForUnknownId()
+    {
+        _index.EnsureLoaded();
+        Assert.IsNull(_index.ById("ghost"));
+    }
+
+    // ── Vault event subscriptions ─────────────────────────────────────────
+
+    [TestMethod]
+    public void VaultSave_AddsToIndex_EmitsAddedDelta()
+    {
+        _index.EnsureLoaded();
+        _deltas.Clear();
+
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Alpha" });
+
+        Assert.AreEqual(1, _deltas.Count);
+        Assert.AreEqual(1, _deltas[0].Added.Count());
+        Assert.AreEqual("a", _deltas[0].Added.Single().Id);
+        Assert.AreEqual(1, _index.Count);
+    }
+
+    [TestMethod]
+    public void VaultSave_ToExistingTask_EmitsChangedDelta()
+    {
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Alpha" });
+        _index.EnsureLoaded();
+        _deltas.Clear();
+
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Alpha v2" });
+
+        Assert.AreEqual(1, _deltas.Count);
+        var changed = _deltas[0].Changed.Single();
+        Assert.AreEqual("Alpha", changed.Old!.Title);
+        Assert.AreEqual("Alpha v2", changed.New!.Title);
+    }
+
+    [TestMethod]
+    public void VaultDelete_RemovesFromIndex_EmitsRemovedDelta()
+    {
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Alpha" });
+        _index.EnsureLoaded();
+        _deltas.Clear();
+
+        _vault.Delete("a");
+
+        Assert.AreEqual(0, _index.Count);
+        Assert.AreEqual(1, _deltas[^1].Removed.Count());
+        Assert.AreEqual("a", _deltas[^1].Removed.Single().Id);
+    }
+
+    // ── Watcher seam: OnFileChangedOnDisk ──────────────────────────────────
+
+    [TestMethod]
+    public void OnFileChangedOnDisk_CreatedOrChanged_ReparsesFile()
+    {
+        _index.EnsureLoaded();
+        // Write a task file directly (bypass VaultService events) to simulate
+        // an external edit reaching us via the watcher.
+        File.WriteAllText(Path.Combine(_tempDir, "ext.md"),
+            "---\nid: ext\ntitle: External\nstatus: todo\n---\n");
+        _deltas.Clear();
+
+        _index.OnFileChangedOnDisk(new TaskFileChange(
+            TaskFileChangeKind.CreatedOrChanged, OldFileName: null, NewFileName: "ext.md"));
+
+        Assert.AreEqual(1, _index.Count);
+        Assert.AreEqual("External", _index.ById("ext")!.Title);
+        Assert.AreEqual("ext", _deltas.Single().Added.Single().Id);
+    }
+
+    [TestMethod]
+    public void OnFileChangedOnDisk_Deleted_RemovesEntry()
+    {
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Alpha" });
+        _index.EnsureLoaded();
+        _deltas.Clear();
+
+        _index.OnFileChangedOnDisk(new TaskFileChange(
+            TaskFileChangeKind.Deleted, OldFileName: null, NewFileName: "a.md"));
+
+        Assert.AreEqual(0, _index.Count);
+        Assert.AreEqual("a", _deltas.Single().Removed.Single().Id);
+    }
+
+    [TestMethod]
+    public void OnFileChangedOnDisk_Renamed_RemovesOldAndAddsNew()
+    {
+        _vault.Save(new GlassworkTask { Id = "old", Title = "Old Name" });
+        _index.EnsureLoaded();
+
+        // Rename on disk: file becomes new.md with id field switched in frontmatter.
+        var newPath = Path.Combine(_tempDir, "new.md");
+        File.WriteAllText(newPath, "---\nid: new\ntitle: New Name\nstatus: todo\n---\n");
+        File.Delete(Path.Combine(_tempDir, "old.md"));
+        _deltas.Clear();
+
+        _index.OnFileChangedOnDisk(new TaskFileChange(
+            TaskFileChangeKind.Renamed, OldFileName: "old.md", NewFileName: "new.md"));
+
+        Assert.IsNull(_index.ById("old"), "Old id must be gone after rename.");
+        Assert.AreEqual("New Name", _index.ById("new")!.Title);
+        // Single delta carrying both the removal and the add.
+        Assert.AreEqual(1, _deltas.Count);
+        Assert.AreEqual(1, _deltas[0].Removed.Count());
+        Assert.AreEqual(1, _deltas[0].Added.Count());
+    }
+
+    [TestMethod]
+    public void OnFileChangedOnDisk_ParseFailure_KeepsPriorSnapshot()
+    {
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Original" });
+        _index.EnsureLoaded();
+
+        // Truncate the file mid-write (typical of an in-flight Obsidian edit).
+        File.WriteAllText(Path.Combine(_tempDir, "a.md"), "this is not valid frontmatter");
+        _deltas.Clear();
+
+        _index.OnFileChangedOnDisk(new TaskFileChange(
+            TaskFileChangeKind.CreatedOrChanged, OldFileName: null, NewFileName: "a.md"));
+
+        // Prior snapshot survives. Either no delta fires, or a delta whose
+        // New snapshot is still the original Title. We assert the safe
+        // invariant: the index still resolves "a" with the original title.
+        Assert.AreEqual("Original", _index.ById("a")!.Title);
+    }
+
+    // ── Query helpers ──────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Carryover_ReturnsUnfinishedTasksWithPastMyDay()
+    {
+        var yesterday = DateTime.Today.AddDays(-1);
+        _vault.Save(new GlassworkTask { Id = "stale", Title = "Yesterday", MyDay = yesterday, Status = "todo" });
+        _vault.Save(new GlassworkTask { Id = "today", Title = "Today", MyDay = DateTime.Today, Status = "todo" });
+        _vault.Save(new GlassworkTask
+        {
+            Id = "done-yesterday",
+            Title = "Done",
+            MyDay = yesterday,
+            Status = "done",
+            CompletedAt = yesterday,
+        });
+        _vault.Save(new GlassworkTask { Id = "no-myday", Title = "Plain", Status = "todo" });
+        _index.EnsureLoaded();
+
+        var carry = _index.Carryover(DateTime.Today).ToList();
+
+        CollectionAssert.AreEquivalent(new[] { "stale" }, carry.Select(t => t.Id).ToList());
+    }
+
+    [TestMethod]
+    public void CompletedBetween_FiltersByCompletedAt()
+    {
+        var weekStart = new DateTime(2026, 1, 5); // Monday
+        var weekEnd = weekStart.AddDays(7);
+        _vault.Save(new GlassworkTask
+        {
+            Id = "in",
+            Title = "In Week",
+            Status = "done",
+            CompletedAt = new DateTime(2026, 1, 7),
+        });
+        _vault.Save(new GlassworkTask
+        {
+            Id = "before",
+            Title = "Before",
+            Status = "done",
+            CompletedAt = new DateTime(2026, 1, 4),
+        });
+        _vault.Save(new GlassworkTask
+        {
+            Id = "after",
+            Title = "After",
+            Status = "done",
+            CompletedAt = new DateTime(2026, 1, 12),
+        });
+        _vault.Save(new GlassworkTask { Id = "open", Title = "Open", Status = "todo" });
+        _index.EnsureLoaded();
+
+        var completed = _index.CompletedBetween(weekStart, weekEnd).ToList();
+
+        CollectionAssert.AreEquivalent(new[] { "in" }, completed.Select(t => t.Id).ToList());
+    }
+}

--- a/tests/Glasswork.Tests/IndexServiceTests.cs
+++ b/tests/Glasswork.Tests/IndexServiceTests.cs
@@ -104,6 +104,12 @@ public class IndexServiceTests
             Path.Combine(_tempDir, "wrapped-task.md"),
             Path.Combine(doneDir, "wrapped-task.md"));
 
+        // In production this disk move is observed by FileWatcherService which
+        // delivers a Deleted/Renamed event to the index. The unit test models
+        // that explicitly because we are not running the live watcher here.
+        _index.OnFileChangedOnDisk(new TaskFileChange(
+            TaskFileChangeKind.Deleted, OldFileName: null, NewFileName: "wrapped-task.md"));
+
         _index.Refresh();
 
         var after = File.ReadAllText(Path.Combine(_tempDir, "_index.md"));

--- a/tests/Glasswork.Tests/SelfWriteCoordinatorTests.cs
+++ b/tests/Glasswork.Tests/SelfWriteCoordinatorTests.cs
@@ -159,4 +159,66 @@ public class SelfWriteCoordinatorTests
         var glassworkDir = Path.Combine(subVault, ".glasswork");
         Assert.IsTrue(Directory.Exists(glassworkDir), ".glasswork/ must be created on demand.");
     }
+
+    // ── IsOwnProcessWrite: own-process-only predicate (issue #184) ──────────
+    //
+    // Background: IsSuppressed returns true for BOTH same-process writes and
+    // cross-process writes (recorded via the marker file). With an in-memory
+    // Index in place, the latter must still reach the UI: an MCP write should
+    // update the Index via the watcher round-trip. IsOwnProcessWrite is the
+    // narrower predicate that returns true ONLY for writes the current process
+    // performed, so the watcher → Index path can deliberately ignore the
+    // marker file while the banner path keeps IsSuppressed's broader behaviour.
+
+    [TestMethod]
+    public void IsOwnProcessWrite_TrueAfterRegisterInSameProcess()
+    {
+        var coord = new SelfWriteCoordinator(_tempDir, TimeSpan.FromMilliseconds(500));
+        var taskPath = Path.Combine(_tempDir, "task.md");
+
+        coord.RegisterWrite(taskPath);
+
+        Assert.IsTrue(coord.IsOwnProcessWrite(taskPath));
+    }
+
+    [TestMethod]
+    public void IsOwnProcessWrite_FalseForCrossProcessMarkerEntry()
+    {
+        // A "cross-process" write is one that only appears in the marker file
+        // and not in this coordinator's in-memory dictionary. We simulate it by
+        // letting coord_a (a separate "process") register the write, then
+        // observing through coord_b which shares only the vault directory.
+        var coordA = new SelfWriteCoordinator(_tempDir, TimeSpan.FromMilliseconds(500));
+        var coordB = new SelfWriteCoordinator(_tempDir, TimeSpan.FromMilliseconds(500));
+        var taskPath = Path.Combine(_tempDir, "task.md");
+
+        coordA.RegisterWrite(taskPath);
+
+        // Sanity: the marker-file-inclusive predicate still sees it.
+        Assert.IsTrue(coordB.IsSuppressed(taskPath),
+            "IsSuppressed must still honour cross-process marker-file entries.");
+
+        // But the own-process predicate must return false — coordB never
+        // registered this path itself.
+        Assert.IsFalse(coordB.IsOwnProcessWrite(taskPath),
+            "IsOwnProcessWrite must return false for cross-process marker-file entries.");
+    }
+
+    [TestMethod]
+    public void IsOwnProcessWrite_FalseAfterTtlExpires()
+    {
+        var coord = new SelfWriteCoordinator(TimeSpan.FromMilliseconds(50));
+        coord.RegisterWrite(@"C:\vault\task.md");
+
+        Thread.Sleep(150);
+
+        Assert.IsFalse(coord.IsOwnProcessWrite(@"C:\vault\task.md"));
+    }
+
+    [TestMethod]
+    public void IsOwnProcessWrite_FalseForUnregisteredPath()
+    {
+        var coord = new SelfWriteCoordinator(TimeSpan.FromMilliseconds(500));
+        Assert.IsFalse(coord.IsOwnProcessWrite(@"C:\vault\other.md"));
+    }
 }

--- a/tests/Glasswork.Tests/VaultServiceEventsTests.cs
+++ b/tests/Glasswork.Tests/VaultServiceEventsTests.cs
@@ -1,0 +1,165 @@
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+/// <summary>
+/// Tests for the domain events <see cref="VaultService.TaskWritten"/> and
+/// <see cref="VaultService.TaskDeleted"/> introduced for issue #184. The
+/// in-memory <see cref="IndexService"/> subscribes to these so the canonical
+/// snapshot store stays consistent with successful disk writes without going
+/// through a watcher round-trip.
+/// </summary>
+[TestClass]
+public class VaultServiceEventsTests
+{
+    private string _tempDir = null!;
+    private VaultService _vault = null!;
+    private List<string> _written = null!;
+    private List<string> _deleted = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-vse-" + Guid.NewGuid().ToString("N")[..8]);
+        _vault = new VaultService(_tempDir);
+        _written = new List<string>();
+        _deleted = new List<string>();
+        _vault.TaskWritten += (_, id) => _written.Add(id);
+        _vault.TaskDeleted += (_, id) => _deleted.Add(id);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public void Save_RaisesTaskWritten_WithTaskId()
+    {
+        var t = new GlassworkTask { Id = "t1", Title = "T1" };
+        _vault.Save(t);
+
+        CollectionAssert.AreEqual(new[] { "t1" }, _written);
+    }
+
+    [TestMethod]
+    public void Delete_RaisesTaskDeleted_WithTaskId()
+    {
+        _vault.Save(new GlassworkTask { Id = "t1", Title = "T1" });
+        _written.Clear();
+
+        var deleted = _vault.Delete("t1");
+
+        Assert.IsTrue(deleted);
+        CollectionAssert.AreEqual(new[] { "t1" }, _deleted);
+    }
+
+    [TestMethod]
+    public void Delete_NonexistentFile_DoesNotRaiseEvent()
+    {
+        _vault.Delete("ghost");
+
+        Assert.AreEqual(0, _deleted.Count);
+    }
+
+    [TestMethod]
+    public void UpdateSubtaskCheckbox_RaisesTaskWritten()
+    {
+        var t = new GlassworkTask { Id = "t1", Title = "T1" };
+        t.Subtasks.Add(new SubTask { Text = "step", IsCompleted = false });
+        _vault.Save(t);
+        _written.Clear();
+
+        _vault.UpdateSubtaskCheckbox("t1", "step", isCompleted: true);
+
+        CollectionAssert.AreEqual(new[] { "t1" }, _written);
+    }
+
+    [TestMethod]
+    public void UpdateSubtaskCheckbox_NoOp_DoesNotRaiseEvent()
+    {
+        // Subtask title does not exist — UpdateSubtaskCheckbox is a no-op and
+        // must not raise the event.
+        _vault.Save(new GlassworkTask { Id = "t1", Title = "T1" });
+        _written.Clear();
+
+        _vault.UpdateSubtaskCheckbox("t1", "nonexistent", isCompleted: true);
+
+        Assert.AreEqual(0, _written.Count);
+    }
+
+    [TestMethod]
+    public void SetSubtaskMyDay_RaisesTaskWritten()
+    {
+        var t = new GlassworkTask { Id = "t1", Title = "T1" };
+        t.Subtasks.Add(new SubTask { Text = "step" });
+        _vault.Save(t);
+        _written.Clear();
+
+        _vault.SetSubtaskMyDay("t1", "step", isMyDay: true);
+
+        CollectionAssert.AreEqual(new[] { "t1" }, _written);
+    }
+
+    [TestMethod]
+    public void SetSubtaskDue_RaisesTaskWritten()
+    {
+        var t = new GlassworkTask { Id = "t1", Title = "T1" };
+        t.Subtasks.Add(new SubTask { Text = "step" });
+        _vault.Save(t);
+        _written.Clear();
+
+        _vault.SetSubtaskDue("t1", "step", new DateTime(2026, 1, 1));
+
+        CollectionAssert.AreEqual(new[] { "t1" }, _written);
+    }
+
+    [TestMethod]
+    public void SetAdoLink_RaisesTaskWritten()
+    {
+        _vault.Save(new GlassworkTask { Id = "t1", Title = "T1" });
+        _written.Clear();
+
+        _vault.SetAdoLink("t1", 1234, "ADO");
+
+        CollectionAssert.AreEqual(new[] { "t1" }, _written);
+    }
+
+    [TestMethod]
+    public void SetParent_RaisesTaskWritten()
+    {
+        _vault.Save(new GlassworkTask { Id = "t1", Title = "T1" });
+        _written.Clear();
+
+        _vault.SetParent("t1", "parent-id");
+
+        CollectionAssert.AreEqual(new[] { "t1" }, _written);
+    }
+
+    [TestMethod]
+    public void AddSubtask_RaisesTaskWritten()
+    {
+        _vault.Save(new GlassworkTask { Id = "t1", Title = "T1" });
+        _written.Clear();
+
+        _vault.AddSubtask("t1", "new step");
+
+        CollectionAssert.AreEqual(new[] { "t1" }, _written);
+    }
+
+    [TestMethod]
+    public void Save_DoesNotCorruptOnEventHandlerException()
+    {
+        // A subscriber throwing must not prevent persistence from completing
+        // (Save already returned by then), nor should the unhandled exception
+        // surface to the caller — events are best-effort/log-and-continue.
+        _vault.TaskWritten += (_, _) => throw new InvalidOperationException("boom");
+
+        _vault.Save(new GlassworkTask { Id = "t1", Title = "T1" });
+
+        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "t1.md")));
+    }
+}


### PR DESCRIPTION
Closes #184.

## What this does

Deepens IndexService from a pass-through over VaultService.LoadAll() into a real in-memory aggregate with a typed delta channel. Eliminates the 11x LoadAll() fan-out described in the issue. Full rationale in [ADR 0010](docs/adr/0010-index-in-memory-aggregate.md) and CONTEXT.md §3.

### Key changes
- **IndexService** — owns Dictionary<TaskId, GlassworkTask> snapshot store; hydrated once via EnsureLoaded(); kept fresh by VaultService.TaskWritten / TaskDeleted (same-process) and FileWatcherService.TaskFileChange (cross-process). Every query returns defensive Clone()s.
- **TasksChanged** event with TaskChange(Old?, New?) deltas — filtered views can detect removal-from-set.
- **VaultService** — new TaskWritten / TaskDeleted domain events (the inversion-of-dependency point: Vault → Index, not Index → Vault).
- **SelfWriteCoordinator** split: IsOwnProcessWrite (in-memory only) vs IsSuppressed (in-memory ∪ marker file).
- **FileWatcherService** — typed TaskFileChange event with Kind + OldFileName; gated on IsOwnProcessWrite so cross-process MCP writes reach the Index. Legacy TaskFileChanged remains gated on IsSuppressed for the conflict-banner path.
- **11 call-site migrations** off LoadAll() — TaskService.GetCarryoverTasks, WorkLogService.GenerateWeeklyLog, BacklogViewModel, MyDayViewModel, MainWindow.RefreshTaskCount, SettingsPage, etc.
- **App.InitVaultServices** — strict startup ordering: Vault → migrate → Index ctor+subscribe → EnsureLoaded → TaskService → UI-state GC → debouncer → watcher.
- **GlassworkTask.Clone()** — deep copy primitive (resets transient UI fields).

## Dual review

I ran `code-review` and `rubber-duck` agents in parallel against the first commit (`dabc0e3`). Both flagged the same #1 blocker; rubber-duck additionally found the `Refresh()` issue. Both are fixed in commit `e982410`:

1. **MCP coherence was broken** — typed event was gated on `IsSuppressed` instead of `IsOwnProcessWrite`, so cross-process writes were swallowed.
2. **`Refresh()` reloaded from disk silently** — would drop parse-failed files without emitting deltas. Now writes surfaces from the in-memory snapshot only.

Both have new tests (`TypedEvent_FiresForCrossProcessWrites_RegisteredOnlyInMarkerFile`, `Refresh_WritesSurfacesFromInMemoryStore_NotFromDisk`).

### Smaller findings deferred as follow-ups
- Rename handling keys by filename stem; `task.Id` comes from frontmatter — can diverge if a user renames the file without updating the YAML id. Pre-existing.
- Legacy `TaskFileChangedExternally` subscribers (status bar, some pages) remain stale on in-process writes until they migrate to `TasksChanged`.
- No `FileSystemWatcher.Error` recovery path; watcher overflow could leave the in-memory store stale until restart.

## Tests
- `dotnet test tests/Glasswork.Tests/ -p:EnableWindowsTargeting=true`: **609 / 612 pass**.
- 3 failures are pre-existing debouncer timing flakes on `main` (`DebouncesBurstsIntoOneEvent` x2, `Trigger_FiresAgainAfterQuietPeriodElapses`), unchanged by this PR.
- +42 new tests across `GlassworkTaskCloneTests`, `VaultServiceEventsTests`, `IndexServiceAggregateTests`, plus targeted additions to `SelfWriteCoordinatorTests` and `FileWatcherServiceTests`.

## Risk
Moderate. Touches startup ordering and the watcher path. The reactive Index flow is well tested but the App-project XAML wiring builds clean (`dotnet build src/Glasswork.App/Glasswork.csproj -r win-x64`) and has not been smoke-tested on a real Windows desktop; that's the main remaining validation.