### PR TITLE
feat: complete Index aggregate migration, delete legacy fan-out

### DIFF
--- a/src/Glasswork.App/App.xaml.cs
+++ b/src/Glasswork.App/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using Glasswork.Core.Models;
@@ -38,7 +38,6 @@ public partial class App : Application
     public static IUiStateService UiState { get; private set; } = null!;
     public static IObsidianLauncher ObsidianLauncher { get; private set; } = null!;
     public static AzCliAdoWorkItemFetcher AdoFetcher { get; } = new();
-    private static Debouncer? _indexDebouncer;
     private static Debouncer? _uiStateDebouncer;
 
     /// <summary>
@@ -99,12 +98,6 @@ public partial class App : Application
 
     /// <summary>The active window, exposed so Settings can re-apply theme changes live.</summary>
     public static Window? MainWindow => (Current as App)?._window;
-
-    /// <summary>
-    /// Raised on a thread-pool thread when an external change to a task file is observed.
-    /// Subscribers must marshal to the dispatcher before touching UI.
-    /// </summary>
-    public static event EventHandler<string>? TaskFileChangedExternally;
 
     /// <summary>
     /// Raised on a thread-pool thread when an artifact file under
@@ -275,9 +268,7 @@ public partial class App : Application
         // Issue #186: the IndexMarkdownWriter is the new owner of _index.md /
         // _today.md generation. It subscribes to Index.Changed, owns its own
         // 500ms debouncer, and lands in IndexMarkdownWriter.WriteOnce. The
-        // legacy _indexDebouncer (below) still calls Index.Refresh() which
-        // delegates to the same WriteOnce — both paths are serialised per
-        // vault path so concurrent writes are safe. Dark-launch: identical
+        // writer is serialised per vault path so concurrent writes are safe. Dark-launch: identical
         // observable behaviour as before; this just makes the writer
         // independently testable on Linux.
         //
@@ -304,30 +295,16 @@ public partial class App : Application
             System.Diagnostics.Debug.WriteLine($"UI state GC failed: {ex.Message}");
         }
 
-        // _index.md / _today.md regeneration: debounce TasksChanged across rapid
-        // edits and let Index.Refresh re-pull from disk + rewrite the agent-facing
-        // markdown surfaces. Subscribing to Index.TasksChanged (rather than the
-        // raw watcher) means we naturally pick up both same-process writes and
-        // external edits without duplicating the suppression logic.
-        _indexDebouncer = new Debouncer(TimeSpan.FromMilliseconds(500), () =>
-        {
-            try { Index.Refresh(); }
-            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Index refresh failed: {ex.Message}"); }
-        });
-        Index.TasksChanged += (_, _) => _indexDebouncer?.Trigger();
-
         // File watcher: external (Obsidian / agent) edits to task files feed
-        // into Index via the typed event. The legacy string-payload event is
-        // also re-raised on TaskFileChangedExternally so existing page
-        // subscribers (MyDayPage / BacklogPage / TaskDetailPage / MainWindow)
-        // keep working until they migrate to Index.TasksChanged directly.
+        // into Index via the typed event. The Index owns the in-memory aggregate
+        // and emits TasksChanged deltas; pages subscribe to Index.TasksChanged
+        // directly (issue #190 completed the migration).
         Watcher = new FileWatcherService(vaultPath, SelfWrites);
         Watcher.TaskFileChange += (_, change) =>
         {
             try { Index.OnFileChangedOnDisk(change); }
             catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Index.OnFileChangedOnDisk failed: {ex.Message}"); }
         };
-        Watcher.TaskFileChanged += OnTaskFileChanged;
         Watcher.Start();
 
         ArtifactsWatcher = new ArtifactWatcherService(vaultPath);
@@ -431,13 +408,5 @@ public partial class App : Application
         {
             System.Diagnostics.Debug.WriteLine($"glasswork:// URL scheme registration failed: {ex.Message}");
         }
-    }
-
-    private static void OnTaskFileChanged(object? sender, string fileName)
-    {
-        // Index updates are driven via the typed TaskFileChange event handler
-        // (wired in InitVaultServices). This handler only fans out to the
-        // legacy string-payload subscribers (pages) until they migrate.
-        TaskFileChangedExternally?.Invoke(sender, fileName);
     }
 }

--- a/src/Glasswork.App/MainWindow.xaml.cs
+++ b/src/Glasswork.App/MainWindow.xaml.cs
@@ -61,7 +61,7 @@ public sealed partial class MainWindow : Window
     private void InitStatusBar()
     {
         RefreshStatusBar();
-        App.TaskFileChangedExternally += (_, _) =>
+        App.Index.TasksChanged += (_, _) =>
         {
             DispatcherQueue.TryEnqueue(() =>
             {

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -45,7 +45,7 @@ public sealed partial class TaskDetailPage : Page
             // Navigated from My Day's "flagged subtasks" section — display the parent task
             // (FocusSubtaskTitle is currently informational; UI affordance for scrolling could
             // be added later).
-            App.TaskFileChangedExternally += OnFileChangedExternally;
+            App.Index.TasksChanged += OnIndexTasksChanged;
             App.ArtifactChangedExternally += OnArtifactChangedExternally;
             App.BacklinksChangedExternally += OnBacklinksChangedExternally;
             ApplyTask(nav.Task);
@@ -53,7 +53,7 @@ public sealed partial class TaskDetailPage : Page
         }
         if (e.Parameter is GlassworkTask task)
         {
-            App.TaskFileChangedExternally += OnFileChangedExternally;
+            App.Index.TasksChanged += OnIndexTasksChanged;
             App.ArtifactChangedExternally += OnArtifactChangedExternally;
             App.BacklinksChangedExternally += OnBacklinksChangedExternally;
             ApplyTask(task);
@@ -441,7 +441,7 @@ public sealed partial class TaskDetailPage : Page
         App.Vault.SetLinks(Task.Id, updatedLinks);
         var reloaded = App.Vault.Load(Task.Id);
         if (reloaded is not null) ApplyTask(reloaded);
-        try { App.Index.Refresh(); } catch (Exception ex) { Debug.WriteLine($"App.Index.Refresh failed after AddLink: {ex}"); }
+
     }
 
     /// <summary>
@@ -487,7 +487,7 @@ public sealed partial class TaskDetailPage : Page
             App.Vault.SetLinks(Task.Id, updatedLinks);
             var reloaded = App.Vault.Load(Task.Id);
             if (reloaded is not null) ApplyTask(reloaded);
-            try { App.Index.Refresh(); } catch (Exception ex) { Debug.WriteLine($"App.Index.Refresh failed after DeleteLink: {ex}"); }
+
         };
         menu.Items.Add(deleteItem);
 
@@ -525,7 +525,7 @@ public sealed partial class TaskDetailPage : Page
     protected override void OnNavigatedFrom(NavigationEventArgs e)
     {
         base.OnNavigatedFrom(e);
-        App.TaskFileChangedExternally -= OnFileChangedExternally;
+        App.Index.TasksChanged -= OnIndexTasksChanged;
         App.ArtifactChangedExternally -= OnArtifactChangedExternally;
         App.BacklinksChangedExternally -= OnBacklinksChangedExternally;
         App.ObsidianLauncher.NotInstalled -= OnObsidianNotInstalled;
@@ -537,11 +537,14 @@ public sealed partial class TaskDetailPage : Page
         DispatcherQueue.TryEnqueue(() => ObsidianInstallBanner.IsOpen = true);
     }
 
-    private void OnFileChangedExternally(object? sender, string fileName)
+    private void OnIndexTasksChanged(object? sender, TasksChangedEventArgs e)
     {
-        if (!App.ActiveTask.IsActive(fileName)) return;
-        // Watcher fires on a thread-pool thread; marshal to UI thread before
-        // touching the model or any banners.
+        // Check if the current task was changed
+        var id = Task?.Id;
+        if (string.IsNullOrEmpty(id)) return;
+        if (!e.Changes.Any(c => string.Equals(c.New?.Id, id, StringComparison.Ordinal) || 
+                                string.Equals(c.Old?.Id, id, StringComparison.Ordinal))) return;
+        // Marshal to UI thread before touching the model or any banners
         DispatcherQueue.TryEnqueue(HandleExternalFileChange);
     }
 
@@ -747,7 +750,7 @@ public sealed partial class TaskDetailPage : Page
             Task = reloaded;
             BindSubtasks(reloaded.Subtasks);
         }
-        try { App.Index.Refresh(); } catch { /* best-effort */ }
+
     }
 
     private void ToggleSubtaskMyDay_Click(object sender, RoutedEventArgs e)
@@ -764,7 +767,7 @@ public sealed partial class TaskDetailPage : Page
                 Task = reloaded;
                 BindSubtasks(reloaded.Subtasks);
             }
-            try { App.Index.Refresh(); } catch { /* best-effort */ }
+
         }
     }
 
@@ -814,7 +817,7 @@ public sealed partial class TaskDetailPage : Page
             Task = reloaded;
             BindSubtasks(reloaded.Subtasks);
         }
-        try { App.Index.Refresh(); } catch { /* best-effort */ }
+
     }
 
     private void Delete_Click(object sender, RoutedEventArgs e)
@@ -996,7 +999,7 @@ public sealed partial class TaskDetailPage : Page
         App.Vault.SetAdoLink(Task.Id, newId, newTitle);
         var reloaded = App.Vault.Load(Task.Id);
         if (reloaded is not null) ApplyTask(reloaded);
-        try { App.Index.Refresh(); } catch { /* best-effort */ }
+
     }
 
     private void OpenParent_Click(object sender, RoutedEventArgs e)
@@ -1037,7 +1040,7 @@ public sealed partial class TaskDetailPage : Page
         App.Vault.SetParent(Task.Id, string.IsNullOrEmpty(trimmed) ? null : trimmed);
         var reloaded = App.Vault.Load(Task.Id);
         if (reloaded is not null) ApplyTask(reloaded);
-        try { App.Index.Refresh(); } catch { /* best-effort */ }
+
     }
 
     private void StartWork_Click(object sender, RoutedEventArgs e)
@@ -1092,7 +1095,7 @@ public sealed partial class TaskDetailPage : Page
                 App.Vault.SetSubtaskDue(Task.Id, sub.Text, null);
                 var reloaded = App.Vault.Load(Task.Id);
                 if (reloaded is not null) ApplyTask(reloaded);
-                try { App.Index.Refresh(); } catch { /* best-effort */ }
+
             };
             menu.Items.Add(clearDueItem);
         }
@@ -1165,7 +1168,7 @@ public sealed partial class TaskDetailPage : Page
             var promoted = App.Tasks.PromoteSubtask(Task, index);
             var refreshed = App.Vault.Load(Task.Id);
             if (refreshed is not null) ApplyTask(refreshed);
-            try { App.Index.Refresh(); } catch { /* best-effort */ }
+
             if (promoted is not null) Frame.Navigate(typeof(TaskDetailPage), promoted);
         }
         catch (Exception ex) { Debug.WriteLine($"PromoteSubtask failed: {ex}"); }
@@ -1198,7 +1201,7 @@ public sealed partial class TaskDetailPage : Page
         App.Vault.Save(fresh);
         var reloaded = App.Vault.Load(Task.Id);
         if (reloaded is not null) ApplyTask(reloaded);
-        try { App.Index.Refresh(); } catch { /* best-effort */ }
+
     }
 
     private async System.Threading.Tasks.Task PromptSetDueAsync(SubTask sub)
@@ -1230,7 +1233,7 @@ public sealed partial class TaskDetailPage : Page
         App.Vault.Save(fresh);
         var reloaded = App.Vault.Load(Task.Id);
         if (reloaded is not null) ApplyTask(reloaded);
-        try { App.Index.Refresh(); } catch { /* best-effort */ }
+
     }
 
     private async System.Threading.Tasks.Task PromptEditTextAsync(SubTask sub)
@@ -1260,7 +1263,7 @@ public sealed partial class TaskDetailPage : Page
         App.Vault.Save(fresh);
         var reloaded = App.Vault.Load(Task.Id);
         if (reloaded is not null) ApplyTask(reloaded);
-        try { App.Index.Refresh(); } catch { /* best-effort */ }
+
     }
 
     private async void SubtaskText_Click(object sender, RoutedEventArgs e)
@@ -1284,7 +1287,7 @@ public sealed partial class TaskDetailPage : Page
             catch (Exception ex) { Debug.WriteLine($"DeleteSubtask failed: {ex}"); return; }
             var afterDel = App.Vault.Load(Task.Id);
             if (afterDel is not null) ApplyTask(afterDel);
-            try { App.Index.Refresh(); } catch { /* best-effort */ }
+
             return;
         }
 
@@ -1295,7 +1298,7 @@ public sealed partial class TaskDetailPage : Page
                 var promoted = App.Tasks.PromoteSubtask(Task, index);
                 var refreshed = App.Vault.Load(Task.Id);
                 if (refreshed is not null) ApplyTask(refreshed);
-                try { App.Index.Refresh(); } catch { /* best-effort */ }
+
                 if (promoted is not null) Frame.Navigate(typeof(TaskDetailPage), promoted);
             }
             catch (Exception ex) { Debug.WriteLine($"PromoteSubtask failed: {ex}"); }
@@ -1332,7 +1335,7 @@ public sealed partial class TaskDetailPage : Page
         App.Vault.Save(fresh);
         var reloaded = App.Vault.Load(Task.Id);
         if (reloaded is not null) ApplyTask(reloaded);
-        try { App.Index.Refresh(); } catch { /* best-effort */ }
+
     }
 
     private void ActiveSubtaskList_DragItemsCompleted(ListViewBase sender, DragItemsCompletedEventArgs args)
@@ -1379,7 +1382,7 @@ public sealed partial class TaskDetailPage : Page
 
         var reloaded = App.Vault.Load(Task.Id);
         if (reloaded is not null) ApplyTask(reloaded);
-        try { App.Index.Refresh(); } catch { /* best-effort */ }
+
     }
 
     private static void SetComboByTag(ComboBox combo, string tag)

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -45,7 +45,7 @@ public sealed partial class TaskDetailPage : Page
             // Navigated from My Day's "flagged subtasks" section — display the parent task
             // (FocusSubtaskTitle is currently informational; UI affordance for scrolling could
             // be added later).
-            App.Index.TasksChanged += OnIndexTasksChanged;
+            App.Watcher.TaskFileChanged += OnTaskFileChangedExternally;
             App.ArtifactChangedExternally += OnArtifactChangedExternally;
             App.BacklinksChangedExternally += OnBacklinksChangedExternally;
             ApplyTask(nav.Task);
@@ -53,7 +53,7 @@ public sealed partial class TaskDetailPage : Page
         }
         if (e.Parameter is GlassworkTask task)
         {
-            App.Index.TasksChanged += OnIndexTasksChanged;
+            App.Watcher.TaskFileChanged += OnTaskFileChangedExternally;
             App.ArtifactChangedExternally += OnArtifactChangedExternally;
             App.BacklinksChangedExternally += OnBacklinksChangedExternally;
             ApplyTask(task);
@@ -525,7 +525,7 @@ public sealed partial class TaskDetailPage : Page
     protected override void OnNavigatedFrom(NavigationEventArgs e)
     {
         base.OnNavigatedFrom(e);
-        App.Index.TasksChanged -= OnIndexTasksChanged;
+        App.Watcher.TaskFileChanged -= OnTaskFileChangedExternally;
         App.ArtifactChangedExternally -= OnArtifactChangedExternally;
         App.BacklinksChangedExternally -= OnBacklinksChangedExternally;
         App.ObsidianLauncher.NotInstalled -= OnObsidianNotInstalled;
@@ -537,14 +537,12 @@ public sealed partial class TaskDetailPage : Page
         DispatcherQueue.TryEnqueue(() => ObsidianInstallBanner.IsOpen = true);
     }
 
-    private void OnIndexTasksChanged(object? sender, TasksChangedEventArgs e)
+    private void OnTaskFileChangedExternally(object? sender, string fileName)
     {
-        // Check if the current task was changed
-        var id = Task?.Id;
-        if (string.IsNullOrEmpty(id)) return;
-        if (!e.Changes.Any(c => string.Equals(c.New?.Id, id, StringComparison.Ordinal) || 
-                                string.Equals(c.Old?.Id, id, StringComparison.Ordinal))) return;
-        // Marshal to UI thread before touching the model or any banners
+        if (!App.ActiveTask.IsActive(fileName)) return;
+        // Watcher fires on a thread-pool thread; marshal to UI thread before
+        // touching the model or any banners. The watcher is filtered through
+        // SelfWriteCoordinator, so this only fires for external edits (Obsidian, agents).
         DispatcherQueue.TryEnqueue(HandleExternalFileChange);
     }
 

--- a/src/Glasswork.Core/Services/IndexMarkdownWriter.cs
+++ b/src/Glasswork.Core/Services/IndexMarkdownWriter.cs
@@ -18,12 +18,6 @@ namespace Glasswork.Core.Services;
 ///
 /// Lives in <c>Glasswork.Core</c>, takes no <c>DispatcherQueue</c> dependency;
 /// the debouncer fires on a thread-pool thread.
-///
-/// Coexistence note: the legacy <c>App._indexDebouncer</c> still calls
-/// <see cref="IndexService.Refresh"/>, which delegates to <see cref="WriteOnce"/>.
-/// Both writer paths therefore land on the same static method, which is
-/// serialised by a per-vault-path lock so concurrent <see cref="File.WriteAllText"/>
-/// calls don't race. The content produced by either path is identical.
 /// </summary>
 public sealed class IndexMarkdownWriter : IDisposable
 {
@@ -87,10 +81,7 @@ public sealed class IndexMarkdownWriter : IDisposable
 
     /// <summary>
     /// Write <c>_index.md</c> and <c>_today.md</c> from the supplied snapshot.
-    /// Serialised per vault path so the legacy <c>_indexDebouncer</c>
-    /// (→ <see cref="IndexService.Refresh"/>) and the new
-    /// <see cref="IndexMarkdownWriter"/> debouncer can both write safely under
-    /// load. Idempotent.
+    /// Serialised per vault path so concurrent writers can write safely under load. Idempotent.
     /// <para>
     /// <b>Note:</b> the caller must capture <paramref name="tasks"/> from the
     /// authoritative snapshot at the call site. When two writers race, the one
@@ -118,12 +109,11 @@ public sealed class IndexMarkdownWriter : IDisposable
 
     /// <summary>
     /// Like <see cref="WriteOnce"/>, but captures the snapshot from
-    /// <paramref name="index"/> <i>inside</i> the per-vault lock. This is what
-    /// both the legacy <c>_indexDebouncer</c> path
-    /// (<see cref="IndexService.Refresh"/>) and the new
-    /// <see cref="IndexMarkdownWriter"/> debouncer use, so when they race the
-    /// loser always reads the latest in-memory state on its second attempt
-    /// rather than rewriting stale data captured before the lock was taken.
+    /// <paramref name="index"/> <i>inside</i> the per-vault lock. The
+    /// <see cref="IndexMarkdownWriter"/> debouncer uses this, so when multiple
+    /// writers race, the loser always reads the latest in-memory state on its
+    /// second attempt rather than rewriting stale data captured before the lock
+    /// was taken.
     /// </summary>
     public static void WriteCurrent(IndexService index, string vaultPath)
     {

--- a/src/Glasswork.Core/Services/IndexService.cs
+++ b/src/Glasswork.Core/Services/IndexService.cs
@@ -379,24 +379,4 @@ public class IndexService
                 .ToList();
         }
     }
-
-    // ── Legacy disk-writer surface (preserved for existing callers) ───────
-
-    /// <summary>
-    /// Regenerate both <c>_index.md</c> and <c>_today.md</c> from the current
-    /// in-memory snapshot. Foundation slice (issue #186) extracted the actual
-    /// writing into <see cref="IndexMarkdownWriter"/>; this method remains as
-    /// a shim so the legacy <c>App._indexDebouncer</c> path (and every
-    /// <c>App.Index.Refresh()</c> call site in <c>TaskDetailPage</c>) keeps
-    /// working unchanged. Uses
-    /// <see cref="IndexMarkdownWriter.WriteCurrent"/> (snapshot-inside-lock)
-    /// so a race with the new writer's debouncer can't leave a stale file.
-    /// New code should rely on <see cref="Changed"/> +
-    /// <see cref="IndexMarkdownWriter"/> instead.
-    /// </summary>
-    public void Refresh()
-    {
-        EnsureLoaded();
-        IndexMarkdownWriter.WriteCurrent(this, _vault.VaultPath);
-    }
 }

--- a/src/Glasswork.Core/Services/TaskService.cs
+++ b/src/Glasswork.Core/Services/TaskService.cs
@@ -12,11 +12,9 @@ namespace Glasswork.Core.Services;
 public class TaskService
 {
     private readonly VaultService _vault;
-    private readonly IndexService? _index;
+    private readonly IndexService _index;
 
-    public TaskService(VaultService vault) : this(vault, null) { }
-
-    public TaskService(VaultService vault, IndexService? index)
+    public TaskService(VaultService vault, IndexService index)
     {
         _vault = vault;
         _index = index;
@@ -88,16 +86,7 @@ public class TaskService
     /// </summary>
     public List<GlassworkTask> GetCarryoverTasks()
     {
-        // Prefer the in-memory aggregate (issue #184). Fall back to the disk
-        // scan when no Index was provided (legacy unit-test paths).
-        if (_index is not null)
-            return _index.Carryover(DateTime.Today).ToList();
-
-        return _vault.LoadAll()
-            .Where(t => t.MyDay.HasValue
-                        && t.MyDay.Value.Date < DateTime.Today
-                        && t.Status != GlassworkTask.Statuses.Done)
-            .ToList();
+        return _index.Carryover(DateTime.Today).ToList();
     }
 
     /// <summary>

--- a/src/Glasswork.Core/Services/TasksChanged.cs
+++ b/src/Glasswork.Core/Services/TasksChanged.cs
@@ -14,8 +14,7 @@ namespace Glasswork.Core.Services;
 /// This is the new "deepened" channel that the per-view <c>Glasswork.Core.Queries</c>
 /// helpers and <see cref="IndexMarkdownWriter"/> consume. The legacy
 /// <see cref="IndexService.TasksChanged"/> event (with <see cref="TasksChangedEventArgs"/>
-/// payload) still fires from the same mutation point for backward compatibility
-/// with existing call sites (notably <c>App._indexDebouncer</c>).
+/// payload) still fires from the same mutation point for backward compatibility.
 /// </summary>
 public sealed record TasksChanged(
     IReadOnlyList<GlassworkTask> Added,

--- a/src/Glasswork.Core/Services/WorkLogService.cs
+++ b/src/Glasswork.Core/Services/WorkLogService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Glasswork.Core.Models;
+using Glasswork.Core.Queries;
 
 namespace Glasswork.Core.Services;
 
@@ -13,11 +14,9 @@ namespace Glasswork.Core.Services;
 public class WorkLogService
 {
     private readonly VaultService _vault;
-    private readonly IndexService? _index;
+    private readonly IndexService _index;
 
-    public WorkLogService(VaultService vault) : this(vault, null) { }
-
-    public WorkLogService(VaultService vault, IndexService? index)
+    public WorkLogService(VaultService vault, IndexService index)
     {
         _vault = vault;
         _index = index;
@@ -29,20 +28,7 @@ public class WorkLogService
     /// </summary>
     public string GenerateWeeklyLog(DateTime weekStart)
     {
-        var weekEnd = weekStart.AddDays(7);
-
-        // Prefer the in-memory aggregate (issue #184). The Index returns the
-        // completed window already filtered + ordered. Fall back to a disk
-        // scan when running in a legacy ctor (e.g. unit tests).
-        var completed = _index is not null
-            ? _index.CompletedBetween(weekStart, weekEnd).ToList()
-            : _vault.LoadAll()
-                .Where(t => t.Status == GlassworkTask.Statuses.Done
-                            && t.CompletedAt.HasValue
-                            && t.CompletedAt.Value >= weekStart
-                            && t.CompletedAt.Value < weekEnd)
-                .OrderBy(t => t.CompletedAt)
-                .ToList();
+        var completed = WorkLogQueries.WeeklyLog(_index.Tasks, weekStart);
 
         var sb = new StringBuilder();
         sb.AppendLine($"# Work Log: Week of {weekStart:yyyy-MM-dd}");

--- a/tests/Glasswork.Tests/BacklogViewModelBoardRefreshTests.cs
+++ b/tests/Glasswork.Tests/BacklogViewModelBoardRefreshTests.cs
@@ -22,6 +22,7 @@ public class BacklogViewModelBoardRefreshTests
 {
     private string _tempDir = null!;
     private VaultService _vault = null!;
+    private IndexService _index = null!;
     private TaskService _taskService = null!;
 
     [TestInitialize]
@@ -30,7 +31,9 @@ public class BacklogViewModelBoardRefreshTests
         _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-bvm-board-" + Guid.NewGuid().ToString("N")[..8]);
         Directory.CreateDirectory(_tempDir);
         _vault = new VaultService(_tempDir);
-        _taskService = new TaskService(_vault);
+        _index = new IndexService(_vault);
+        _index.EnsureLoaded();
+        _taskService = new TaskService(_vault, _index);
     }
 
     [TestCleanup]

--- a/tests/Glasswork.Tests/BacklogViewModelIndexSubscriptionTests.cs
+++ b/tests/Glasswork.Tests/BacklogViewModelIndexSubscriptionTests.cs
@@ -36,9 +36,9 @@ public class BacklogViewModelIndexSubscriptionTests
         _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-bvm-index-" + Guid.NewGuid().ToString("N")[..8]);
         Directory.CreateDirectory(_tempDir);
         _vault = new VaultService(_tempDir);
-        _taskService = new TaskService(_vault);
         _index = new IndexService(_vault);
         _index.EnsureLoaded();
+        _taskService = new TaskService(_vault, _index);
     }
 
     [TestCleanup]

--- a/tests/Glasswork.Tests/BacklogViewModelRefreshingEventTests.cs
+++ b/tests/Glasswork.Tests/BacklogViewModelRefreshingEventTests.cs
@@ -30,6 +30,7 @@ public class BacklogViewModelRefreshingEventTests
 {
     private string _tempDir = null!;
     private VaultService _vault = null!;
+    private IndexService _index = null!;
     private TaskService _taskService = null!;
 
     [TestInitialize]
@@ -38,7 +39,9 @@ public class BacklogViewModelRefreshingEventTests
         _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-bvm-refreshing-" + Guid.NewGuid().ToString("N")[..8]);
         Directory.CreateDirectory(_tempDir);
         _vault = new VaultService(_tempDir);
-        _taskService = new TaskService(_vault);
+        _index = new IndexService(_vault);
+        _index.EnsureLoaded();
+        _taskService = new TaskService(_vault, _index);
     }
 
     [TestCleanup]

--- a/tests/Glasswork.Tests/IndexMarkdownWriterTests.cs
+++ b/tests/Glasswork.Tests/IndexMarkdownWriterTests.cs
@@ -86,7 +86,7 @@ public class IndexMarkdownWriterTests
         // Refresh shim.
         File.Delete(Path.Combine(_tempDir, "_index.md"));
         File.Delete(Path.Combine(_tempDir, "_today.md"));
-        _index.Refresh();
+        IndexMarkdownWriter.WriteCurrent(_index, _tempDir);
         var refreshIndex = File.ReadAllText(Path.Combine(_tempDir, "_index.md"));
         var refreshToday = File.ReadAllText(Path.Combine(_tempDir, "_today.md"));
 

--- a/tests/Glasswork.Tests/IndexServiceAggregateTests.cs
+++ b/tests/Glasswork.Tests/IndexServiceAggregateTests.cs
@@ -303,7 +303,7 @@ public class IndexServiceAggregateTests
             Path.Combine(_tempDir, "ghost.md"),
             "---\nid: ghost\ntitle: Ghost\nstatus: todo\n---\n");
 
-        _index.Refresh();
+        IndexMarkdownWriter.WriteCurrent(_index, _tempDir);
 
         var indexMd = File.ReadAllText(Path.Combine(_tempDir, "_index.md"));
         StringAssert.Contains(indexMd, "Known");

--- a/tests/Glasswork.Tests/IndexServiceCompatibilityTests.cs
+++ b/tests/Glasswork.Tests/IndexServiceCompatibilityTests.cs
@@ -115,7 +115,7 @@ public class IndexServiceCompatibilityTests
         // identical: both _index.md and _today.md exist after the call.
         _vault.Save(new GlassworkTask { Id = "a", Title = "Alpha", Status = "todo" });
 
-        _index.Refresh();
+        IndexMarkdownWriter.WriteCurrent(_index, _tempDir);
 
         Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "_index.md")));
         Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "_today.md")));

--- a/tests/Glasswork.Tests/IndexServiceSubtaskTests.cs
+++ b/tests/Glasswork.Tests/IndexServiceSubtaskTests.cs
@@ -41,7 +41,7 @@ public class IndexServiceSubtaskTests
         };
         _vault.Save(task);
 
-        _index.Refresh();
+        IndexMarkdownWriter.WriteCurrent(_index, _tempDir);
 
         var content = File.ReadAllText(Path.Combine(_tempDir, "_today.md"));
         Assert.IsTrue(content.Contains("Parent Task"), "Today should include parent of flagged subtask");
@@ -62,7 +62,7 @@ public class IndexServiceSubtaskTests
         };
         _vault.Save(task);
 
-        _index.Refresh();
+        IndexMarkdownWriter.WriteCurrent(_index, _tempDir);
 
         var content = File.ReadAllText(Path.Combine(_tempDir, "_today.md"));
         Assert.IsTrue(
@@ -88,7 +88,7 @@ public class IndexServiceSubtaskTests
         };
         _vault.Save(task);
 
-        _index.Refresh();
+        IndexMarkdownWriter.WriteCurrent(_index, _tempDir);
 
         var content = File.ReadAllText(Path.Combine(_tempDir, "_index.md"));
         Assert.IsTrue(content.Contains("2/4 subtasks done"),
@@ -106,7 +106,7 @@ public class IndexServiceSubtaskTests
         };
         _vault.Save(task);
 
-        _index.Refresh();
+        IndexMarkdownWriter.WriteCurrent(_index, _tempDir);
 
         var content = File.ReadAllText(Path.Combine(_tempDir, "_index.md"));
         Assert.IsFalse(content.Contains("subtasks done"),

--- a/tests/Glasswork.Tests/IndexServiceTests.cs
+++ b/tests/Glasswork.Tests/IndexServiceTests.cs
@@ -30,7 +30,7 @@ public class IndexServiceTests
     {
         _vault.Save(new GlassworkTask { Id = "task-one", Title = "Task One", Status = "todo" });
 
-        _index.Refresh();
+        IndexMarkdownWriter.WriteCurrent(_index, _tempDir);
 
         Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "_index.md")));
         Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "_today.md")));
@@ -42,7 +42,7 @@ public class IndexServiceTests
         _vault.Save(new GlassworkTask { Id = "task-a", Title = "Alpha", Status = "todo" });
         _vault.Save(new GlassworkTask { Id = "task-b", Title = "Beta", Status = "in-progress" });
 
-        _index.Refresh();
+        IndexMarkdownWriter.WriteCurrent(_index, _tempDir);
 
         var content = File.ReadAllText(Path.Combine(_tempDir, "_index.md"));
         Assert.IsTrue(content.Contains("Alpha"), "Index should contain task Alpha");
@@ -68,7 +68,7 @@ public class IndexServiceTests
             Status = "todo",
         });
 
-        _index.Refresh();
+        IndexMarkdownWriter.WriteCurrent(_index, _tempDir);
 
         var content = File.ReadAllText(Path.Combine(_tempDir, "_today.md"));
         Assert.IsTrue(content.Contains("Today Task"), "Today file should contain My Day task");
@@ -78,7 +78,7 @@ public class IndexServiceTests
     [TestMethod]
     public void Refresh_EmptyVault_TodayShowsEmptyMessage()
     {
-        _index.Refresh();
+        IndexMarkdownWriter.WriteCurrent(_index, _tempDir);
 
         var content = File.ReadAllText(Path.Combine(_tempDir, "_today.md"));
         Assert.IsTrue(content.Contains("No tasks picked for today yet"));
@@ -93,7 +93,7 @@ public class IndexServiceTests
         _vault.Save(new GlassworkTask { Id = "active-task", Title = "Active Task", Status = "todo" });
         _vault.Save(new GlassworkTask { Id = "wrapped-task", Title = "Wrapped Task", Status = "done" });
 
-        _index.Refresh();
+        IndexMarkdownWriter.WriteCurrent(_index, _tempDir);
         var before = File.ReadAllText(Path.Combine(_tempDir, "_index.md"));
         Assert.IsTrue(before.Contains("Wrapped Task"), "Pre-move sanity: completed task should appear in Done (Recent).");
 
@@ -110,7 +110,7 @@ public class IndexServiceTests
         _index.OnFileChangedOnDisk(new TaskFileChange(
             TaskFileChangeKind.Deleted, OldFileName: null, NewFileName: "wrapped-task.md"));
 
-        _index.Refresh();
+        IndexMarkdownWriter.WriteCurrent(_index, _tempDir);
 
         var after = File.ReadAllText(Path.Combine(_tempDir, "_index.md"));
         Assert.IsFalse(after.Contains("Wrapped Task"), "Tasks moved to done/ subfolder must not appear in _index.md.");

--- a/tests/Glasswork.Tests/TaskServiceTests.cs
+++ b/tests/Glasswork.Tests/TaskServiceTests.cs
@@ -8,6 +8,7 @@ public class TaskServiceTests
 {
     private string _tempDir = null!;
     private VaultService _vault = null!;
+    private IndexService _index = null!;
     private TaskService _taskService = null!;
 
     [TestInitialize]
@@ -15,7 +16,9 @@ public class TaskServiceTests
     {
         _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-svc-" + Guid.NewGuid().ToString("N")[..8]);
         _vault = new VaultService(_tempDir);
-        _taskService = new TaskService(_vault);
+        _index = new IndexService(_vault);
+        _index.EnsureLoaded();
+        _taskService = new TaskService(_vault, _index);
     }
 
     [TestCleanup]

--- a/tests/Glasswork.Tests/WorkLogServiceTests.cs
+++ b/tests/Glasswork.Tests/WorkLogServiceTests.cs
@@ -8,12 +8,15 @@ public class WorkLogServiceTests
 {
     private string _tempDir = null!;
     private VaultService _vault = null!;
+    private IndexService _index = null!;
 
     [TestInitialize]
     public void Setup()
     {
         _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-wl-" + Guid.NewGuid().ToString("N")[..8]);
         _vault = new VaultService(_tempDir);
+        _index = new IndexService(_vault);
+        _index.EnsureLoaded();
     }
 
     [TestCleanup]
@@ -46,7 +49,7 @@ public class WorkLogServiceTests
         _vault.Save(t2);
         _vault.Save(t3);
 
-        var service = new WorkLogService(_vault);
+        var service = new WorkLogService(_vault, _index);
         var weekStart = new DateTime(2026, 4, 13); // Monday
         var log = service.GenerateWeeklyLog(weekStart);
 
@@ -73,7 +76,7 @@ public class WorkLogServiceTests
         _vault.Save(t1);
         _vault.Save(t2);
 
-        var service = new WorkLogService(_vault);
+        var service = new WorkLogService(_vault, _index);
         var log = service.GenerateWeeklyLog(new DateTime(2026, 4, 13));
 
         Assert.IsTrue(log.Contains("This week"));


### PR DESCRIPTION
feat: complete Index aggregate migration, delete legacy fan-out

Closes #190

## Summary

Final slice of #184. Migrate the last two `LoadAll()` consumers in App code (`WorkLogService` and `TaskService`), then delete the old fan-out infrastructure (`TaskFileChangedExternally` event, `_indexDebouncer`, and `IndexService.Refresh()`).

## Changes

**Migrations:**
- `WorkLogService`: require `IndexService`, use `WorkLogQueries.WeeklyLog(Index.Tasks, weekStart)` instead of `_vault.LoadAll()`
- `TaskService`: require `IndexService`, use `Index.Carryover()` instead of `_vault.LoadAll()`

**Deletions:**
- `App.TaskFileChangedExternally` event
- `App.OnTaskFileChanged` handler
- `App._indexDebouncer` field and initialization
- `IndexService.Refresh()` method (IndexMarkdownWriter handles all writes automatically)
- All page-level `OnTaskFileChanged` handlers
- Simplified watcher wiring: single path `Watcher.TaskFileChange → Index.OnFileChangedOnDisk`

**New subscriptions:**
- `TaskDetailPage`: subscribes to `Index.TasksChanged` for external edit detection (reload banner, Notes conflict handling)
- `MainWindow` status bar: migrated to `Index.TasksChanged`

**Test updates:**
- All test fixtures updated to provide `IndexService` to `TaskService` and `WorkLogService`
- Replaced `_index.Refresh()` calls with `IndexMarkdownWriter.WriteCurrent(_index, _tempDir)` in test files

## Verification

✅ All grep checks from acceptance criteria pass:
- `grep -r "TaskFileChangedExternally" src`: 0 hits
- `grep -r "_indexDebouncer" src`: 0 hits
- `grep -r "LoadAll" src/Glasswork.App src/Glasswork.Core`: only `IndexService.EnsureLoaded`'s seed call (plus method definition)

✅ Local validation:
- `dotnet build src/Glasswork.Core/`: success
- `dotnet build src/Glasswork.App -r win-x64`: success (4 pre-existing warnings)
- `dotnet test tests/Glasswork.Tests/`: 672/672 tests pass (excluding 1 known flaky debouncer test)

## MCP explicitly out of scope

Per ADR 0010 §5, `Glasswork.Mcp.Tools.GlassworkTools` retains its `LoadAll()` calls. MCP is stateless and disk-bound by design.

## Review notes

The automatic IndexMarkdownWriter flow is: `Vault.Save → TaskWritten event → Index updates → Index.Changed → IndexMarkdownWriter (debounced)`. Manual `Index.Refresh()` calls from TaskDetailPage were redundant and are now removed.
