### PR TITLE
feat(index): migrate cheap counters to Index.Tasks dictionary

### DIFF
--- a/src/Glasswork.App/App.xaml.cs
+++ b/src/Glasswork.App/App.xaml.cs
@@ -289,11 +289,12 @@ public partial class App : Application
 
         // GC stale per-task UI state entries (e.g. collapse overrides for tasks the
         // user has since deleted from the vault). Cheap: O(state) + one in-memory
-        // index walk (no longer a disk scan, per issue #184).
+        // index walk (no longer a disk scan, per issue #187). Uses the Tasks
+        // dictionary API from issue #186.
         try
         {
             var liveIds = new System.Collections.Generic.HashSet<string>(
-                System.Linq.Enumerable.Select(Index.All, t => t.Id),
+                Index.Tasks.Keys,
                 StringComparer.Ordinal);
             uiStateImpl.RemoveKeysNotIn(CollapsedTaskKeyPrefix, liveIds);
             uiStateImpl.Save();

--- a/src/Glasswork.App/MainWindow.xaml.cs
+++ b/src/Glasswork.App/MainWindow.xaml.cs
@@ -93,9 +93,9 @@ public sealed partial class MainWindow : Window
     {
         try
         {
-            // Status-bar count from the in-memory aggregate (issue #184) —
-            // no disk scan, O(1).
-            var count = App.Index?.Count ?? 0;
+            // Status-bar count from the in-memory aggregate (issue #187) —
+            // uses the Tasks dictionary API from issue #186.
+            var count = App.Index?.Tasks.Count ?? 0;
             StatusTaskCountText.Text = count == 1 ? "1 task" : $"{count} tasks";
         }
         catch

--- a/src/Glasswork.App/MainWindow.xaml.cs
+++ b/src/Glasswork.App/MainWindow.xaml.cs
@@ -93,9 +93,10 @@ public sealed partial class MainWindow : Window
     {
         try
         {
-            // Status-bar count from the in-memory aggregate (issue #187) —
-            // uses the Tasks dictionary API from issue #186.
-            var count = App.Index?.Tasks.Count ?? 0;
+            // Status-bar count from the in-memory aggregate (issue #184) —
+            // O(1) read, no disk scan, no cloning. Use Count directly rather
+            // than Tasks.Count to avoid materializing the dictionary.
+            var count = App.Index?.Count ?? 0;
             StatusTaskCountText.Text = count == 1 ? "1 task" : $"{count} tasks";
         }
         catch

--- a/src/Glasswork.App/Pages/SettingsPage.xaml.cs
+++ b/src/Glasswork.App/Pages/SettingsPage.xaml.cs
@@ -43,8 +43,9 @@ public sealed partial class SettingsPage : Page
 
         try
         {
-            // Count via the in-memory aggregate (issue #184) — no disk scan.
-            var taskCount = App.Index?.Count ?? 0;
+            // Count via the in-memory aggregate (issue #187) — uses the Tasks
+            // dictionary API from issue #186.
+            var taskCount = App.Index?.Tasks.Count ?? 0;
             var lastWrite = Directory.GetLastWriteTime(path);
             VaultInfoText.Text = $"{taskCount} task file{(taskCount == 1 ? "" : "s")} · last modified {lastWrite:g}";
         }

--- a/src/Glasswork.App/Pages/SettingsPage.xaml.cs
+++ b/src/Glasswork.App/Pages/SettingsPage.xaml.cs
@@ -43,9 +43,10 @@ public sealed partial class SettingsPage : Page
 
         try
         {
-            // Count via the in-memory aggregate (issue #187) — uses the Tasks
-            // dictionary API from issue #186.
-            var taskCount = App.Index?.Tasks.Count ?? 0;
+            // Count via the in-memory aggregate (issue #184) — O(1) read, no
+            // disk scan, no cloning. Use Count directly rather than Tasks.Count
+            // to avoid materializing the dictionary.
+            var taskCount = App.Index?.Count ?? 0;
             var lastWrite = Directory.GetLastWriteTime(path);
             VaultInfoText.Text = $"{taskCount} task file{(taskCount == 1 ? "" : "s")} · last modified {lastWrite:g}";
         }

--- a/tests/Glasswork.Tests/IndexServiceApiEquivalenceTests.cs
+++ b/tests/Glasswork.Tests/IndexServiceApiEquivalenceTests.cs
@@ -1,0 +1,121 @@
+using Glasswork.Core.Services;
+using Glasswork.Core.Models;
+
+namespace Glasswork.Tests;
+
+/// <summary>
+/// Verifies that the new Index.Tasks dictionary API (issue #186) is
+/// functionally equivalent to the legacy Index.Count and Index.All
+/// properties, ensuring safe migration of call sites (issue #187).
+/// </summary>
+[TestClass]
+public class IndexServiceApiEquivalenceTests
+{
+    private string _tempDir = null!;
+    private VaultService _vault = null!;
+    private IndexService _index = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-equiv-" + Guid.NewGuid().ToString("N")[..8]);
+        _vault = new VaultService(_tempDir);
+        _index = new IndexService(_vault);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public void Tasks_Count_EqualsLegacyCount()
+    {
+        // Empty vault
+        _index.EnsureLoaded();
+        Assert.AreEqual(_index.Count, _index.Tasks.Count, "Empty vault: Tasks.Count should equal Count");
+
+        // Add some tasks
+        var t1 = new GlassworkTask { Id = "task-1", Status = "todo" };
+        var t2 = new GlassworkTask { Id = "task-2", Status = "in-progress" };
+        var t3 = new GlassworkTask { Id = "task-3", Status = "done" };
+        _vault.Save(t1);
+        _vault.Save(t2);
+        _vault.Save(t3);
+
+        // Re-load to pick up the written tasks
+        var index2 = new IndexService(new VaultService(_tempDir));
+        index2.EnsureLoaded();
+
+        Assert.AreEqual(3, index2.Count, "Precondition: Count should be 3");
+        Assert.AreEqual(index2.Count, index2.Tasks.Count, "Tasks.Count should equal Count");
+    }
+
+    [TestMethod]
+    public void Tasks_Keys_EqualsIdsFromAll()
+    {
+        // Empty vault
+        _index.EnsureLoaded();
+        var allIds = _index.All.Select(t => t.Id).ToHashSet(StringComparer.Ordinal);
+        var taskKeys = _index.Tasks.Keys.ToHashSet(StringComparer.Ordinal);
+        CollectionAssert.AreEquivalent(allIds.ToList(), taskKeys.ToList(),
+            "Empty vault: Tasks.Keys should equal ids from All");
+
+        // Add some tasks
+        var t1 = new GlassworkTask { Id = "alpha", Status = "todo" };
+        var t2 = new GlassworkTask { Id = "beta", Status = "in-progress" };
+        var t3 = new GlassworkTask { Id = "gamma", Status = "done" };
+        _vault.Save(t1);
+        _vault.Save(t2);
+        _vault.Save(t3);
+
+        // Re-load
+        var index2 = new IndexService(new VaultService(_tempDir));
+        index2.EnsureLoaded();
+
+        var allIds2 = index2.All.Select(t => t.Id).ToHashSet(StringComparer.Ordinal);
+        var taskKeys2 = index2.Tasks.Keys.ToHashSet(StringComparer.Ordinal);
+
+        Assert.AreEqual(3, allIds2.Count, "Precondition: should have 3 ids from All");
+        Assert.AreEqual(3, taskKeys2.Count, "Precondition: should have 3 keys from Tasks");
+
+        CollectionAssert.AreEquivalent(allIds2.ToList(), taskKeys2.ToList(),
+            "Tasks.Keys should equal ids from All");
+        Assert.IsTrue(taskKeys2.Contains("alpha"), "Tasks.Keys should contain alpha");
+        Assert.IsTrue(taskKeys2.Contains("beta"), "Tasks.Keys should contain beta");
+        Assert.IsTrue(taskKeys2.Contains("gamma"), "Tasks.Keys should contain gamma");
+    }
+
+    [TestMethod]
+    public void Tasks_Keys_CanBeUsedForUiStateGC()
+    {
+        // Simulates the App.xaml.cs UI-state GC pattern: build a live-id set
+        // from the index and use it to filter stale UI state entries.
+        var t1 = new GlassworkTask { Id = "one", Status = "todo" };
+        var t2 = new GlassworkTask { Id = "two", Status = "in-progress" };
+        _vault.Save(t1);
+        _vault.Save(t2);
+
+        _index.EnsureLoaded();
+
+        // Old pattern (issue #184): Select(Index.All, t => t.Id)
+        var liveIdsOld = new HashSet<string>(
+            _index.All.Select(t => t.Id),
+            StringComparer.Ordinal);
+
+        // New pattern (issue #187): Index.Tasks.Keys
+        var liveIdsNew = new HashSet<string>(
+            _index.Tasks.Keys,
+            StringComparer.Ordinal);
+
+        CollectionAssert.AreEquivalent(liveIdsOld.ToList(), liveIdsNew.ToList(),
+            "UI-state GC pattern: Tasks.Keys should produce the same live-id set as All.Select");
+
+        // Verify the set contains expected ids
+        Assert.IsTrue(liveIdsNew.Contains("one"));
+        Assert.IsTrue(liveIdsNew.Contains("two"));
+        Assert.IsFalse(liveIdsNew.Contains("deleted-task"));
+    }
+}

--- a/tests/Glasswork.Tests/IndexServiceApiEquivalenceTests.cs
+++ b/tests/Glasswork.Tests/IndexServiceApiEquivalenceTests.cs
@@ -7,6 +7,8 @@ namespace Glasswork.Tests;
 /// Verifies that the new Index.Tasks dictionary API (issue #186) is
 /// functionally equivalent to the legacy Index.Count and Index.All
 /// properties, ensuring safe migration of call sites (issue #187).
+/// Only UI-state GC migrates to Tasks.Keys; counter-only sites continue
+/// to use the O(1) Count property.
 /// </summary>
 [TestClass]
 public class IndexServiceApiEquivalenceTests
@@ -28,6 +30,18 @@ public class IndexServiceApiEquivalenceTests
     {
         if (Directory.Exists(_tempDir))
             Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public void Tasks_IsNeverNull()
+    {
+        // Per code-review: MainWindow and SettingsPage rely on Tasks being
+        // non-null (they guard Index, not Tasks). Verify the contract.
+        var fresh = new IndexService(_vault);
+        Assert.IsNotNull(fresh.Tasks, "Tasks should be non-null before EnsureLoaded");
+
+        fresh.EnsureLoaded();
+        Assert.IsNotNull(fresh.Tasks, "Tasks should be non-null after EnsureLoaded");
     }
 
     [TestMethod]
@@ -92,7 +106,8 @@ public class IndexServiceApiEquivalenceTests
     public void Tasks_Keys_CanBeUsedForUiStateGC()
     {
         // Simulates the App.xaml.cs UI-state GC pattern: build a live-id set
-        // from the index and use it to filter stale UI state entries.
+        // from the index and use it to filter stale UI state entries. This
+        // is the one call site that actually migrates to Tasks.Keys (issue #187).
         var t1 = new GlassworkTask { Id = "one", Status = "todo" };
         var t2 = new GlassworkTask { Id = "two", Status = "in-progress" };
         _vault.Save(t1);


### PR DESCRIPTION
# Migrate cheap counters to Index.Tasks dictionary

Closes #187

## What this does

Migrates the UI-state GC call site from `Index.All.Select(t => t.Id)` to the new `Index.Tasks.Keys` dictionary API added in issue #186.

**Counter-only call sites** (MainWindow, SettingsPage) **continue to use `Index.Count`** — the new `Index.Tasks.Count` is not O(1) (it clones the entire store), so migrating those sites would regress performance.

This is the smoke-test slice for the aggregate — validates that the in-memory dictionary is populated and current at every observable point, without touching any event-driven consumers.

## Changes

- **App.InitVaultServices UI-state GC**: Uses `Index.Tasks.Keys` instead of `Select(Index.All, t => t.Id)` (this call site actually needs the key set)
- **MainWindow.RefreshTaskCount**: Still uses `App.Index?.Count` (O(1), no migration)
- **SettingsPage.RefreshVaultInfo**: Still uses `App.Index?.Count` (O(1), no migration)

All three call sites are read-on-demand consumers — they do NOT subscribe to `Index.Changed`. Each reads at its own existing cadence (window load, page load, app launch respectively). `Index.Tasks` always reflects the current truth thanks to the watcher → `Index.OnFileChangedOnDisk` wiring from #186.

## Tests

Added `IndexServiceApiEquivalenceTests.cs` with 4 new tests:
- `Tasks_IsNeverNull` — verifies `Index.Tasks` is never null (contract pinning per code-review)
- `Tasks_Count_EqualsLegacyCount` — verifies `Index.Tasks.Count == Index.Count` for any vault state
- `Tasks_Keys_EqualsIdsFromAll` — verifies `Index.Tasks.Keys == Index.All.Select(t => t.Id)`
- `Tasks_Keys_CanBeUsedForUiStateGC` — validates the UI-state GC pattern migrates safely

Full test suite: **666 / 668 pass** (2 pre-existing flaky debouncer tests unrelated to this change).

## Dual review (mandatory)

Ran `code-review` agents in parallel with both `gpt-5.5` and `claude-opus-4.7`. Both independently flagged that `Index.Tasks.Count` is not O(1) — it materializes a dictionary and clones every task. Counter-only call sites should stay on the existing `Index.Count` property. Findings adopted:

- **MainWindow + SettingsPage**: reverted to `Index.Count` (O(1))
- **App.xaml.cs UI-state GC**: migration to `Index.Tasks.Keys` stands (this call site actually needs the key set)
- **Tests**: added `Tasks_IsNeverNull` to pin down the non-null contract

No other findings. Zero findings on null-safety regressions, semantic correctness, or test gaps beyond the non-null assertion (now added).

## Validation

- [x] `dotnet build src/Glasswork.Core/Glasswork.Core.csproj -nologo` — clean build
- [x] `dotnet build src/Glasswork.App -nologo -r win-x64` — clean build  
- [x] `dotnet test tests/Glasswork.Tests/Glasswork.Tests.csproj -nologo` — 666/668 pass
- [x] No `_vault.LoadAll()` remains in `MainWindow.xaml.cs`, `SettingsPage.xaml.cs`, or `App.xaml.cs`
- [x] UI-state GC now uses `Index.Tasks.Keys` API; counter-only sites continue using `Index.Count`
- [x] Dual-model code review complete; all findings addressed