### PR TITLE
Render task-card blurbs as plain text instead of VaultMarkdownView (#185)

### DIFF
--- a/src/Glasswork.App/Pages/BacklogPage.xaml
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml
@@ -107,12 +107,12 @@
                         <TextBlock Text="{Binding FirstBlockerText}" FontSize="12"
                                    Foreground="#C50F1F" TextTrimming="CharacterEllipsis" />
                     </StackPanel>
-                    <controls:VaultMarkdownView Markdown="{Binding Description}"
-                                               AutomationProperties.Name="{Binding BlurbPreview}"
-                                               Opacity="0.8"
-                                               Loaded="OnBlurbMarkdownLoaded"
-                                               Unloaded="OnBlurbMarkdownUnloaded"
-                                               Visibility="{Binding HasBlurb, Converter={StaticResource BoolVis}}" />
+                    <TextBlock Text="{Binding BlurbPreview}"
+                               AutomationProperties.Name="{Binding BlurbPreview}"
+                               Opacity="0.8"
+                               TextWrapping="NoWrap"
+                               TextTrimming="CharacterEllipsis"
+                               Visibility="{Binding HasBlurb, Converter={StaticResource BoolVis}}" />
                 </StackPanel>
             </Grid>
         </DataTemplate>

--- a/src/Glasswork.App/Pages/BacklogPage.xaml.cs
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Glasswork.Controls;
 using Glasswork.Core.Models;
 using Glasswork.Core.Services;
 using Glasswork.Services;
@@ -475,25 +474,6 @@ public sealed partial class BacklogPage : Page
         var slugPath = p.Replace('/', Path.DirectorySeparatorChar);
         var absolutePath = Path.Combine(wikiRoot, slugPath + ".md");
         return File.Exists(absolutePath) ? absolutePath : null;
-    }
-
-    private void OnBlurbMarkdownLoaded(object sender, RoutedEventArgs e)
-    {
-        if (sender is not VaultMarkdownView view) return;
-        view.WikiLinkResolver ??= VaultPageHelper.BuildWikiLinkResolver();
-        view.LinkClicked -= OnBlurbLinkClicked;
-        view.LinkClicked += OnBlurbLinkClicked;
-    }
-
-    private void OnBlurbMarkdownUnloaded(object sender, RoutedEventArgs e)
-    {
-        if (sender is not VaultMarkdownView view) return;
-        view.LinkClicked -= OnBlurbLinkClicked;
-    }
-
-    private async void OnBlurbLinkClicked(object? sender, LinkClickedEventArgs e)
-    {
-        await VaultPageHelper.RouteLinkClickAsync(Frame, e);
     }
 
     private void ShowUndoInfoBar(string taskTitle)

--- a/src/Glasswork.App/Pages/MyDayPage.xaml
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml
@@ -180,12 +180,12 @@
                                            Foreground="#C50F1F" TextTrimming="CharacterEllipsis" />
                             </StackPanel>
                             <!-- Blurb -->
-                            <controls:VaultMarkdownView Markdown="{Binding Description}"
-                                                        AutomationProperties.Name="{Binding BlurbPreview}"
-                                                        Opacity="0.8"
-                                                        Loaded="OnBlurbMarkdownLoaded"
-                                                        Unloaded="OnBlurbMarkdownUnloaded"
-                                                        Visibility="{Binding HasBlurb, Converter={StaticResource BoolVis}}" />
+                            <TextBlock Text="{Binding BlurbPreview}"
+                                       AutomationProperties.Name="{Binding BlurbPreview}"
+                                       Opacity="0.8"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"
+                                       Visibility="{Binding HasBlurb, Converter={StaticResource BoolVis}}" />
                         </StackPanel>
 
                         <!-- Today's subtasks (ADR 0008): flagged or due-today subtasks rendered
@@ -386,12 +386,12 @@
                                 <TextBlock Grid.Column="1" Text="{Binding CurrentStepText}" FontSize="13" FontWeight="SemiBold"
                                            TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
                             </Grid>
-                            <controls:VaultMarkdownView Markdown="{Binding Description}"
-                                                        AutomationProperties.Name="{Binding BlurbPreview}"
-                                                        Opacity="0.8"
-                                                        Loaded="OnBlurbMarkdownLoaded"
-                                                        Unloaded="OnBlurbMarkdownUnloaded"
-                                                        Visibility="{Binding HasBlurb, Converter={StaticResource BoolVis}}" />
+                            <TextBlock Text="{Binding BlurbPreview}"
+                                       AutomationProperties.Name="{Binding BlurbPreview}"
+                                       Opacity="0.8"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"
+                                       Visibility="{Binding HasBlurb, Converter={StaticResource BoolVis}}" />
                         </StackPanel>
                     </Grid>
                 </DataTemplate>

--- a/src/Glasswork.App/Pages/MyDayPage.xaml.cs
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using Glasswork.Controls;
 using Glasswork.Core.Models;
 using Glasswork.Services;
 using Glasswork.ViewModels;
@@ -203,25 +202,6 @@ public sealed partial class MyDayPage : Page
         var vaultRelative = VaultPageHelper.ToVaultRelativePath(absolutePath);
         if (vaultRelative is null) return;
         await App.ObsidianLauncher.Open(vaultRelative);
-    }
-
-    private void OnBlurbMarkdownLoaded(object sender, RoutedEventArgs e)
-    {
-        if (sender is not VaultMarkdownView view) return;
-        view.WikiLinkResolver ??= VaultPageHelper.BuildWikiLinkResolver();
-        view.LinkClicked -= OnBlurbLinkClicked;
-        view.LinkClicked += OnBlurbLinkClicked;
-    }
-
-    private void OnBlurbMarkdownUnloaded(object sender, RoutedEventArgs e)
-    {
-        if (sender is not VaultMarkdownView view) return;
-        view.LinkClicked -= OnBlurbLinkClicked;
-    }
-
-    private async void OnBlurbLinkClicked(object? sender, LinkClickedEventArgs e)
-    {
-        await VaultPageHelper.RouteLinkClickAsync(Frame, e);
     }
 }
 

--- a/src/Glasswork.Core/Models/GlassworkTask.cs
+++ b/src/Glasswork.Core/Models/GlassworkTask.cs
@@ -29,6 +29,8 @@ public partial class GlassworkTask : ObservableObject
     [NotifyPropertyChangedFor(nameof(BlurbPreview))]
     [NotifyPropertyChangedFor(nameof(HasBlurb))]
     [NotifyPropertyChangedFor(nameof(IsActive))]
+    [NotifyPropertyChangedFor(nameof(IsQuiet))]
+    [NotifyPropertyChangedFor(nameof(ShowCardDetails))]
     public partial string Description { get; set; } = string.Empty;
     [ObservableProperty] public partial string Notes { get; set; } = string.Empty;
     [ObservableProperty] public partial List<string> ContextLinks { get; set; } = [];
@@ -103,6 +105,10 @@ public partial class GlassworkTask : ObservableObject
             if (firstLine == null) return string.Empty;
             // Strip leading markdown noise: heading hashes, blockquote, list markers.
             var cleaned = firstLine.TrimStart('#', '>', '-', '*', ' ', '\t').Trim();
+            // Strip a leading task-list checkbox marker exposed by the previous trim
+            // (e.g. "- [ ] Foo" → "[ ] Foo" → "Foo"). Without this, the literal
+            // brackets leak into the plain-text blurb and look like a broken checkbox.
+            cleaned = TaskCheckboxRegex.Replace(cleaned, string.Empty);
             if (cleaned.Length == 0) return string.Empty;
             // Unwrap link syntax so a plain TextBlock doesn't show raw brackets.
             cleaned = UnwrapLinks(cleaned);
@@ -119,6 +125,10 @@ public partial class GlassworkTask : ObservableObject
         new(@"\[\[(?<target>[^\[\]]+)\]\]", RegexOptions.Compiled);
     private static readonly Regex MarkdownLinkRegex =
         new(@"\[(?<text>[^\[\]]+)\]\((?<url>[^()]+)\)", RegexOptions.Compiled);
+    // Leading "[ ]", "[x]", "[X]" (with optional trailing whitespace) from a
+    // markdown task-list item that survived list-marker stripping.
+    private static readonly Regex TaskCheckboxRegex =
+        new(@"^\[[ xX]\]\s*", RegexOptions.Compiled);
 
     private static string UnwrapLinks(string s)
     {

--- a/src/Glasswork.Core/Models/GlassworkTask.cs
+++ b/src/Glasswork.Core/Models/GlassworkTask.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Glasswork.Core.Models;
@@ -24,7 +25,11 @@ public partial class GlassworkTask : ObservableObject
     [ObservableProperty] public partial List<TaskLink> Links { get; set; } = [];
     
     [ObservableProperty] public partial string? Parent { get; set; }
-    [ObservableProperty] public partial string Description { get; set; } = string.Empty;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(BlurbPreview))]
+    [NotifyPropertyChangedFor(nameof(HasBlurb))]
+    [NotifyPropertyChangedFor(nameof(IsActive))]
+    public partial string Description { get; set; } = string.Empty;
     [ObservableProperty] public partial string Notes { get; set; } = string.Empty;
     [ObservableProperty] public partial List<string> ContextLinks { get; set; } = [];
     [ObservableProperty] public partial List<string> Tags { get; set; } = [];
@@ -78,7 +83,8 @@ public partial class GlassworkTask : ObservableObject
 
     /// <summary>
     /// Single-line preview shown in the task card. Source: first non-blank line of <see cref="Description"/>,
-    /// stripped of leading markdown noise (#, &gt;, list markers), truncated at 80 chars.
+    /// stripped of leading markdown noise (#, &gt;, list markers) and unwrapped of wiki/markdown link
+    /// syntax so it renders cleanly as plain text. Truncated at 80 chars.
     /// Future: a <c>summary:</c> frontmatter field will take precedence when present.
     /// </summary>
     public string BlurbPreview
@@ -98,8 +104,28 @@ public partial class GlassworkTask : ObservableObject
             // Strip leading markdown noise: heading hashes, blockquote, list markers.
             var cleaned = firstLine.TrimStart('#', '>', '-', '*', ' ', '\t').Trim();
             if (cleaned.Length == 0) return string.Empty;
+            // Unwrap link syntax so a plain TextBlock doesn't show raw brackets.
+            cleaned = UnwrapLinks(cleaned);
             return cleaned.Length > 80 ? cleaned[..80] + "…" : cleaned;
         }
+    }
+
+    // [[target|alias]] -> alias; [[target]] -> target; [text](url) -> text.
+    // Aliased wikilinks must match before bare ones to avoid the bare pattern
+    // swallowing the pipe.
+    private static readonly Regex AliasedWikiLinkRegex =
+        new(@"\[\[(?<target>[^\[\]|]+)\|(?<alias>[^\[\]]+)\]\]", RegexOptions.Compiled);
+    private static readonly Regex BareWikiLinkRegex =
+        new(@"\[\[(?<target>[^\[\]]+)\]\]", RegexOptions.Compiled);
+    private static readonly Regex MarkdownLinkRegex =
+        new(@"\[(?<text>[^\[\]]+)\]\((?<url>[^()]+)\)", RegexOptions.Compiled);
+
+    private static string UnwrapLinks(string s)
+    {
+        s = AliasedWikiLinkRegex.Replace(s, m => m.Groups["alias"].Value);
+        s = BareWikiLinkRegex.Replace(s, m => m.Groups["target"].Value);
+        s = MarkdownLinkRegex.Replace(s, m => m.Groups["text"].Value);
+        return s;
     }
 
     public bool HasBlurb => BlurbPreview.Length > 0;

--- a/tests/Glasswork.Tests/GlassworkTaskAdaptiveRowTests.cs
+++ b/tests/Glasswork.Tests/GlassworkTaskAdaptiveRowTests.cs
@@ -131,6 +131,21 @@ public class GlassworkTaskAdaptiveRowTests
         CollectionAssert.Contains(changed, nameof(GlassworkTask.BlurbPreview));
         CollectionAssert.Contains(changed, nameof(GlassworkTask.HasBlurb));
         CollectionAssert.Contains(changed, nameof(GlassworkTask.IsActive));
+        CollectionAssert.Contains(changed, nameof(GlassworkTask.IsQuiet));
+        CollectionAssert.Contains(changed, nameof(GlassworkTask.ShowCardDetails));
+    }
+
+    [TestMethod]
+    public void BlurbPreview_StripsTaskCheckboxMarker()
+    {
+        var t = new GlassworkTask { Description = "- [ ] Write tests" };
+        Assert.AreEqual("Write tests", t.BlurbPreview);
+
+        var t2 = new GlassworkTask { Description = "- [x] Done thing" };
+        Assert.AreEqual("Done thing", t2.BlurbPreview);
+
+        var t3 = new GlassworkTask { Description = "* [X] Capital X" };
+        Assert.AreEqual("Capital X", t3.BlurbPreview);
     }
 
     // ---------- Progress ----------

--- a/tests/Glasswork.Tests/GlassworkTaskAdaptiveRowTests.cs
+++ b/tests/Glasswork.Tests/GlassworkTaskAdaptiveRowTests.cs
@@ -75,6 +75,64 @@ public class GlassworkTaskAdaptiveRowTests
         Assert.IsFalse(t.HasBlurb);
     }
 
+    // ---------- BlurbPreview link unwrapping (issue #185) ----------
+    // Blurb is plain text by construction; wiki/markdown link wrappers
+    // would render as literal brackets in a plain TextBlock, so we strip
+    // them at the model layer.
+
+    [TestMethod]
+    public void BlurbPreview_UnwrapsBareWikilink()
+    {
+        var t = new GlassworkTask { Description = "[[Foo]]" };
+        Assert.AreEqual("Foo", t.BlurbPreview);
+    }
+
+    [TestMethod]
+    public void BlurbPreview_UnwrapsAliasedWikilink_PrefersAlias()
+    {
+        var t = new GlassworkTask { Description = "[[wiki/Foo|Friendly Name]]" };
+        Assert.AreEqual("Friendly Name", t.BlurbPreview);
+    }
+
+    [TestMethod]
+    public void BlurbPreview_UnwrapsMarkdownLink_PrefersDisplayText()
+    {
+        var t = new GlassworkTask { Description = "[Foo](https://example.com)" };
+        Assert.AreEqual("Foo", t.BlurbPreview);
+    }
+
+    [TestMethod]
+    public void BlurbPreview_StripsHeadingThenUnwrapsWikilink()
+    {
+        var t = new GlassworkTask { Description = "## [[Foo]]" };
+        Assert.AreEqual("Foo", t.BlurbPreview);
+    }
+
+    [TestMethod]
+    public void BlurbPreview_UnwrapsMidSentenceWikilink()
+    {
+        var t = new GlassworkTask { Description = "See [[Foo|the spec]] for details." };
+        Assert.AreEqual("See the spec for details.", t.BlurbPreview);
+    }
+
+    // ---------- Description change notifications (issue #185) ----------
+    // The card UI binds directly to BlurbPreview/HasBlurb; Description
+    // must raise dependent PropertyChanged events so edits refresh the card.
+
+    [TestMethod]
+    public void Description_Change_RaisesBlurbPreviewAndHasBlurbAndIsActive()
+    {
+        var t = new GlassworkTask();
+        var changed = new List<string>();
+        t.PropertyChanged += (_, e) => changed.Add(e.PropertyName ?? string.Empty);
+
+        t.Description = "Some context.";
+
+        CollectionAssert.Contains(changed, nameof(GlassworkTask.BlurbPreview));
+        CollectionAssert.Contains(changed, nameof(GlassworkTask.HasBlurb));
+        CollectionAssert.Contains(changed, nameof(GlassworkTask.IsActive));
+    }
+
     // ---------- Progress ----------
 
     [TestMethod]


### PR DESCRIPTION
Closes #185.

## What

Render every task-card blurb in **MyDayPage** and **BacklogPage** as a plain `TextBlock` bound to `GlassworkTask.BlurbPreview` (a plain string) instead of routing it through `VaultMarkdownView` (Markdig + `RichTextBlock` + wiki-link resolver + `ArtifactLinkPolicy`). Under `ListView` virtualization, every recycled row re-parsed the markdown on scroll — for what is, by definition in `UBIQUITOUS_LANGUAGE.md`, a one-line plain-text summary.

Three blurb sites total: `MyDayPage.xaml` x2 (issue body called out only one — there are two), `BacklogPage.xaml` x1.

## Two domain fixes the swap forced

A rubber-duck pass before implementation surfaced two real issues:

1. **`Description` did not notify `BlurbPreview` / `HasBlurb` dependents.** The old binding refreshed because XAML bound directly to `Description`; the new binding to `BlurbPreview` needs explicit `[NotifyPropertyChangedFor]` on `Description` so in-place edits still refresh the card. Added a regression test.
2. **`BlurbPreview` did not strip link wrappers**, despite `UBIQUITOUS_LANGUAGE.md` already promising it did. Under `VaultMarkdownView` `[[Foo]]` rendered as a clickable wiki link; under a plain `TextBlock` it would have shown raw brackets. `BlurbPreview` now unwraps `[[target|alias]] -> alias`, `[[target]] -> target`, and `[text](url) -> text`. Tests added for each.

## Behavior change to be aware of

Wiki-links inside a blurb are no longer clickable. Intentional and consistent with the ubiquitous language; blurbs were never an interactive markdown surface in ADR 0006's sense. ADR 0006's single-renderer rule continues to apply to Notes (read mode) and Artifacts. No ADR text change in this PR — the issue defers that until `grilling`.

## Verification

- `dotnet build Glasswork.slnx` — clean.
- `dotnet test tests/Glasswork.Tests/` — 624 pass (after a re-run for two pre-existing timing-sensitive `BacklinksWatcher` debouncer tests that are unrelated to this change).
- Six new unit tests in `GlassworkTaskAdaptiveRowTests.cs` covering link unwrapping and the `Description` PropertyChanged behavior.

## Files touched

- `src/Glasswork.Core/Models/GlassworkTask.cs` — `Description` notifications + `BlurbPreview` link unwrapping.
- `src/Glasswork.App/Pages/MyDayPage.xaml{,.cs}` — two blurb swaps, three handlers deleted.
- `src/Glasswork.App/Pages/BacklogPage.xaml{,.cs}` — one blurb swap, three handlers deleted.
- `tests/Glasswork.Tests/GlassworkTaskAdaptiveRowTests.cs` — six new tests.
