### PR TITLE
Add Backlog task search

### DIFF
--- a/src/Glasswork.App/Pages/BacklogPage.xaml
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml
@@ -289,6 +289,12 @@
                 <ComboBoxItem Tag="done" Content="Done" />
             </ComboBox>
 
+            <TextBox x:Name="SearchBox"
+                     Width="240"
+                     PlaceholderText="Search tasks"
+                     AutomationProperties.Name="Search Backlog tasks"
+                     TextChanged="SearchBox_TextChanged" />
+
             <ToggleButton x:Name="GroupToggle"
                           IsChecked="{x:Bind ViewModel.IsGrouped, Mode=TwoWay}"
                           ToolTipService.ToolTip="Group by parent">

--- a/src/Glasswork.App/Pages/BacklogPage.xaml.cs
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml.cs
@@ -25,10 +25,11 @@ public sealed partial class BacklogPage : Page
     // applied (with bounded retry) after ViewModel.Refreshed. Null when no restore
     // is queued (e.g. fresh page, or after AddTask which explicitly discards).
     private ScrollSnapshot? _pendingRestore;
+    private bool _skipNextScrollCapture;
 
     /// <summary>
     /// Captured scroll state for a single Refresh() round-trip. Includes the
-    /// layout context (ViewMode/IsGrouped/FilterStatus) so the restore callback
+    /// layout context (ViewMode/IsGrouped/FilterStatus/SearchText) so the restore callback
     /// can detect when an intentional layout change has invalidated the snapshot
     /// and drop it instead of restoring a now-meaningless offset.
     /// </summary>
@@ -36,6 +37,7 @@ public sealed partial class BacklogPage : Page
         string ViewMode,
         bool IsGrouped,
         string FilterStatus,
+        string SearchText,
         double ListOffset,
         double BoardHorizontalOffset,
         Dictionary<string, double> BoardColumnOffsets);
@@ -71,6 +73,13 @@ public sealed partial class BacklogPage : Page
         {
             // Visual-tree walks must be on the UI thread.
             if (!DispatcherQueue.HasThreadAccess) return;
+            if (_skipNextScrollCapture)
+            {
+                _skipNextScrollCapture = false;
+                _pendingRestore = null;
+                return;
+            }
+
             // ??= preserves the ORIGINAL pre-refresh offset across back-to-back
             // refreshes (e.g. status command followed by file watcher echo) — without
             // this, the second Refreshing would capture the post-clear scroll-zero
@@ -261,7 +270,8 @@ public sealed partial class BacklogPage : Page
         var hasContent = isBoard
             ? ViewModel.BoardColumns.Any(c => c.Tasks.Count > 0)
             : ViewModel.Tasks.Count > 0;
-        
+        var isSearching = !string.IsNullOrWhiteSpace(ViewModel.SearchText);
+
         // Only manage TaskList visibility in list mode
         if (isList)
         {
@@ -272,7 +282,11 @@ public sealed partial class BacklogPage : Page
         {
             BoardView.Visibility = hasContent ? Visibility.Visible : Visibility.Collapsed;
         }
-        
+
+        EmptyStateView.Headline = isSearching ? "No matching tasks." : "Nothing in the Backlog yet.";
+        EmptyStateView.Body = isSearching
+            ? "Try a different search, or clear the search box to see every Backlog task."
+            : "Capture a task to get started. You can pull anything you add here into My Day later.";
         EmptyStateView.Visibility = hasContent ? Visibility.Collapsed : Visibility.Visible;
     }
 
@@ -284,6 +298,14 @@ public sealed partial class BacklogPage : Page
         {
             ViewModel.FilterStatus = item.Tag?.ToString() ?? "all";
         }
+    }
+
+    private void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        if (sender is not TextBox tb) return;
+        if (ViewModel.SearchText == tb.Text) return;
+        _skipNextScrollCapture = true;
+        ViewModel.SearchText = tb.Text;
     }
 
     private async void AddTask_Click(object sender, RoutedEventArgs e)
@@ -754,6 +776,7 @@ public sealed partial class BacklogPage : Page
             ViewMode: ViewModel.ViewMode,
             IsGrouped: ViewModel.IsGrouped,
             FilterStatus: ViewModel.FilterStatus,
+            SearchText: ViewModel.SearchText,
             ListOffset: listOffset,
             BoardHorizontalOffset: boardHorizontal,
             BoardColumnOffsets: columnOffsets);
@@ -766,10 +789,11 @@ public sealed partial class BacklogPage : Page
         if (_pendingRestore != snapshot) return;
 
         // Layout context changed since capture (user toggled view-mode, group,
-        // or filter)? The captured offset is meaningless now. Drop the snapshot.
+        // status filter, or search)? The captured offset is meaningless now. Drop it.
         if (snapshot.ViewMode    != ViewModel.ViewMode    ||
             snapshot.IsGrouped   != ViewModel.IsGrouped   ||
-            snapshot.FilterStatus != ViewModel.FilterStatus)
+            snapshot.FilterStatus != ViewModel.FilterStatus ||
+            snapshot.SearchText   != ViewModel.SearchText)
         {
             _pendingRestore = null;
             return;

--- a/src/Glasswork.Core/Queries/BacklogQueries.cs
+++ b/src/Glasswork.Core/Queries/BacklogQueries.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Glasswork.Core.Models;
+using Glasswork.Core.Services;
 
 namespace Glasswork.Core.Queries;
 
@@ -23,14 +24,27 @@ public static class BacklogQueries
     /// </summary>
     public static IReadOnlyList<GlassworkTask> Filter(
         IReadOnlyDictionary<string, GlassworkTask> tasks,
-        string filterStatus)
+        string filterStatus,
+        string? searchText = null)
+    {
+        if (tasks is null) throw new ArgumentNullException(nameof(tasks));
+        return Filter(tasks.Values, filterStatus, searchText);
+    }
+
+    public static IReadOnlyList<GlassworkTask> Filter(
+        IEnumerable<GlassworkTask> tasks,
+        string filterStatus,
+        string? searchText = null)
     {
         if (tasks is null) throw new ArgumentNullException(nameof(tasks));
         if (filterStatus is null) throw new ArgumentNullException(nameof(filterStatus));
 
         IEnumerable<GlassworkTask> filtered = filterStatus == "all"
-            ? tasks.Values.Where(t => t.Status != GlassworkTask.Statuses.Done)
-            : tasks.Values.Where(t => t.Status == filterStatus);
+            ? tasks.Where(t => t.Status != GlassworkTask.Statuses.Done)
+            : tasks.Where(t => t.Status == filterStatus);
+
+        if (!string.IsNullOrWhiteSpace(searchText))
+            filtered = filtered.Where(t => TaskSearchText.Matches(t, searchText));
 
         return filtered.Select(t => t.Clone()).ToList();
     }

--- a/src/Glasswork.Core/Services/TaskSearchService.cs
+++ b/src/Glasswork.Core/Services/TaskSearchService.cs
@@ -7,15 +7,6 @@ namespace Glasswork.Core.Services;
 /// </summary>
 public sealed class TaskSearchService
 {
-    private static readonly HashSet<string> ValidFields = new(StringComparer.Ordinal)
-    {
-        "title",
-        "description",
-        "notes",
-        "subtasks",
-        "tags",
-    };
-
     private readonly VaultService _vault;
 
     public TaskSearchService(VaultService vault)
@@ -36,13 +27,10 @@ public sealed class TaskSearchService
             throw new ArgumentException("query must be 500 characters or fewer.");
 
         var clampedLimit = Math.Clamp(limit, 1, 100);
-        var scope = NormalizeScope(fields);
-        var requiredTagSet = NormalizeTags(requiredTags);
-        var allowedStatuses = NormalizeStatuses(statuses);
-        var tokens = query.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Select(t => t.ToLowerInvariant())
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
+        var scope = TaskSearchText.NormalizeScope(fields);
+        var requiredTagSet = TaskSearchText.NormalizeTags(requiredTags);
+        var allowedStatuses = TaskSearchText.NormalizeStatuses(statuses);
+        var tokens = TaskSearchText.Tokenize(query);
 
         var all = _vault.LoadAll();
         var hits = new List<ScoredHit>();
@@ -59,22 +47,17 @@ public sealed class TaskSearchService
                     continue;
             }
 
-            var searchable = BuildSearchableFields(task, scope);
-            if (!AllTokensMatch(tokens, searchable))
+            var searchable = TaskSearchText.BuildSearchableFields(task, scope);
+            if (!TaskSearchText.AllTokensMatch(tokens, searchable))
                 continue;
 
-            var matchedFields = new List<string>();
-            foreach (var pair in searchable)
-            {
-                if (tokens.Any(t => pair.Value.Contains(t, StringComparison.OrdinalIgnoreCase)))
-                    matchedFields.Add(pair.Key);
-            }
+            var matchedFields = TaskSearchText.MatchedFields(searchable, tokens);
 
             if (matchedFields.Count == 0)
                 continue;
 
-            var snippet = BuildSnippet(searchable, matchedFields, tokens);
-            var score = ComputeScore(matchedFields);
+            var snippet = TaskSearchText.BuildSnippet(searchable, matchedFields, tokens);
+            var score = TaskSearchText.ComputeScore(matchedFields);
             var effectiveStatus = task.Status == GlassworkTask.Statuses.InProgress ? "doing" : task.Status;
             hits.Add(new ScoredHit(
                 new TaskSearchHit(
@@ -97,7 +80,40 @@ public sealed class TaskSearchService
             .ToArray();
     }
 
-    private static Dictionary<string, string> BuildSearchableFields(GlassworkTask task, HashSet<string> scope)
+    private sealed record ScoredHit(TaskSearchHit Hit, int Score, DateTime Created);
+}
+
+internal static class TaskSearchText
+{
+    private static readonly HashSet<string> ValidFields = new(StringComparer.Ordinal)
+    {
+        "title",
+        "description",
+        "notes",
+        "subtasks",
+        "tags",
+    };
+
+    internal static bool Matches(GlassworkTask task, string? query, IReadOnlyList<string>? fields = null)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return true;
+
+        var scope = NormalizeScope(fields);
+        var tokens = Tokenize(query);
+        var searchable = BuildSearchableFields(task, scope);
+        return AllTokensMatch(tokens, searchable);
+    }
+
+    internal static string[] Tokenize(string query)
+    {
+        return query.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(t => t.ToLowerInvariant())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    internal static Dictionary<string, string> BuildSearchableFields(GlassworkTask task, HashSet<string> scope)
     {
         var result = new Dictionary<string, string>(StringComparer.Ordinal);
         if (scope.Contains("title")) result["title"] = task.Title ?? string.Empty;
@@ -114,7 +130,7 @@ public sealed class TaskSearchService
         return result;
     }
 
-    private static HashSet<string> NormalizeScope(IReadOnlyList<string>? fields)
+    internal static HashSet<string> NormalizeScope(IReadOnlyList<string>? fields)
     {
         if (fields is null || fields.Count == 0)
             return new HashSet<string>(ValidFields, StringComparer.Ordinal);
@@ -131,7 +147,7 @@ public sealed class TaskSearchService
         return scope;
     }
 
-    private static HashSet<string>? NormalizeTags(IReadOnlyList<string>? tags)
+    internal static HashSet<string>? NormalizeTags(IReadOnlyList<string>? tags)
     {
         if (tags is null || tags.Count == 0)
             return null;
@@ -146,7 +162,7 @@ public sealed class TaskSearchService
         return set.Count == 0 ? null : set;
     }
 
-    private static HashSet<string>? NormalizeStatuses(IReadOnlyList<string>? statuses)
+    internal static HashSet<string>? NormalizeStatuses(IReadOnlyList<string>? statuses)
     {
         if (statuses is null || statuses.Count == 0)
             return null;
@@ -167,7 +183,7 @@ public sealed class TaskSearchService
         return set;
     }
 
-    private static bool AllTokensMatch(IReadOnlyList<string> tokens, Dictionary<string, string> searchable)
+    internal static bool AllTokensMatch(IReadOnlyList<string> tokens, Dictionary<string, string> searchable)
     {
         foreach (var token in tokens)
         {
@@ -177,7 +193,20 @@ public sealed class TaskSearchService
         return true;
     }
 
-    private static string BuildSnippet(
+    internal static List<string> MatchedFields(
+        Dictionary<string, string> searchable,
+        IReadOnlyList<string> tokens)
+    {
+        var matchedFields = new List<string>();
+        foreach (var pair in searchable)
+        {
+            if (tokens.Any(t => pair.Value.Contains(t, StringComparison.OrdinalIgnoreCase)))
+                matchedFields.Add(pair.Key);
+        }
+        return matchedFields;
+    }
+
+    internal static string BuildSnippet(
         Dictionary<string, string> searchable,
         IReadOnlyList<string> matchedFields,
         IReadOnlyList<string> tokens)
@@ -202,15 +231,13 @@ public sealed class TaskSearchService
         return segment;
     }
 
-    private static int ComputeScore(IReadOnlyCollection<string> matchedFields)
+    internal static int ComputeScore(IReadOnlyCollection<string> matchedFields)
     {
         var score = matchedFields.Count;
         if (matchedFields.Contains("title"))
             score += 10;
         return score;
     }
-
-    private sealed record ScoredHit(TaskSearchHit Hit, int Score, DateTime Created);
 }
 
 public sealed record TaskSearchHit(

--- a/src/Glasswork.Core/ViewModels/BacklogViewModel.cs
+++ b/src/Glasswork.Core/ViewModels/BacklogViewModel.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Glasswork.Core.Models;
+using Glasswork.Core.Queries;
 using Glasswork.Core.Services;
 
 namespace Glasswork.ViewModels;
@@ -66,6 +67,7 @@ public partial class BacklogViewModel : ObservableObject, IDisposable
     [ObservableProperty] public partial GlassworkTask? SelectedTask { get; set; }
     [ObservableProperty] public partial bool IsGrouped { get; set; } = true;
     [ObservableProperty] public partial string ViewMode { get; set; } = "list"; // "list" | "board"
+    [ObservableProperty] public partial string SearchText { get; set; } = string.Empty;
 
     private readonly IndexService _index;
 
@@ -101,7 +103,8 @@ public partial class BacklogViewModel : ObservableObject, IDisposable
         if (ViewMode == "board")
         {
             // Board mode: use BacklogBoardGrouper, ignore FilterStatus and IsGrouped
-            var columns = BacklogBoardGrouper.GroupByStatus(all);
+            var searched = BacklogQueries.Filter(all, "all", SearchText);
+            var columns = BacklogBoardGrouper.GroupByStatus(searched);
             foreach (var col in columns)
             {
                 BoardColumns.Add(col);
@@ -118,11 +121,7 @@ public partial class BacklogViewModel : ObservableObject, IDisposable
         else
         {
             // List mode: existing logic
-            var filtered = FilterStatus switch
-            {
-                "all" => all.Where(t => t.Status != GlassworkTask.Statuses.Done),
-                _ => all.Where(t => t.Status == FilterStatus)
-            };
+            var filtered = BacklogQueries.Filter(all, FilterStatus, SearchText);
 
             var ordered = filtered.OrderByDescending(t => t.Priority == "urgent")
                                   .ThenByDescending(t => t.Priority == "high")
@@ -139,6 +138,7 @@ public partial class BacklogViewModel : ObservableObject, IDisposable
                 // Hydrate cache from persisted store before grouping so headers render
                 // resolved titles on the first frame instead of flashing the bare ID.
                 HydrateParentTitleCache(ordered);
+                var liveBacklogTasks = BacklogQueries.Filter(all, "all");
 
                 var collapseState = GroupCollapseStateProvider?.Invoke()
                                     ?? new Dictionary<string, bool>();
@@ -149,7 +149,7 @@ public partial class BacklogViewModel : ObservableObject, IDisposable
                 }
 
                 // GC stale entries no longer referenced by any task in the current set.
-                CompactParentTitleStore(ordered);
+                CompactParentTitleStore(liveBacklogTasks);
 
                 // Kick off background fetches for any numeric parents we haven't resolved yet.
                 KickOffParentTitleFetches(ordered);
@@ -308,6 +308,7 @@ public partial class BacklogViewModel : ObservableObject, IDisposable
 
     partial void OnIsGroupedChanged(bool value) => Refresh();
     partial void OnViewModeChanged(string value) => Refresh();
+    partial void OnSearchTextChanged(string value) => Refresh();
 
     public void Dispose()
     {

--- a/tests/Glasswork.Tests/BacklogQueriesTests.cs
+++ b/tests/Glasswork.Tests/BacklogQueriesTests.cs
@@ -31,6 +31,67 @@ public class BacklogQueriesTests
     }
 
     [TestMethod]
+    public void Filter_SearchText_MatchesTaskContentWithinBacklog()
+    {
+        var dict = Snapshot(
+            new GlassworkTask
+            {
+                Id = "title",
+                Title = "Fix backlog search",
+                Status = GlassworkTask.Statuses.Todo
+            },
+            new GlassworkTask
+            {
+                Id = "notes",
+                Title = "Unrelated",
+                Status = GlassworkTask.Statuses.Todo,
+                Notes = "Search should inspect planning notes."
+            },
+            new GlassworkTask
+            {
+                Id = "tag",
+                Title = "Another task",
+                Status = GlassworkTask.Statuses.InProgress,
+                Tags = ["search"]
+            },
+            new GlassworkTask
+            {
+                Id = "done",
+                Title = "Search completed task",
+                Status = GlassworkTask.Statuses.Done
+            });
+
+        var result = BacklogQueries.Filter(dict, "all", "search");
+
+        CollectionAssert.AreEquivalent(
+            new[] { "title", "notes", "tag" },
+            result.Select(t => t.Id).ToArray());
+    }
+
+    [TestMethod]
+    public void Filter_SearchText_ComposesWithStatusFilter()
+    {
+        var dict = Snapshot(
+            new GlassworkTask
+            {
+                Id = "todo",
+                Title = "Search candidate",
+                Status = GlassworkTask.Statuses.Todo
+            },
+            new GlassworkTask
+            {
+                Id = "doing",
+                Title = "Search candidate",
+                Status = GlassworkTask.Statuses.InProgress
+            });
+
+        var result = BacklogQueries.Filter(dict, GlassworkTask.Statuses.InProgress, "search");
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("doing", result[0].Id);
+    }
+
+    [TestMethod]
     public void Filter_NamedStatus_ReturnsOnlyMatching()
     {
         var dict = Snapshot(

--- a/tests/Glasswork.Tests/BacklogViewModelIndexSubscriptionTests.cs
+++ b/tests/Glasswork.Tests/BacklogViewModelIndexSubscriptionTests.cs
@@ -63,6 +63,70 @@ public class BacklogViewModelIndexSubscriptionTests
     }
 
     [TestMethod]
+    public void SearchText_FiltersListModeBacklogTasks()
+    {
+        _taskService.CreateTask("Improve backlog search");
+        _taskService.CreateTask("Polish My Day cards");
+
+        var vm = new BacklogViewModel(_vault, _taskService, _index);
+        vm.Refresh();
+
+        vm.SearchText = "search";
+
+        Assert.AreEqual(1, vm.Tasks.Count);
+        Assert.AreEqual("Improve backlog search", vm.Tasks[0].Title);
+        Assert.AreEqual(1, vm.Rows.OfType<GlassworkTask>().Count());
+    }
+
+    [TestMethod]
+    public void SearchText_FiltersBoardModeBacklogTasks()
+    {
+        _taskService.CreateTask("Improve backlog search");
+        var inProgress = _taskService.CreateTask("Polish My Day cards");
+        _taskService.SetStatus(inProgress, GlassworkTask.Statuses.InProgress);
+
+        var vm = new BacklogViewModel(_vault, _taskService, _index);
+        vm.ViewMode = "board";
+
+        vm.SearchText = "cards";
+
+        Assert.AreEqual(1, vm.BoardColumns.Sum(c => c.Tasks.Count));
+        Assert.AreEqual("Polish My Day cards", vm.BoardColumns.SelectMany(c => c.Tasks).Single().Title);
+    }
+
+    [TestMethod]
+    public void Refresh_CompactsParentTitleCacheAgainstAllActiveBacklogTasks()
+    {
+        var todo = _taskService.CreateTask("Todo child");
+        todo.Parent = "1";
+        _vault.Save(todo);
+        var inProgress = _taskService.CreateTask("In-progress child");
+        inProgress.Parent = "2";
+        _vault.Save(inProgress);
+        _taskService.SetStatus(inProgress, GlassworkTask.Statuses.InProgress);
+
+        var uiStatePath = Path.Combine(_tempDir, "ui-state.json");
+        var ui = new JsonFileUiStateService(uiStatePath);
+        var store = new AdoParentTitleCacheStore(ui);
+        store.Set(1, "Todo parent");
+        store.Set(2, "In-progress parent");
+        store.Save();
+
+        var vm = new BacklogViewModel(_vault, _taskService, _index, ui)
+        {
+            FilterStatus = GlassworkTask.Statuses.Todo
+        };
+
+        vm.Refresh();
+
+        var loaded = new AdoParentTitleCacheStore(new JsonFileUiStateService(uiStatePath))
+            .LoadFresh(new[] { 1, 2 });
+        Assert.AreEqual(2, loaded.Count);
+        Assert.AreEqual("Todo parent", loaded[1]);
+        Assert.AreEqual("In-progress parent", loaded[2]);
+    }
+
+    [TestMethod]
     public void SetStatusCommand_CallsRefreshForImmediateUpdate()
     {
         var task1 = _taskService.CreateTask("Task 1");


### PR DESCRIPTION
## Summary
- add a search box to the Backlog page
- filter Backlog list and board tasks by task search content
- share task-search matching logic with TaskSearchService
- prevent search refreshes from restoring stale scroll offsets and keep ADO parent-title cache compaction non-destructive across filters

## Validation
- dotnet test tests\Glasswork.Tests\Glasswork.Tests.csproj --filter "FullyQualifiedName~BacklogViewModelIndexSubscriptionTests|FullyQualifiedName~BacklogQueriesTests|FullyQualifiedName~TaskSearchServiceTests" --logger "console;verbosity=minimal"
- dotnet build src\Glasswork.App\Glasswork.csproj -p:RuntimeIdentifier=win-x64 --verbosity minimal