### PR TITLE
feat(mcp): v0.5.0 polish pass — uniform errors, todo-relative paths, trace coverage, fields[] (#133)

### DIFF
--- a/src/Glasswork.Mcp/CHANGELOG.md
+++ b/src/Glasswork.Mcp/CHANGELOG.md
@@ -9,7 +9,7 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ### Breaking
 
-- **Paths in MCP tool output are now todo-relative and use forward slashes** (issue #133). All `path` fields returned by `add_task`, `list_tasks`, `get_task`, `add_artifact`, and `load_context.artifacts[]` are relative to `<vault>/wiki/todo/` and always use `/` as the separator — `add_task` no longer returns absolute paths like `C:\Users\…\wiki\todo\foo.md` and `get_task`/`add_artifact` no longer emit OS-shaped paths like `foo.artifacts\plan.md` on Windows. **Migration**: prepend `$GLASSWORK_VAULT/wiki/todo/` to recover the previous absolute form. The single exception is `load_context.backlinks[].source_path`, which stays relative to the **vault root** (e.g. `wiki/concepts/foo.md`) because backlinks point at pages outside `wiki/todo/`. Per ADR 0007 §8, this drives the minor-version bump.
+- **Paths in MCP tool output are now todo-relative and use forward slashes** (issue #133). All `path` fields returned by `add_task`, `list_tasks`, `get_task`, `add_artifact`, and every artifact path inside `load_context` (both root and subtree levels) are relative to `<vault>/wiki/todo/` and always use `/` as the separator — `add_task` no longer returns absolute paths like `C:\Users\…\wiki\todo\foo.md` and `get_task`/`add_artifact` no longer emit OS-shaped paths like `foo.artifacts\plan.md` on Windows. **Migration**: prepend `$GLASSWORK_VAULT/wiki/todo/` to recover the previous absolute form. The single exception is `load_context.backlinks[].source_path`, which stays relative to the **vault root** (e.g. `wiki/concepts/foo.md`) because backlinks point at pages outside `wiki/todo/`. Per ADR 0007 §8, this drives the minor-version bump.
 
 ### Added
 
@@ -17,7 +17,7 @@ This project follows [Semantic Versioning](https://semver.org/).
   - `add_task` validates an empty title (`invalid_title`) and invalid status (`invalid_status`).
   - `list_tasks` validates invalid status (`invalid_status`).
   - `search_tasks` validates empty/too-long query (`invalid_query`), invalid `in` field (`invalid_in_field`), and invalid status filter (`invalid_status`); pre-validation runs in the MCP layer so error codes do not depend on `Glasswork.Core` exception messages.
-  - `add_artifact` validates an empty filename (`invalid_filename`).
+  - `add_artifact` validates an empty filename (`invalid_filename`), a null `content` (`invalid_content`), and a `filename` containing a path separator (`path_traversal`). The path-separator check sits above `VaultPathGuard.EnsurePathInVault` because the guard only verifies the resolved path stays inside the artifact folder — a value like `nested/plan.md` passes that check but would then crash `File.WriteAllText` with `DirectoryNotFoundException` and escape the structured envelope.
 - **Trace phase coverage for the remaining tools** (issue #133). Under `GLASSWORK_MCP_TRACE=1`:
   - `get_task` now emits `load_task` (the vault read) and `scan_artifacts` (the artifact-folder enumeration) phases.
   - `add_artifact` now emits a `write` phase around `File.WriteAllText`.

--- a/src/Glasswork.Mcp/CHANGELOG.md
+++ b/src/Glasswork.Mcp/CHANGELOG.md
@@ -5,6 +5,31 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.5.0] — 2026-05-26
+
+### Breaking
+
+- **Paths in MCP tool output are now todo-relative and use forward slashes** (issue #133). All `path` fields returned by `add_task`, `list_tasks`, `get_task`, `add_artifact`, and `load_context.artifacts[]` are relative to `<vault>/wiki/todo/` and always use `/` as the separator — `add_task` no longer returns absolute paths like `C:\Users\…\wiki\todo\foo.md` and `get_task`/`add_artifact` no longer emit OS-shaped paths like `foo.artifacts\plan.md` on Windows. **Migration**: prepend `$GLASSWORK_VAULT/wiki/todo/` to recover the previous absolute form. The single exception is `load_context.backlinks[].source_path`, which stays relative to the **vault root** (e.g. `wiki/concepts/foo.md`) because backlinks point at pages outside `wiki/todo/`. Per ADR 0007 §8, this drives the minor-version bump.
+
+### Added
+
+- **Uniform structured error envelope across every tool** (issue #133). No tool throws `ArgumentException` (or any other exception triggered by user input) to the MCP transport. `add_task`, `list_tasks`, and `search_tasks` now return the structured `{ "error": "<code>", "message": "<text>" }` envelope on invalid input — matching the shape `get_task` / `add_artifact` / `load_context` already used.
+  - `add_task` validates an empty title (`invalid_title`) and invalid status (`invalid_status`).
+  - `list_tasks` validates invalid status (`invalid_status`).
+  - `search_tasks` validates empty/too-long query (`invalid_query`), invalid `in` field (`invalid_in_field`), and invalid status filter (`invalid_status`); pre-validation runs in the MCP layer so error codes do not depend on `Glasswork.Core` exception messages.
+  - `add_artifact` validates an empty filename (`invalid_filename`).
+- **Trace phase coverage for the remaining tools** (issue #133). Under `GLASSWORK_MCP_TRACE=1`:
+  - `get_task` now emits `load_task` (the vault read) and `scan_artifacts` (the artifact-folder enumeration) phases.
+  - `add_artifact` now emits a `write` phase around `File.WriteAllText`.
+- **`list_tasks.fields[]` projection parameter** (issue #133). Optional `fields: string[]` argument. When omitted, null, or empty, the default summary shape (`id`, `title`, `status`, `parent_id`, `path`) is preserved byte-for-byte. When supplied, the summary contains the listed fields plus `id` (always included). Allowed values: `title`, `status`, `parent_id`, `path`, `created`, `priority`. Field names are case-folded, whitespace-trimmed, and de-duplicated; unknown names are silently dropped. `created` is rendered as `yyyy-MM-dd`.
+
+### Internal
+
+- `MapToInternalStatus` refactored to `TryMapToInternalStatus` with a try-pattern signature so call sites can early-return the structured envelope rather than throwing.
+- All output-path construction now flows through `TodoRelativeTaskPath` / `TodoRelativeArtifactPath` / `NormalizeOutputPath` helpers. `Path.Combine` is reserved for filesystem operations only.
+
+---
+
 ## [0.4.0] — 2026-05-15
 
 ### Added

--- a/src/Glasswork.Mcp/Glasswork.Mcp.csproj
+++ b/src/Glasswork.Mcp/Glasswork.Mcp.csproj
@@ -8,7 +8,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>glasswork-mcp</ToolCommandName>
     <PackageId>glasswork-mcp</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Description>Glasswork MCP server — typed agent access to an Obsidian-backed task vault.</Description>
     <Authors>Glasswork</Authors>
     <RollForward>LatestMajor</RollForward>

--- a/src/Glasswork.Mcp/README.md
+++ b/src/Glasswork.Mcp/README.md
@@ -2,7 +2,7 @@
 
 `glasswork-mcp` is a standalone [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that gives AI agents typed read/write access to a [Glasswork](https://github.com/tjegbejimba/Glasswork) task vault. It communicates over stdio and requires no running Glasswork app instance.
 
-> **v0.5.0 — M5**: `search_tasks` is now implemented — topic-driven task discovery across title, description, notes, subtasks, and tags with ranked results and per-hit snippets. See [Tool reference](#tool-reference) for the schema.
+> **v0.5.0**: cross-cutting polish pass — uniform structured error envelope across every tool (no more `ArgumentException` to the MCP transport), todo-relative paths with forward-slash normalization (breaking — see [CHANGELOG](./CHANGELOG.md)), trace phase coverage extended to `get_task` and `add_artifact`, and `list_tasks` gains an optional `fields[]` projection parameter. See [Tool reference](#tool-reference) for the updated schemas.
 
 ---
 
@@ -134,7 +134,7 @@ Topic-driven task discovery. Splits the query on whitespace and requires **all t
 }
 ```
 
-- **`in`** (optional): restrict which fields are searched. Omit to search all five. Invalid values cause an `ArgumentException`.
+- **`in`** (optional): restrict which fields are searched. Omit to search all five.
 - **`tags`** (optional): AND filter — every listed tag must be present on the task.
 - **`status`** (optional): include only tasks with one of the listed statuses.
 - **`limit`** (optional): max results. Values outside `[1, 100]` are silently clamped.
@@ -158,14 +158,14 @@ Topic-driven task discovery. Splits the query on whitespace and requires **all t
 
 Results are ranked: tasks with a title match score higher than body-only matches. Tiebreak: newest first, then by ID. Artifact body content is **not** searched in v1.
 
-**Errors** — propagated as `ArgumentException`:
+**Errors** — returned as the structured `{ "error": "<code>", "message": "<text>" }` envelope:
 
-| Condition | Message |
+| `error` value | When |
 |---|---|
-| Empty / whitespace query | `query is required.` |
-| Query longer than 500 chars | `query must be 500 characters or fewer.` |
-| Unknown `in` field | `Invalid in field '<name>'. Valid values: title, description, notes, subtasks, tags.` |
-| Unknown `status` value | `Invalid status '<value>'. Valid values: todo, doing, done.` |
+| `invalid_query` | Empty/whitespace query or query longer than 500 characters |
+| `invalid_in_field` | Unknown value in `in[]` (allowed: `title`, `description`, `notes`, `subtasks`, `tags`) |
+| `invalid_status` | Unknown value in `status[]` (allowed: `todo`, `doing`, `done`) |
+| `invalid_argument` | Defensive fallback for any other input-validation failure surfaced from `Glasswork.Core` |
 
 ---
 
@@ -182,14 +182,21 @@ Results are ranked: tasks with a title match score higher than body-only matches
 }
 ```
 
-**Output**
+**Output (success)**
 
 ```json
 {
   "task_id": "string — the generated task ID (slug from title)",
-  "path": "string — absolute path to the created task file"
+  "path": "string — todo-relative path to the created task file, e.g. fix-the-bug.md"
 }
 ```
+
+**Output (errors)**
+
+| `error` value | When |
+|---|---|
+| `invalid_title` | `title` is null, empty, or whitespace |
+| `invalid_status` | `status` is not one of `todo`, `doing`, `done` |
 
 ### `list_tasks`
 
@@ -198,11 +205,14 @@ Results are ranked: tasks with a title match score higher than body-only matches
 ```json
 {
   "status": "\"todo\" | \"doing\" | \"done\" (optional)",
-  "parent_task_id": "string (optional)"
+  "parent_task_id": "string (optional)",
+  "fields": ["string", "..."]
 }
 ```
 
-**Output**
+- **`fields`** (optional): when provided, each returned summary contains only the requested fields plus `id` (always included). Allowed values: `title`, `status`, `parent_id`, `path`, `created`, `priority`. Field names are case-folded, whitespace-trimmed, and de-duplicated; unknown names are silently dropped. Omitting `fields` (or passing `null` / `[]`) preserves the default shape below.
+
+**Output (default — no `fields`)**
 
 ```json
 {
@@ -212,13 +222,29 @@ Results are ranked: tasks with a title match score higher than body-only matches
       "title": "string",
       "status": "\"todo\" | \"doing\" | \"done\"",
       "parent_id": "string | null",
-      "path": "string — absolute path to the task file"
+      "path": "string — todo-relative path to the task file, e.g. fix-the-bug.md"
     }
   ]
 }
 ```
 
+**Output (with `fields: ["created", "priority"]`)**
+
+```json
+{
+  "tasks": [
+    { "id": "string", "created": "yyyy-MM-dd", "priority": "medium" }
+  ]
+}
+```
+
 Results are sorted by created date ascending, then by ID for stability.
+
+**Output (error)**
+
+| `error` value | When |
+|---|---|
+| `invalid_status` | `status` is not one of `todo`, `doing`, `done` |
 
 ---
 
@@ -245,7 +271,7 @@ Results are sorted by created date ascending, then by ID for stability.
   "artifacts": [
     {
       "filename": "string — e.g. plan.md",
-      "path": "string — vault-relative path, e.g. task-id.artifacts/plan.md"
+      "path": "string — todo-relative path, e.g. task-id.artifacts/plan.md"
     }
   ]
 }
@@ -260,7 +286,7 @@ Results are sorted by created date ascending, then by ID for stability.
 }
 ```
 
-Re-reads the vault and artifact folder on every call (no cache). The `artifacts` array lists filenames and vault-relative paths but does not include artifact body content.
+Re-reads the vault and artifact folder on every call (no cache). The `artifacts` array lists filenames and todo-relative paths but does not include artifact body content.
 
 ---
 
@@ -280,7 +306,7 @@ Re-reads the vault and artifact folder on every call (no cache). The `artifacts`
 
 ```json
 {
-  "path": "string — vault-relative path to the created file, e.g. task-id.artifacts/plan.md"
+  "path": "string — todo-relative path to the created file, e.g. task-id.artifacts/plan.md"
 }
 ```
 
@@ -289,7 +315,7 @@ Re-reads the vault and artifact folder on every call (no cache). The `artifacts`
 | `error` value | When |
 |---|---|
 | `not_found` | The task ID does not exist in the vault |
-| `invalid_filename` | `filename` does not end in `.md` |
+| `invalid_filename` | `filename` is null, empty, whitespace, or does not end in `.md` |
 | `path_traversal` | `filename` contains `..`, is absolute, or resolves outside the artifact folder |
 | `conflict` | A file with that name already exists — `add_artifact` is create-only in v1 |
 
@@ -327,7 +353,7 @@ Returns a task's complete context bundle — task content, every artifact's body
   "artifacts": [
     {
       "filename": "string — e.g. plan.md",
-      "path": "string — vault-relative, e.g. task-id.artifacts/plan.md",
+      "path": "string — todo-relative, e.g. task-id.artifacts/plan.md",
       "content": "string — full file body"
     }
   ],
@@ -340,7 +366,7 @@ Returns a task's complete context bundle — task content, every artifact's body
   ],
   "backlinks": [
     {
-      "source_path": "string — vault-relative path to the linking page",
+      "source_path": "string — vault-root-relative path to the linking page, e.g. wiki/concepts/foo.md (always forward slashes). NOTE: this is the one path field that is vault-root-relative, not todo-relative — backlinks point at pages outside wiki/todo/.",
       "source_title": "string — H1 or first non-empty line",
       "page_type": "\"concept\" | \"decision\" | \"incident\" | \"system\" | \"other\""
     }
@@ -422,7 +448,7 @@ Every MCP tool call emits one structured JSON line (JSONL) to **stderr**. An opt
 | Variable | Value | Effect |
 |---|---|---|
 | `GLASSWORK_MCP_LOG` | `1` | Also write each log line to `<vault>/.glasswork/mcp.log`. The file is capped at ~1 MB; when the cap is exceeded the oldest half of entries is automatically pruned. |
-| `GLASSWORK_MCP_TRACE` | `1` | Adds a `phases` object to each log line with per-phase wall-clock times (glob, yaml_parse, filter, sort, write). Off by default — zero overhead in normal use. |
+| `GLASSWORK_MCP_TRACE` | `1` | Adds a `phases` object to each log line with per-phase wall-clock times. Off by default — zero overhead in normal use. |
 
 ### JSONL log-line shape
 
@@ -456,7 +482,12 @@ Phases instrumented in v1:
 | `yaml_parse` | `list_tasks` | Reading and parsing each file's YAML frontmatter |
 | `filter` | `list_tasks` | Applying status / parent_task_id filters |
 | `sort` | `list_tasks` | Sorting results by created date and ID |
-| `write` | `add_task` | Writing the new task file to disk |
+| `write` | `add_task`, `add_artifact` | Writing the file to disk |
+| `load_task` | `get_task`, `load_context` | Loading the root task from disk |
+| `scan_artifacts` | `get_task` | Enumerating the task's artifact folder |
+| `load_artifacts` | `load_context` | Reading every artifact body for the root task |
+| `load_subtasks` | `load_context` | Bounded BFS over the subtask tree |
+| `load_backlinks` | `load_context` | Building the backlink index against the vault root |
 
 ### Enabling the file sink (PowerShell)
 

--- a/src/Glasswork.Mcp/README.md
+++ b/src/Glasswork.Mcp/README.md
@@ -316,10 +316,11 @@ Re-reads the vault and artifact folder on every call (no cache). The `artifacts`
 |---|---|
 | `not_found` | The task ID does not exist in the vault |
 | `invalid_filename` | `filename` is null, empty, whitespace, or does not end in `.md` |
-| `path_traversal` | `filename` contains `..`, is absolute, or resolves outside the artifact folder |
+| `invalid_content` | `content` is null |
+| `path_traversal` | `filename` contains a path separator (`/` or `\`), `..`, is absolute, or resolves outside the artifact folder |
 | `conflict` | A file with that name already exists — `add_artifact` is create-only in v1 |
 
-Artifacts are stored under `<vault>/<task-id>.artifacts/<filename>`. The write is registered with `SelfWriteCoordinator` so the running Glasswork app does not raise a spurious "external change" banner.
+Artifacts are stored under `<vault>/wiki/todo/<task-id>.artifacts/<filename>`. The write is registered with `SelfWriteCoordinator` so the running Glasswork app does not raise a spurious "external change" banner.
 
 ---
 

--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -50,7 +50,18 @@ public sealed class GlassworkTools
         using var scope = _logger?.BeginCall("add_task");
         try
         {
-            var internalStatus = MapToInternalStatus(status);
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                scope?.SetResult("error");
+                return JsonSerializer.Serialize(new ErrorResult("invalid_title", "title is required."));
+            }
+
+            if (!TryMapToInternalStatus(status, out var internalStatus, out var statusError))
+            {
+                scope?.SetResult("error");
+                return JsonSerializer.Serialize(new ErrorResult("invalid_status", statusError!));
+            }
+
             var safeParent = SanitizeId(parent_task_id);
 
             var baseId = VaultService.GenerateId(title);
@@ -74,8 +85,7 @@ public sealed class GlassworkTools
             _vault.Save(task);
             scope?.RecordPhase("write", writeSw.ElapsedMilliseconds);
 
-            var path = Path.Combine(_vaultPath, $"{id}.md");
-            return JsonSerializer.Serialize(new AddTaskResult(TaskId: id, Path: path));
+            return JsonSerializer.Serialize(new AddTaskResult(TaskId: id, Path: TodoRelativeTaskPath(id)));
         }
         catch
         {
@@ -89,12 +99,22 @@ public sealed class GlassworkTools
     [Description("List task summaries filtered by status or parent. Re-reads from disk on every call. For topic or keyword search, use search_tasks.")]
     public string ListTasks(
         [Description("Filter by status: todo, doing, or done.")] string? status = null,
-        [Description("Filter by parent task ID.")] string? parent_task_id = null)
+        [Description("Filter by parent task ID.")] string? parent_task_id = null,
+        [Description("Optional field projection. When provided, each summary contains only these fields plus `id`. Allowed values: title, status, parent_id, path, created, priority. Unknown names are silently dropped. Case-insensitive; whitespace trimmed.")] string[]? fields = null)
     {
         using var scope = _logger?.BeginCall("list_tasks");
         try
         {
-            var internalStatus = status is null ? null : MapToInternalStatus(status);
+            string? internalStatus = null;
+            if (status is not null)
+            {
+                if (!TryMapToInternalStatus(status, out var mapped, out var statusError))
+                {
+                    scope?.SetResult("error");
+                    return JsonSerializer.Serialize(new ErrorResult("invalid_status", statusError!));
+                }
+                internalStatus = mapped;
+            }
 
             List<GlassworkTask> all;
             if (scope is { IsTracing: true })
@@ -133,20 +153,32 @@ public sealed class GlassworkTools
 
             // Phase: sort
             var sortSw = Stopwatch.StartNew();
-            var tasks = filtered
+            var sortedTasks = filtered
                 .OrderBy(t => t.Created)
                 .ThenBy(t => t.Id)
-                .Select(t => new TaskSummary(
-                    Id: t.Id,
-                    Title: t.Title,
-                    Status: MapToExternalStatus(t.Status),
-                    ParentId: t.Parent,
-                    Path: Path.Combine(_vaultPath, $"{t.Id}.md")))
                 .ToList();
             scope?.RecordPhase("sort", sortSw.ElapsedMilliseconds);
 
-            scope?.SetCount("task_count", tasks.Count);
-            return JsonSerializer.Serialize(new ListTasksResult(tasks));
+            scope?.SetCount("task_count", sortedTasks.Count);
+
+            var requestedFields = NormalizeFieldProjection(fields);
+            if (requestedFields is null)
+            {
+                var summaries = sortedTasks
+                    .Select(t => new TaskSummary(
+                        Id: t.Id,
+                        Title: t.Title,
+                        Status: MapToExternalStatus(t.Status),
+                        ParentId: t.Parent,
+                        Path: TodoRelativeTaskPath(t.Id)))
+                    .ToList();
+                return JsonSerializer.Serialize(new ListTasksResult(summaries));
+            }
+
+            var projected = sortedTasks
+                .Select(t => ProjectTaskSummary(t, requestedFields))
+                .ToList();
+            return JsonSerializer.Serialize(new ListTasksProjectedResult(projected));
         }
         catch
         {
@@ -168,15 +200,33 @@ public sealed class GlassworkTools
         using var scope = _logger?.BeginCall("search_tasks");
         try
         {
-            var hits = _search.Search(query, @in, tags, status, limit)
-                .Select(h => new TaskSearchSummary(
-                    Id: h.Id,
-                    Title: h.Title,
-                    Status: h.Status,
-                    ParentId: h.ParentId,
-                    MatchedIn: h.MatchedIn.ToArray(),
-                    Snippet: h.Snippet))
-                .ToList();
+            if (!TryValidateSearchInputs(query, @in, status, out var inputError))
+            {
+                scope?.SetResult("error");
+                return JsonSerializer.Serialize(inputError);
+            }
+
+            List<TaskSearchSummary> hits;
+            try
+            {
+                hits = _search.Search(query, @in, tags, status, limit)
+                    .Select(h => new TaskSearchSummary(
+                        Id: h.Id,
+                        Title: h.Title,
+                        Status: h.Status,
+                        ParentId: h.ParentId,
+                        MatchedIn: h.MatchedIn.ToArray(),
+                        Snippet: h.Snippet))
+                    .ToList();
+            }
+            catch (ArgumentException ex)
+            {
+                // Defensive net: pre-validation should have caught known cases,
+                // but a future Core validation we didn't mirror still surfaces
+                // as a structured envelope rather than crashing the transport.
+                scope?.SetResult("error");
+                return JsonSerializer.Serialize(new ErrorResult("invalid_argument", ex.Message));
+            }
             scope?.SetCount("task_count", hits.Count);
             return JsonSerializer.Serialize(new SearchTasksResult(hits));
         }
@@ -193,37 +243,56 @@ public sealed class GlassworkTools
     public string GetTask(
         [Description("Task ID to look up.")] string task_id)
     {
-        var safeId = SanitizeId(task_id);
-        if (safeId is null)
-            return JsonSerializer.Serialize(new ErrorResult("not_found", $"Task '{task_id}' not found."));
-
-        var task = _vault.Load(safeId);
-        if (task is null)
-            return JsonSerializer.Serialize(new ErrorResult("not_found", $"Task '{task_id}' not found."));
-
-        var artifactFolder = Path.Combine(_vaultPath, safeId + ".artifacts");
-        var artifacts = new List<ArtifactInfo>();
-        if (Directory.Exists(artifactFolder))
+        using var scope = _logger?.BeginCall("get_task");
+        try
         {
-            foreach (var file in Directory.EnumerateFiles(artifactFolder, "*.md", SearchOption.TopDirectoryOnly))
+            var safeId = SanitizeId(task_id);
+            if (safeId is null)
             {
-                var filename = Path.GetFileName(file);
-                var vaultRelative = Path.Combine(safeId + ".artifacts", filename);
-                artifacts.Add(new ArtifactInfo(filename, vaultRelative));
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("not_found", $"Task '{task_id}' not found."));
             }
-            artifacts.Sort((a, b) => string.Compare(a.Filename, b.Filename, StringComparison.OrdinalIgnoreCase));
+
+            var loadSw = Stopwatch.StartNew();
+            var task = _vault.Load(safeId);
+            scope?.RecordPhase("load_task", loadSw.ElapsedMilliseconds);
+
+            if (task is null)
+            {
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("not_found", $"Task '{task_id}' not found."));
+            }
+
+            var scanSw = Stopwatch.StartNew();
+            var artifactFolder = Path.Combine(_vaultPath, safeId + ".artifacts");
+            var artifacts = new List<ArtifactInfo>();
+            if (Directory.Exists(artifactFolder))
+            {
+                foreach (var file in Directory.EnumerateFiles(artifactFolder, "*.md", SearchOption.TopDirectoryOnly))
+                {
+                    var filename = Path.GetFileName(file);
+                    artifacts.Add(new ArtifactInfo(filename, TodoRelativeArtifactPath(safeId, filename)));
+                }
+                artifacts.Sort((a, b) => string.Compare(a.Filename, b.Filename, StringComparison.OrdinalIgnoreCase));
+            }
+            scope?.RecordPhase("scan_artifacts", scanSw.ElapsedMilliseconds);
+
+            var result = new GetTaskResult(
+                Id: task.Id,
+                Title: task.Title,
+                Status: MapToExternalStatus(task.Status),
+                ParentId: task.Parent,
+                Description: task.Description,
+                Notes: task.Notes,
+                Artifacts: artifacts);
+
+            return JsonSerializer.Serialize(result);
         }
-
-        var result = new GetTaskResult(
-            Id: task.Id,
-            Title: task.Title,
-            Status: MapToExternalStatus(task.Status),
-            ParentId: task.Parent,
-            Description: task.Description,
-            Notes: task.Notes,
-            Artifacts: artifacts);
-
-        return JsonSerializer.Serialize(result);
+        catch
+        {
+            scope?.SetResult("error");
+            throw;
+        }
     }
 
     [McpServerTool(Name = "add_artifact")]
@@ -234,37 +303,63 @@ public sealed class GlassworkTools
         [Description("Filename for the artifact, must end in .md (e.g. 'plan.md'). Simple filenames only — no path separators.")] string filename,
         [Description("Markdown content to write into the artifact file.")] string content)
     {
-        var safeId = SanitizeId(task_id);
-        if (safeId is null || !_vault.Exists(safeId))
-            return JsonSerializer.Serialize(new ErrorResult("not_found", $"Task '{task_id}' not found."));
-
-        if (!filename.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
-            return JsonSerializer.Serialize(new ErrorResult("invalid_filename", "Filename must end in '.md'."));
-
-        var artifactFolder = Path.Combine(_vaultPath, safeId + ".artifacts");
-
-        // Path-traversal guard: ensure the resolved artifact path stays inside the artifact folder.
-        string resolvedPath;
+        using var scope = _logger?.BeginCall("add_artifact");
         try
         {
-            resolvedPath = VaultPathGuard.EnsurePathInVault(artifactFolder, filename);
+            var safeId = SanitizeId(task_id);
+            if (safeId is null || !_vault.Exists(safeId))
+            {
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("not_found", $"Task '{task_id}' not found."));
+            }
+
+            if (string.IsNullOrWhiteSpace(filename))
+            {
+                scope?.SetResult("error");
+                return JsonSerializer.Serialize(new ErrorResult("invalid_filename", "filename is required."));
+            }
+
+            if (!filename.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            {
+                scope?.SetResult("error");
+                return JsonSerializer.Serialize(new ErrorResult("invalid_filename", "Filename must end in '.md'."));
+            }
+
+            var artifactFolder = Path.Combine(_vaultPath, safeId + ".artifacts");
+
+            string resolvedPath;
+            try
+            {
+                resolvedPath = VaultPathGuard.EnsurePathInVault(artifactFolder, filename);
+            }
+            catch (ArgumentException)
+            {
+                scope?.SetResult("error");
+                return JsonSerializer.Serialize(new ErrorResult("path_traversal",
+                    $"Filename '{filename}' is not allowed. Use a simple filename without path separators or '..'."));
+            }
+
+            if (File.Exists(resolvedPath))
+            {
+                scope?.SetResult("conflict");
+                return JsonSerializer.Serialize(new ErrorResult("conflict",
+                    $"Artifact '{filename}' already exists for task '{safeId}'."));
+            }
+
+            Directory.CreateDirectory(artifactFolder);
+            _selfWrites.RegisterWrite(resolvedPath);
+            var writeSw = Stopwatch.StartNew();
+            File.WriteAllText(resolvedPath, content ?? string.Empty);
+            scope?.RecordPhase("write", writeSw.ElapsedMilliseconds);
+
+            var resultPath = TodoRelativeArtifactPath(safeId, Path.GetFileName(resolvedPath));
+            return JsonSerializer.Serialize(new AddArtifactResult(Path: resultPath));
         }
-        catch (ArgumentException)
+        catch
         {
-            return JsonSerializer.Serialize(new ErrorResult("path_traversal",
-                $"Filename '{filename}' is not allowed. Use a simple filename without path separators or '..'."));
+            scope?.SetResult("error");
+            throw;
         }
-
-        if (File.Exists(resolvedPath))
-            return JsonSerializer.Serialize(new ErrorResult("conflict",
-                $"Artifact '{filename}' already exists for task '{safeId}'."));
-
-        Directory.CreateDirectory(artifactFolder);
-        _selfWrites.RegisterWrite(resolvedPath);
-        File.WriteAllText(resolvedPath, content);
-
-        var vaultRelative = Path.Combine(safeId + ".artifacts", Path.GetFileName(resolvedPath));
-        return JsonSerializer.Serialize(new AddArtifactResult(Path: vaultRelative));
     }
 
     [McpServerTool(Name = "load_context")]
@@ -385,11 +480,10 @@ public sealed class GlassworkTools
         foreach (var file in Directory.EnumerateFiles(artifactFolder, "*.md", SearchOption.TopDirectoryOnly))
         {
             var filename = Path.GetFileName(file);
-            var vaultRelative = Path.Combine(safeId + ".artifacts", filename);
             string content;
             try { content = File.ReadAllText(file); }
             catch { content = string.Empty; }
-            artifacts.Add(new ArtifactWithBody(filename, vaultRelative, content));
+            artifacts.Add(new ArtifactWithBody(filename, TodoRelativeArtifactPath(safeId, filename), content));
         }
         artifacts.Sort((a, b) => string.Compare(a.Filename, b.Filename, StringComparison.OrdinalIgnoreCase));
         return artifacts;
@@ -407,11 +501,11 @@ public sealed class GlassworkTools
     {
         try
         {
-            return Path.GetRelativePath(_vaultRoot, fullPath);
+            return NormalizeOutputPath(Path.GetRelativePath(_vaultRoot, fullPath));
         }
         catch
         {
-            return fullPath;
+            return NormalizeOutputPath(fullPath);
         }
     }
 
@@ -426,13 +520,129 @@ public sealed class GlassworkTools
         return n;
     }
 
-    private static string MapToInternalStatus(string? status) => status switch
+    private static bool TryMapToInternalStatus(string? status, out string internalStatus, out string? errMessage)
     {
-        "todo" or null => GlassworkTask.Statuses.Todo,
-        "doing" => GlassworkTask.Statuses.InProgress,
-        "done" => GlassworkTask.Statuses.Done,
-        _ => throw new ArgumentException($"Invalid status '{status}'. Valid values: todo, doing, done."),
+        switch (status)
+        {
+            case null:
+            case "todo":
+                internalStatus = GlassworkTask.Statuses.Todo;
+                errMessage = null;
+                return true;
+            case "doing":
+                internalStatus = GlassworkTask.Statuses.InProgress;
+                errMessage = null;
+                return true;
+            case "done":
+                internalStatus = GlassworkTask.Statuses.Done;
+                errMessage = null;
+                return true;
+            default:
+                internalStatus = string.Empty;
+                errMessage = $"Invalid status '{status}'. Valid values: todo, doing, done.";
+                return false;
+        }
+    }
+
+    private static readonly HashSet<string> ValidSearchFields = new(StringComparer.Ordinal)
+    {
+        "title", "description", "notes", "subtasks", "tags",
     };
+
+    private static bool TryValidateSearchInputs(
+        string query,
+        string[]? @in,
+        string[]? status,
+        out ErrorResult? error)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            error = new ErrorResult("invalid_query", "query is required.");
+            return false;
+        }
+        if (query.Length > 500)
+        {
+            error = new ErrorResult("invalid_query", "query must be 500 characters or fewer.");
+            return false;
+        }
+        if (@in is not null)
+        {
+            foreach (var raw in @in)
+            {
+                var field = (raw ?? string.Empty).Trim().ToLowerInvariant();
+                if (!ValidSearchFields.Contains(field))
+                {
+                    error = new ErrorResult(
+                        "invalid_in_field",
+                        $"Invalid in field '{raw}'. Valid values: title, description, notes, subtasks, tags.");
+                    return false;
+                }
+            }
+        }
+        if (status is not null)
+        {
+            foreach (var raw in status)
+            {
+                var s = (raw ?? string.Empty).Trim().ToLowerInvariant();
+                if (s is not ("todo" or "doing" or "done"))
+                {
+                    error = new ErrorResult(
+                        "invalid_status",
+                        $"Invalid status '{raw}'. Valid values: todo, doing, done.");
+                    return false;
+                }
+            }
+        }
+        error = null;
+        return true;
+    }
+
+    private static readonly HashSet<string> AllowedSummaryFields = new(StringComparer.Ordinal)
+    {
+        "title", "status", "parent_id", "path", "created", "priority",
+    };
+
+    /// <summary>
+    /// Normalises and whitelists the requested fields[] for list_tasks projection.
+    /// Returns null when the caller did NOT request a projection (null or empty input,
+    /// or every requested name was unknown). In that case the default typed shape is used.
+    /// </summary>
+    private static HashSet<string>? NormalizeFieldProjection(string[]? fields)
+    {
+        if (fields is null || fields.Length == 0) return null;
+
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var raw in fields)
+        {
+            if (raw is null) continue;
+            var normalized = raw.Trim().ToLowerInvariant();
+            if (normalized.Length == 0) continue;
+            if (AllowedSummaryFields.Contains(normalized))
+                set.Add(normalized);
+        }
+        return set.Count == 0 ? null : set;
+    }
+
+    private Dictionary<string, object?> ProjectTaskSummary(GlassworkTask task, HashSet<string> fields)
+    {
+        var dict = new Dictionary<string, object?> { ["id"] = task.Id };
+        if (fields.Contains("title")) dict["title"] = task.Title;
+        if (fields.Contains("status")) dict["status"] = MapToExternalStatus(task.Status);
+        if (fields.Contains("parent_id")) dict["parent_id"] = task.Parent;
+        if (fields.Contains("path")) dict["path"] = TodoRelativeTaskPath(task.Id);
+        if (fields.Contains("created")) dict["created"] = task.Created.ToString("yyyy-MM-dd");
+        if (fields.Contains("priority")) dict["priority"] = task.Priority;
+        return dict;
+    }
+
+    // ────── output path helpers (slash-normalized, always forward slashes) ──────
+
+    private static string TodoRelativeTaskPath(string id) => $"{id}.md";
+
+    private static string TodoRelativeArtifactPath(string id, string filename)
+        => $"{id}.artifacts/{filename}";
+
+    private static string NormalizeOutputPath(string path) => path.Replace('\\', '/');
 
     private static string MapToExternalStatus(string internalStatus) => internalStatus switch
     {
@@ -464,6 +674,9 @@ public sealed class GlassworkTools
 
     private sealed record ListTasksResult(
         [property: JsonPropertyName("tasks")] List<TaskSummary> Tasks);
+
+    private sealed record ListTasksProjectedResult(
+        [property: JsonPropertyName("tasks")] List<Dictionary<string, object?>> Tasks);
 
     private sealed record TaskSearchSummary(
         [property: JsonPropertyName("id")] string Id,

--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -161,8 +161,8 @@ public sealed class GlassworkTools
 
             scope?.SetCount("task_count", sortedTasks.Count);
 
-            var requestedFields = NormalizeFieldProjection(fields);
-            if (requestedFields is null)
+            var projection = NormalizeFieldProjection(fields);
+            if (projection.Mode == FieldProjectionMode.UseDefault)
             {
                 var summaries = sortedTasks
                     .Select(t => new TaskSummary(
@@ -176,7 +176,7 @@ public sealed class GlassworkTools
             }
 
             var projected = sortedTasks
-                .Select(t => ProjectTaskSummary(t, requestedFields))
+                .Select(t => ProjectTaskSummary(t, projection.Fields))
                 .ToList();
             return JsonSerializer.Serialize(new ListTasksProjectedResult(projected));
         }
@@ -206,27 +206,31 @@ public sealed class GlassworkTools
                 return JsonSerializer.Serialize(inputError);
             }
 
-            List<TaskSearchSummary> hits;
+            // Defensive net: pre-validation should have caught known cases, but a
+            // future Core validation we didn't mirror still surfaces as a structured
+            // envelope rather than crashing the transport. Wraps ONLY the Search
+            // call so that genuine bugs in the projection / serialization paths
+            // below propagate normally.
+            IReadOnlyList<TaskSearchHit> searchHits;
             try
             {
-                hits = _search.Search(query, @in, tags, status, limit)
-                    .Select(h => new TaskSearchSummary(
-                        Id: h.Id,
-                        Title: h.Title,
-                        Status: h.Status,
-                        ParentId: h.ParentId,
-                        MatchedIn: h.MatchedIn.ToArray(),
-                        Snippet: h.Snippet))
-                    .ToList();
+                searchHits = _search.Search(query, @in, tags, status, limit);
             }
             catch (ArgumentException ex)
             {
-                // Defensive net: pre-validation should have caught known cases,
-                // but a future Core validation we didn't mirror still surfaces
-                // as a structured envelope rather than crashing the transport.
                 scope?.SetResult("error");
                 return JsonSerializer.Serialize(new ErrorResult("invalid_argument", ex.Message));
             }
+
+            var hits = searchHits
+                .Select(h => new TaskSearchSummary(
+                    Id: h.Id,
+                    Title: h.Title,
+                    Status: h.Status,
+                    ParentId: h.ParentId,
+                    MatchedIn: h.MatchedIn.ToArray(),
+                    Snippet: h.Snippet))
+                .ToList();
             scope?.SetCount("task_count", hits.Count);
             return JsonSerializer.Serialize(new SearchTasksResult(hits));
         }
@@ -301,7 +305,7 @@ public sealed class GlassworkTools
     public string AddArtifact(
         [Description("Task ID that owns the artifact.")] string task_id,
         [Description("Filename for the artifact, must end in .md (e.g. 'plan.md'). Simple filenames only — no path separators.")] string filename,
-        [Description("Markdown content to write into the artifact file.")] string content)
+        [Description("Markdown content to write into the artifact file.")] string? content)
     {
         using var scope = _logger?.BeginCall("add_artifact");
         try
@@ -317,6 +321,25 @@ public sealed class GlassworkTools
             {
                 scope?.SetResult("error");
                 return JsonSerializer.Serialize(new ErrorResult("invalid_filename", "filename is required."));
+            }
+
+            if (content is null)
+            {
+                scope?.SetResult("error");
+                return JsonSerializer.Serialize(new ErrorResult("invalid_content", "content is required."));
+            }
+
+            // Reject anything that is not a simple filename. VaultPathGuard only
+            // checks that the resolved path stays inside the artifact folder — a
+            // value like "nested/plan.md" passes that check but then crashes
+            // File.WriteAllText with DirectoryNotFoundException because we only
+            // CreateDirectory the artifact folder itself. Catch it here so the
+            // structured envelope owns the failure.
+            if (filename.Contains('/') || filename.Contains('\\'))
+            {
+                scope?.SetResult("error");
+                return JsonSerializer.Serialize(new ErrorResult("path_traversal",
+                    $"Filename '{filename}' is not allowed. Use a simple filename without path separators or '..'."));
             }
 
             if (!filename.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
@@ -349,7 +372,7 @@ public sealed class GlassworkTools
             Directory.CreateDirectory(artifactFolder);
             _selfWrites.RegisterWrite(resolvedPath);
             var writeSw = Stopwatch.StartNew();
-            File.WriteAllText(resolvedPath, content ?? string.Empty);
+            File.WriteAllText(resolvedPath, content);
             scope?.RecordPhase("write", writeSw.ElapsedMilliseconds);
 
             var resultPath = TodoRelativeArtifactPath(safeId, Path.GetFileName(resolvedPath));
@@ -603,13 +626,19 @@ public sealed class GlassworkTools
     };
 
     /// <summary>
-    /// Normalises and whitelists the requested fields[] for list_tasks projection.
-    /// Returns null when the caller did NOT request a projection (null or empty input,
-    /// or every requested name was unknown). In that case the default typed shape is used.
+    /// Three-state result of normalising the requested fields[] for list_tasks:
+    /// <list type="bullet">
+    /// <item><c>UseDefault</c>: caller did not request a projection — null or empty input. Use the typed 5-field shape.</item>
+    /// <item><c>EmptyProjection</c>: caller requested a projection but every name was unknown after normalisation. Return id-only summaries.</item>
+    /// <item><c>Projection</c>: at least one valid field was requested. Project on the returned set.</item>
+    /// </list>
     /// </summary>
-    private static HashSet<string>? NormalizeFieldProjection(string[]? fields)
+    private enum FieldProjectionMode { UseDefault, EmptyProjection, Projection }
+
+    private static (FieldProjectionMode Mode, HashSet<string> Fields) NormalizeFieldProjection(string[]? fields)
     {
-        if (fields is null || fields.Length == 0) return null;
+        if (fields is null || fields.Length == 0)
+            return (FieldProjectionMode.UseDefault, new HashSet<string>(StringComparer.Ordinal));
 
         var set = new HashSet<string>(StringComparer.Ordinal);
         foreach (var raw in fields)
@@ -620,7 +649,9 @@ public sealed class GlassworkTools
             if (AllowedSummaryFields.Contains(normalized))
                 set.Add(normalized);
         }
-        return set.Count == 0 ? null : set;
+        return set.Count == 0
+            ? (FieldProjectionMode.EmptyProjection, set)
+            : (FieldProjectionMode.Projection, set);
     }
 
     private Dictionary<string, object?> ProjectTaskSummary(GlassworkTask task, HashSet<string> fields)

--- a/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
@@ -15,6 +15,12 @@ public class GlassworkToolsTests
     // GlassworkTools resolves the task directory as <vault>/wiki/todo.
     private string TasksDir => Path.Combine(_vaultDir, "wiki", "todo");
 
+    // Converts a todo-relative path returned by an MCP tool into an absolute
+    // filesystem path for test assertions. MCP outputs use forward slashes;
+    // tests need OS-native separators when calling File/Directory APIs.
+    private string ResolveTodoPath(string todoRelativePath) =>
+        Path.Combine(TasksDir, todoRelativePath.Replace('/', Path.DirectorySeparatorChar));
+
     [TestInitialize]
     public void Setup()
     {
@@ -43,8 +49,8 @@ public class GlassworkToolsTests
         var path = doc.RootElement.GetProperty("path").GetString()!;
 
         Assert.IsFalse(string.IsNullOrEmpty(taskId));
-        Assert.IsTrue(File.Exists(path), "Task file must exist on disk after add_task.");
-        StringAssert.Contains(path, TasksDir);
+        Assert.AreEqual($"{taskId}.md", path, "add_task returns a todo-relative path.");
+        Assert.IsTrue(File.Exists(ResolveTodoPath(path)), "Task file must exist on disk after add_task.");
     }
 
     [TestMethod]
@@ -55,7 +61,7 @@ public class GlassworkToolsTests
         var doc = JsonDocument.Parse(json);
         var path = doc.RootElement.GetProperty("path").GetString()!;
 
-        var content = File.ReadAllText(path);
+        var content = File.ReadAllText(ResolveTodoPath(path));
         StringAssert.Contains(content, "This is the description.");
     }
 
@@ -63,11 +69,11 @@ public class GlassworkToolsTests
     public void AddTask_WithoutDescription_FileIsValid()
     {
         var json = _tools.AddTask("Task without description");
-        var doc = JsonDocument.Parse(json);
-        var path = doc.RootElement.GetProperty("path").GetString()!;
+        var path = JsonDocument.Parse(json).RootElement.GetProperty("path").GetString()!;
+        var absPath = ResolveTodoPath(path);
 
-        Assert.IsTrue(File.Exists(path));
-        var content = File.ReadAllText(path);
+        Assert.IsTrue(File.Exists(absPath));
+        var content = File.ReadAllText(absPath);
         StringAssert.Contains(content, "title: Task without description");
     }
 
@@ -80,7 +86,7 @@ public class GlassworkToolsTests
         var childJson = _tools.AddTask("Child Task", parent_task_id: parentId);
         var childPath = JsonDocument.Parse(childJson).RootElement.GetProperty("path").GetString()!;
 
-        var content = File.ReadAllText(childPath);
+        var content = File.ReadAllText(ResolveTodoPath(childPath));
         StringAssert.Contains(content, $"parent: {parentId}");
     }
 
@@ -90,7 +96,7 @@ public class GlassworkToolsTests
         var json = _tools.AddTask("A todo task");
         var path = JsonDocument.Parse(json).RootElement.GetProperty("path").GetString()!;
 
-        var content = File.ReadAllText(path);
+        var content = File.ReadAllText(ResolveTodoPath(path));
         StringAssert.Contains(content, "status: todo");
     }
 
@@ -100,7 +106,7 @@ public class GlassworkToolsTests
         var json = _tools.AddTask("An active task", status: "doing");
         var path = JsonDocument.Parse(json).RootElement.GetProperty("path").GetString()!;
 
-        var content = File.ReadAllText(path);
+        var content = File.ReadAllText(ResolveTodoPath(path));
         StringAssert.Contains(content, "status: in-progress");
     }
 
@@ -110,14 +116,42 @@ public class GlassworkToolsTests
         var json = _tools.AddTask("A done task", status: "done");
         var path = JsonDocument.Parse(json).RootElement.GetProperty("path").GetString()!;
 
-        var content = File.ReadAllText(path);
+        var content = File.ReadAllText(ResolveTodoPath(path));
         StringAssert.Contains(content, "status: done");
     }
 
     [TestMethod]
-    public void AddTask_InvalidStatus_Throws()
+    public void AddTask_InvalidStatus_ReturnsStructuredError()
     {
-        Assert.ThrowsExactly<ArgumentException>(() => _tools.AddTask("Task", status: "pending"));
+        var json = _tools.AddTask("Task", status: "pending");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("invalid_status", doc.RootElement.GetProperty("error").GetString());
+        Assert.IsFalse(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("message").GetString()));
+    }
+
+    [TestMethod]
+    public void AddTask_EmptyTitle_ReturnsStructuredError()
+    {
+        var json = _tools.AddTask("   ");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("invalid_title", doc.RootElement.GetProperty("error").GetString());
+        Assert.IsFalse(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("message").GetString()));
+    }
+
+    [TestMethod]
+    public void AddTask_ReturnsTodoRelativePath()
+    {
+        var json = _tools.AddTask("Path Shape");
+        var doc = JsonDocument.Parse(json);
+        var taskId = doc.RootElement.GetProperty("task_id").GetString()!;
+        var path = doc.RootElement.GetProperty("path").GetString()!;
+
+        Assert.AreEqual($"{taskId}.md", path,
+            "add_task must return a todo-relative path of the form '<id>.md'.");
+        Assert.IsFalse(path.Contains('\\'), "Path must not contain backslashes.");
+        Assert.IsFalse(Path.IsPathRooted(path), "Path must not be absolute.");
     }
 
     [TestMethod]
@@ -259,9 +293,134 @@ public class GlassworkToolsTests
     }
 
     [TestMethod]
-    public void ListTasks_InvalidStatus_Throws()
+    public void ListTasks_InvalidStatus_ReturnsStructuredError()
     {
-        Assert.ThrowsExactly<ArgumentException>(() => _tools.ListTasks(status: "invalid"));
+        var json = _tools.ListTasks(status: "invalid");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("invalid_status", doc.RootElement.GetProperty("error").GetString());
+    }
+
+    [TestMethod]
+    public void ListTasks_SummaryPathIsTodoRelative()
+    {
+        _tools.AddTask("Path Shape One");
+        _tools.AddTask("Path Shape Two");
+
+        var json = _tools.ListTasks();
+        var tasks = JsonDocument.Parse(json).RootElement.GetProperty("tasks");
+
+        for (int i = 0; i < tasks.GetArrayLength(); i++)
+        {
+            var id = tasks[i].GetProperty("id").GetString()!;
+            var path = tasks[i].GetProperty("path").GetString()!;
+            Assert.AreEqual($"{id}.md", path,
+                "list_tasks summary path must be todo-relative.");
+            Assert.IsFalse(path.Contains('\\'), "Path must not contain backslashes.");
+        }
+    }
+
+    [TestMethod]
+    public void ListTasks_DefaultShape_Unchanged()
+    {
+        _tools.AddTask("Default Shape Task");
+
+        var json = _tools.ListTasks();
+        var first = JsonDocument.Parse(json).RootElement.GetProperty("tasks")[0];
+
+        var keys = first.EnumerateObject().Select(p => p.Name).OrderBy(s => s).ToArray();
+        CollectionAssert.AreEqual(
+            new[] { "id", "parent_id", "path", "status", "title" },
+            keys,
+            "Default list_tasks shape must be exactly id+title+status+parent_id+path.");
+    }
+
+    [TestMethod]
+    public void ListTasks_FieldsHonored_ReturnsRequestedSubset()
+    {
+        _tools.AddTask("Projection Task");
+
+        var json = _tools.ListTasks(fields: new[] { "created", "priority" });
+        var first = JsonDocument.Parse(json).RootElement.GetProperty("tasks")[0];
+
+        var keys = first.EnumerateObject().Select(p => p.Name).OrderBy(s => s).ToArray();
+        CollectionAssert.AreEqual(
+            new[] { "created", "id", "priority" },
+            keys,
+            "fields=[created,priority] must return exactly id+created+priority.");
+    }
+
+    [TestMethod]
+    public void ListTasks_FieldsUnknown_Dropped()
+    {
+        _tools.AddTask("Unknown Field Task");
+
+        var json = _tools.ListTasks(fields: new[] { "bogus", "title" });
+        var first = JsonDocument.Parse(json).RootElement.GetProperty("tasks")[0];
+
+        var keys = first.EnumerateObject().Select(p => p.Name).OrderBy(s => s).ToArray();
+        CollectionAssert.AreEqual(
+            new[] { "id", "title" },
+            keys,
+            "Unknown field names must be silently dropped; only id+title remain.");
+    }
+
+    [TestMethod]
+    public void ListTasks_FieldsEmpty_DefaultShape()
+    {
+        _tools.AddTask("Empty Fields Task");
+
+        var json = _tools.ListTasks(fields: Array.Empty<string>());
+        var first = JsonDocument.Parse(json).RootElement.GetProperty("tasks")[0];
+
+        var keys = first.EnumerateObject().Select(p => p.Name).OrderBy(s => s).ToArray();
+        CollectionAssert.AreEqual(
+            new[] { "id", "parent_id", "path", "status", "title" },
+            keys,
+            "Empty fields array must preserve default shape.");
+    }
+
+    [TestMethod]
+    public void ListTasks_FieldsAllUnknown_DropsToDefaultShape()
+    {
+        _tools.AddTask("All Unknown Task");
+
+        var json = _tools.ListTasks(fields: new[] { "bogus", "garbage" });
+        var first = JsonDocument.Parse(json).RootElement.GetProperty("tasks")[0];
+
+        var keys = first.EnumerateObject().Select(p => p.Name).OrderBy(s => s).ToArray();
+        CollectionAssert.AreEqual(
+            new[] { "id", "parent_id", "path", "status", "title" },
+            keys,
+            "When every requested field is unknown the default shape applies.");
+    }
+
+    [TestMethod]
+    public void ListTasks_FieldsNormalized_CaseAndWhitespace()
+    {
+        _tools.AddTask("Normalize Task");
+
+        var json = _tools.ListTasks(fields: new[] { " Created ", "PRIORITY" });
+        var first = JsonDocument.Parse(json).RootElement.GetProperty("tasks")[0];
+
+        var keys = first.EnumerateObject().Select(p => p.Name).OrderBy(s => s).ToArray();
+        CollectionAssert.AreEqual(
+            new[] { "created", "id", "priority" },
+            keys,
+            "fields names must be case-folded and whitespace-trimmed.");
+    }
+
+    [TestMethod]
+    public void ListTasks_CreatedIsIsoDate()
+    {
+        _tools.AddTask("Date Format Task");
+
+        var json = _tools.ListTasks(fields: new[] { "created" });
+        var first = JsonDocument.Parse(json).RootElement.GetProperty("tasks")[0];
+        var created = first.GetProperty("created").GetString()!;
+
+        Assert.IsTrue(System.Text.RegularExpressions.Regex.IsMatch(created, @"^\d{4}-\d{2}-\d{2}$"),
+            $"created must be yyyy-MM-dd; got '{created}'.");
     }
 
     [TestMethod]
@@ -333,17 +492,40 @@ public class GlassworkToolsTests
     }
 
     [TestMethod]
-    public void SearchTasks_InvalidInField_ThrowsArgumentException()
+    public void SearchTasks_InvalidInField_ReturnsStructuredError()
     {
-        Assert.ThrowsExactly<ArgumentException>(() =>
-            _tools.SearchTasks("query", @in: ["artifact"]));
+        var json = _tools.SearchTasks("query", @in: new[] { "artifact" });
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("invalid_in_field", doc.RootElement.GetProperty("error").GetString());
+        Assert.IsFalse(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("message").GetString()));
     }
 
     [TestMethod]
-    public void SearchTasks_EmptyQuery_ThrowsArgumentException()
+    public void SearchTasks_EmptyQuery_ReturnsStructuredError()
     {
-        Assert.ThrowsExactly<ArgumentException>(() =>
-            _tools.SearchTasks("   "));
+        var json = _tools.SearchTasks("   ");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("invalid_query", doc.RootElement.GetProperty("error").GetString());
+    }
+
+    [TestMethod]
+    public void SearchTasks_QueryTooLong_ReturnsStructuredError()
+    {
+        var json = _tools.SearchTasks(new string('x', 501));
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("invalid_query", doc.RootElement.GetProperty("error").GetString());
+    }
+
+    [TestMethod]
+    public void SearchTasks_InvalidStatusFilter_ReturnsStructuredError()
+    {
+        var json = _tools.SearchTasks("query", status: new[] { "bogus" });
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("invalid_status", doc.RootElement.GetProperty("error").GetString());
     }
 
     [TestMethod]
@@ -453,7 +635,7 @@ public class GlassworkToolsTests
     }
 
     [TestMethod]
-    public void GetTask_ArtifactEntry_HasFilenameAndVaultRelativePath()
+    public void GetTask_ArtifactEntry_HasFilenameAndTodoRelativePath()
     {
         var addJson = _tools.AddTask("Artifact Path Task");
         var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
@@ -467,8 +649,25 @@ public class GlassworkToolsTests
         var artifact = doc.RootElement.GetProperty("artifacts")[0];
 
         Assert.AreEqual("design.md", artifact.GetProperty("filename").GetString());
-        StringAssert.Contains(artifact.GetProperty("path").GetString()!, taskId + ".artifacts");
-        StringAssert.Contains(artifact.GetProperty("path").GetString()!, "design.md");
+        var path = artifact.GetProperty("path").GetString()!;
+        Assert.AreEqual($"{taskId}.artifacts/design.md", path,
+            "get_task must return a todo-relative artifact path with forward slashes.");
+    }
+
+    [TestMethod]
+    public void GetTask_ArtifactPath_UsesForwardSlashes()
+    {
+        var addJson = _tools.AddTask("Slash Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var artifactFolder = Path.Combine(TasksDir, taskId + ".artifacts");
+        Directory.CreateDirectory(artifactFolder);
+        File.WriteAllText(Path.Combine(artifactFolder, "plan.md"), "p");
+
+        var json = _tools.GetTask(taskId);
+        var path = JsonDocument.Parse(json).RootElement.GetProperty("artifacts")[0].GetProperty("path").GetString()!;
+
+        Assert.IsFalse(path.Contains('\\'), "Artifact path must not contain backslashes.");
     }
 
     [TestMethod]
@@ -513,7 +712,7 @@ public class GlassworkToolsTests
         var json = _tools.AddArtifact(taskId, "plan.md", "# Plan\n\nContent here.");
         var doc = JsonDocument.Parse(json);
 
-        Assert.IsTrue(doc.RootElement.TryGetProperty("path", out var pathElem),
+        Assert.IsTrue(doc.RootElement.TryGetProperty("path", out _),
             "add_artifact must return a 'path' field on success.");
 
         var artifactFolder = Path.Combine(TasksDir, taskId + ".artifacts");
@@ -523,7 +722,7 @@ public class GlassworkToolsTests
     }
 
     [TestMethod]
-    public void AddArtifact_ReturnedPath_ContainsArtifactsFolderAndFilename()
+    public void AddArtifact_ReturnedPath_IsTodoRelativeWithForwardSlashes()
     {
         var addJson = _tools.AddTask("Path Return Task");
         var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
@@ -531,8 +730,21 @@ public class GlassworkToolsTests
         var json = _tools.AddArtifact(taskId, "notes.md", "notes");
         var path = JsonDocument.Parse(json).RootElement.GetProperty("path").GetString()!;
 
-        StringAssert.Contains(path, taskId + ".artifacts");
-        StringAssert.Contains(path, "notes.md");
+        Assert.AreEqual($"{taskId}.artifacts/notes.md", path);
+        Assert.IsFalse(path.Contains('\\'), "Path must not contain backslashes.");
+    }
+
+    [TestMethod]
+    public void AddArtifact_EmptyFilename_ReturnsStructuredError()
+    {
+        var addJson = _tools.AddTask("Empty Filename Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var json = _tools.AddArtifact(taskId, "   ", "content");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("invalid_filename", doc.RootElement.GetProperty("error").GetString());
+        Assert.IsFalse(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("message").GetString()));
     }
 
     [TestMethod]
@@ -666,11 +878,47 @@ public class GlassworkToolsTests
 
         // OrdinalIgnoreCase filename order: design.md then plan.md
         Assert.AreEqual("design.md", artifacts[0].GetProperty("filename").GetString());
-        StringAssert.Contains(artifacts[0].GetProperty("path").GetString()!, taskId + ".artifacts");
+        Assert.AreEqual($"{taskId}.artifacts/design.md", artifacts[0].GetProperty("path").GetString());
         Assert.AreEqual("# Design\n\nThe design.", artifacts[0].GetProperty("content").GetString());
 
         Assert.AreEqual("plan.md", artifacts[1].GetProperty("filename").GetString());
         Assert.AreEqual("# Plan\n\nThe plan.", artifacts[1].GetProperty("content").GetString());
+    }
+
+    [TestMethod]
+    public void LoadContext_ArtifactPath_UsesForwardSlashes()
+    {
+        var addJson = _tools.AddTask("LC Slash Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var artifactFolder = Path.Combine(TasksDir, taskId + ".artifacts");
+        Directory.CreateDirectory(artifactFolder);
+        File.WriteAllText(Path.Combine(artifactFolder, "plan.md"), "p");
+
+        var json = _tools.LoadContext(taskId);
+        var path = JsonDocument.Parse(json).RootElement.GetProperty("artifacts")[0].GetProperty("path").GetString()!;
+
+        Assert.IsFalse(path.Contains('\\'),
+            "load_context artifact path must use forward slashes only.");
+    }
+
+    [TestMethod]
+    public void LoadContext_BacklinkSourcePath_UsesForwardSlashes()
+    {
+        var taskId = JsonDocument.Parse(_tools.AddTask("Slash Backlink Task"))
+            .RootElement.GetProperty("task_id").GetString()!;
+
+        var conceptDir = Path.Combine(_vaultDir, "wiki", "concepts");
+        Directory.CreateDirectory(conceptDir);
+        File.WriteAllText(Path.Combine(conceptDir, "foo.md"),
+            $"# Foo\n\n[[{taskId}]]");
+
+        var json = _tools.LoadContext(taskId);
+        var sourcePath = JsonDocument.Parse(json).RootElement
+            .GetProperty("backlinks")[0].GetProperty("source_path").GetString()!;
+
+        Assert.IsFalse(sourcePath.Contains('\\'),
+            "Backlink source_path must use forward slashes only.");
     }
 
     [TestMethod]

--- a/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
@@ -381,7 +381,7 @@ public class GlassworkToolsTests
     }
 
     [TestMethod]
-    public void ListTasks_FieldsAllUnknown_DropsToDefaultShape()
+    public void ListTasks_FieldsAllUnknown_ReturnsIdOnly()
     {
         _tools.AddTask("All Unknown Task");
 
@@ -390,9 +390,21 @@ public class GlassworkToolsTests
 
         var keys = first.EnumerateObject().Select(p => p.Name).OrderBy(s => s).ToArray();
         CollectionAssert.AreEqual(
-            new[] { "id", "parent_id", "path", "status", "title" },
+            new[] { "id" },
             keys,
-            "When every requested field is unknown the default shape applies.");
+            "When every requested field is unknown the projection contract still applies: id only.");
+    }
+
+    [TestMethod]
+    public void ListTasks_FieldsProjected_PreservesNullParentId()
+    {
+        _tools.AddTask("Standalone Projected");
+
+        var json = _tools.ListTasks(fields: new[] { "parent_id" });
+        var first = JsonDocument.Parse(json).RootElement.GetProperty("tasks")[0];
+
+        Assert.AreEqual(JsonValueKind.Null, first.GetProperty("parent_id").ValueKind,
+            "Projected parent_id must serialise as JSON null for tasks without a parent.");
     }
 
     [TestMethod]
@@ -745,6 +757,49 @@ public class GlassworkToolsTests
 
         Assert.AreEqual("invalid_filename", doc.RootElement.GetProperty("error").GetString());
         Assert.IsFalse(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("message").GetString()));
+    }
+
+    [TestMethod]
+    public void AddArtifact_NullContent_ReturnsInvalidContentError()
+    {
+        var addJson = _tools.AddTask("Null Content Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var json = _tools.AddArtifact(taskId, "plan.md", null!);
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("invalid_content", doc.RootElement.GetProperty("error").GetString());
+
+        // And we did not silently create an empty file.
+        var expectedFile = Path.Combine(TasksDir, taskId + ".artifacts", "plan.md");
+        Assert.IsFalse(File.Exists(expectedFile), "Null content must not create an empty artifact.");
+    }
+
+    [TestMethod]
+    public void AddArtifact_ForwardSlashInFilename_ReturnsPathTraversalError()
+    {
+        var addJson = _tools.AddTask("Slash Filename Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var json = _tools.AddArtifact(taskId, "nested/plan.md", "content");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("path_traversal", doc.RootElement.GetProperty("error").GetString());
+
+        var nested = Path.Combine(TasksDir, taskId + ".artifacts", "nested", "plan.md");
+        Assert.IsFalse(File.Exists(nested), "Nested file must not have been written.");
+    }
+
+    [TestMethod]
+    public void AddArtifact_BackslashInFilename_ReturnsPathTraversalError()
+    {
+        var addJson = _tools.AddTask("Backslash Filename Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var json = _tools.AddArtifact(taskId, "nested\\plan.md", "content");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("path_traversal", doc.RootElement.GetProperty("error").GetString());
     }
 
     [TestMethod]

--- a/tests/Glasswork.Mcp.Tests/McpLoggerTests.cs
+++ b/tests/Glasswork.Mcp.Tests/McpLoggerTests.cs
@@ -101,12 +101,15 @@ public class McpLoggerTests
     }
 
     [TestMethod]
-    public void ToolCall_ErrorResult_WhenToolThrows()
+    public void ToolCall_ErrorResult_WhenStructuredErrorReturned()
     {
+        // After the polish pass (issue #133), tools no longer throw ArgumentException
+        // for user-input validation. They return a structured envelope AND emit
+        // result="error" on the log line.
         var sink = new StringBuilder();
         var tools = MakeTools(MakeLogger(sink));
 
-        try { tools.ListTasks(status: "bad"); } catch (ArgumentException) { }
+        tools.ListTasks(status: "bad");
 
         var doc = JsonDocument.Parse(sink.ToString().Trim());
         Assert.AreEqual("error", doc.RootElement.GetProperty("result").GetString());
@@ -308,6 +311,65 @@ public class McpLoggerTests
         Assert.IsTrue(phases.TryGetProperty("load_artifacts", out _), "Must have 'load_artifacts' phase.");
         Assert.IsTrue(phases.TryGetProperty("load_subtasks", out _), "Must have 'load_subtasks' phase.");
         Assert.IsTrue(phases.TryGetProperty("load_backlinks", out _), "Must have 'load_backlinks' phase.");
+    }
+
+    [TestMethod]
+    public void TraceEnabled_GetTask_PhasesContainLoadTaskAndScanArtifacts()
+    {
+        var sink = new StringBuilder();
+        var tools = MakeTools(MakeLogger(sink, traceEnabled: true));
+
+        var addJson = tools.AddTask("Trace GetTask Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+        sink.Clear();
+
+        tools.GetTask(taskId);
+
+        var line = FilterToolLine(sink.ToString(), "get_task");
+        var phases = JsonDocument.Parse(line).RootElement.GetProperty("phases");
+
+        Assert.IsTrue(phases.TryGetProperty("load_task", out _),
+            "get_task must record 'load_task' phase.");
+        Assert.IsTrue(phases.TryGetProperty("scan_artifacts", out _),
+            "get_task must record 'scan_artifacts' phase.");
+    }
+
+    [TestMethod]
+    public void TraceEnabled_AddArtifact_IncludesWritePhase()
+    {
+        var sink = new StringBuilder();
+        var tools = MakeTools(MakeLogger(sink, traceEnabled: true));
+
+        var addJson = tools.AddTask("Trace AddArtifact Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+        sink.Clear();
+
+        tools.AddArtifact(taskId, "plan.md", "content");
+
+        var line = FilterToolLine(sink.ToString(), "add_artifact");
+        var phases = JsonDocument.Parse(line).RootElement.GetProperty("phases");
+
+        Assert.IsTrue(phases.TryGetProperty("write", out _),
+            "add_artifact must record 'write' phase.");
+    }
+
+    // Filters multi-line JSONL stderr output to the single line whose "tool" field
+    // matches the given name. The MCP tools may emit multiple log lines per test
+    // (e.g. setup AddTask + the call under test).
+    private static string FilterToolLine(string stderr, string toolName)
+    {
+        foreach (var raw in stderr.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
+        {
+            try
+            {
+                var doc = JsonDocument.Parse(raw);
+                if (doc.RootElement.TryGetProperty("tool", out var t) && t.GetString() == toolName)
+                    return raw;
+            }
+            catch { /* skip non-JSON lines */ }
+        }
+        Assert.Fail($"No log line found for tool '{toolName}'. Stderr was:\n{stderr}");
+        return string.Empty;
     }
 
     // ─────────────────────── helpers ─────────────────────────────────────


### PR DESCRIPTION
Closes #133.

Cross-cutting cleanups across the v0.4.0 MCP tool surface, landed as one PR so v0.5.0 release notes call out one breaking change with one migration note (per ADR 0007 §8).

## Four slices

1. **Uniform error envelope.** No tool throws `ArgumentException` to the MCP transport. `add_task` / `list_tasks` / `search_tasks` / `add_artifact` now return the structured `{error, message}` envelope on invalid input, matching the shape `get_task` / `load_context` already used. New error codes: `invalid_title`, `invalid_status`, `invalid_query`, `invalid_in_field`, `invalid_filename`, `invalid_content`, `invalid_argument`. `search_tasks` pre-validates inputs in the MCP layer; the defensive `catch (ArgumentException)` wraps only the `_search.Search(...)` call so projection bugs are not misclassified.
2. **Todo-relative paths + forward-slash normalization (BREAKING).** `add_task` / `list_tasks` / `get_task` / `add_artifact` / `load_context.artifacts[]` (root + subtrees) all return `{id}.md` or `{id}.artifacts/{filename}` instead of absolute or OS-shaped paths. `backlinks[].source_path` stays vault-root-relative as a documented exception (backlinks point outside `wiki/todo/`).
3. **Trace coverage.** `get_task` and `add_artifact` previously had no `CallScope` at all. Now both have a scope + try/catch wrapper. New phases: `load_task` + `scan_artifacts` (`get_task`), `write` (`add_artifact`).
4. **`list_tasks` `fields[]` projection.** Optional case-folded whitelist. `id` always included. Allowed: `title`, `status`, `parent_id`, `path`, `created`, `priority`. `null` / `[]` preserves default shape byte-for-byte. All-unknown names → `{id}` only (projection contract). `created` rendered as `yyyy-MM-dd`.

## Companion changes

- `Glasswork.Mcp.csproj` `<Version>`: 0.4.0 → **0.5.0**.
- `CHANGELOG.md`: `[0.5.0]` with explicit **Breaking** section + migration note ("prepend `$GLASSWORK_VAULT/wiki/todo/`").
- `README.md`: "todo-relative" terminology, `fields[]` parameter doc, structured-error envelope tables, expanded trace-phases table per tool, `invalid_content` and path-separator rows added to `add_artifact` errors.

## Validation

- `dotnet test tests/Glasswork.Mcp.Tests/`: **121 pass** (up from 99 on main). 22 new tests + 5 rewrites.
- `dotnet test tests/Glasswork.Tests/ -p:EnableWindowsTargeting=true`: smoke green modulo a known flaky `Debouncer` test (passes on isolated rerun; unrelated to MCP).

## Review process

This PR went through two rubber-duck rounds + a dual code-review + rubber-duck pass at the end. Findings folded in:

- **Plan stage (rubber-duck):** `Path.Combine` on Windows emits `\\` — expanded slice 2 to normalize all six tools' path output rather than just `add_task`/`list_tasks`. Also: pre-validate `search_tasks` in MCP layer instead of `ArgumentException.Message` prefix-matching. "Todo-relative" vocabulary chosen over "vault-relative" (issue text was ambiguous).
- **Post-implementation (dual review):**
  - `add_artifact` accepted `nested/plan.md` because `VaultPathGuard` only checks the resolved path stays inside the artifact folder — separator filenames passed validation and then crashed `File.WriteAllText` with `DirectoryNotFoundException`, escaping the structured envelope. **Fixed**: explicit separator check above the guard.
  - `add_artifact` silently coerced `null` content to `""`. **Fixed**: return `invalid_content`; parameter typed `string?`.
  - `list_tasks` projection: all-unknown `fields` fell back to default shape. **Fixed**: returns `{id}` only (real projection contract).
  - `search_tasks` defensive catch had too-wide scope. **Fixed**: narrowed to just the `_search.Search` call.
