### PR TITLE
Add visual verification primitive for local agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -149,6 +149,22 @@ inside Ubuntu.
      `false` on an element that's already in the live tree. Check
      `element.Parent != null` instead.
 
+7. **Visual verification before declaring a local task done.** After any
+   change touching `src\Glasswork.App\` (XAML, code-behind, ViewModels,
+   `App.xaml.cs`, services that affect what's drawn), you **must** run
+   [`scripts\verify-app.ps1`](../scripts/verify-app.ps1) and view the
+   resulting PNG before signing off. The test suite cannot catch XAML
+   parse errors, layout regressions, blank screens, or the silent
+   `STOWED_EXCEPTION` crashes from hard rule 6 — only a real render can.
+   The script does Debug build → launch dev-build exe → wait for window →
+   screenshot via `PrintWindow(PW_RENDERFULLCONTENT)` → kill the spawned
+   instance → print the PNG path. It only touches the exe under
+   `src\Glasswork.App\bin\`, so the user's installed Glasswork (from
+   `publish.ps1`) is left alone. Pure `Glasswork.Core` changes (no UI
+   surface affected) may skip this. **Cloud / Linux agents cannot run
+   this** — they must flag UI-touching work for local re-verification
+   before merge.
+
 ## Investigation guidance (for issue triage & root-cause analysis)
 
 When assigned a user-reported issue (label `user-report`):

--- a/scripts/screenshot-app.ps1
+++ b/scripts/screenshot-app.ps1
@@ -1,0 +1,108 @@
+<#
+.SYNOPSIS
+  Capture a screenshot of a running window by process name or PID using Win32 PrintWindow.
+
+.DESCRIPTION
+  Uses PrintWindow with PW_RENDERFULLCONTENT (Windows 8.1+) which asks the window to render
+  itself into a DC. Works on occluded windows, secondary monitors, and (unlike GDI BitBlt)
+  RDP-disconnected sessions. No UI Automation involvement, no desktop enumeration — just a
+  direct HWND -> PNG capture. This is the approach Microsoft's UFO research agent uses.
+
+  Intended as the "give the agent eyes" primitive for Glasswork. Saves a PNG and prints
+  its absolute path on the last line of stdout so callers can capture it.
+
+.PARAMETER ProcessName
+  Process name (without .exe). Mutually exclusive with -Pid.
+
+.PARAMETER Pid
+  Process ID. Mutually exclusive with -ProcessName.
+
+.PARAMETER OutPath
+  Destination PNG. Defaults to $env:TEMP\<processname>-<timestamp>.png.
+
+.EXAMPLE
+  pwsh -File scripts\screenshot-app.ps1 -ProcessName Glasswork
+#>
+[CmdletBinding(DefaultParameterSetName='ByName')]
+param(
+    [Parameter(ParameterSetName='ByName', Mandatory)]
+    [string]$ProcessName,
+    [Parameter(ParameterSetName='ByPid', Mandatory)]
+    [int]$ProcessId,
+    [string]$OutPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Resolve target process
+$proc = if ($PSCmdlet.ParameterSetName -eq 'ByName') {
+    Get-Process -Name $ProcessName -ErrorAction Stop | Where-Object { $_.MainWindowHandle -ne 0 } | Select-Object -First 1
+} else {
+    Get-Process -Id $ProcessId -ErrorAction Stop
+}
+if (-not $proc) { throw "No process found." }
+$hwnd = $proc.MainWindowHandle
+if ($hwnd -eq 0) { throw "Process $($proc.Id) has no top-level window." }
+
+if (-not $OutPath) {
+    $ts = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $OutPath = Join-Path $env:TEMP "$($proc.ProcessName)-$ts.png"
+}
+
+# Inline P/Invoke for PrintWindow + GetWindowRect.
+$sig = @'
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+
+public static class WinShot {
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool PrintWindow(IntPtr hwnd, IntPtr hdcBlt, uint nFlags);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT { public int Left, Top, Right, Bottom; }
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+    [DllImport("dwmapi.dll")]
+    public static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out RECT pvAttribute, int cbAttribute);
+
+    // PW_RENDERFULLCONTENT = 2 — handles DirectComposition (WinUI/WPF) windows.
+    public const uint PW_RENDERFULLCONTENT = 2;
+    // DWMWA_EXTENDED_FRAME_BOUNDS = 9 — true window bounds excluding invisible shadow margins.
+    public const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
+
+    public static void Capture(IntPtr hwnd, string path) {
+        RECT r;
+        if (DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, out r, Marshal.SizeOf<RECT>()) != 0) {
+            if (!GetWindowRect(hwnd, out r)) throw new Exception("GetWindowRect failed");
+        }
+        int w = r.Right - r.Left;
+        int h = r.Bottom - r.Top;
+        if (w <= 0 || h <= 0) throw new Exception("Window has zero size — minimized?");
+
+        using (var bmp = new Bitmap(w, h, PixelFormat.Format32bppArgb))
+        using (var g = Graphics.FromImage(bmp)) {
+            IntPtr hdc = g.GetHdc();
+            try {
+                bool ok = PrintWindow(hwnd, hdc, PW_RENDERFULLCONTENT);
+                if (!ok) throw new Exception("PrintWindow returned false");
+            } finally {
+                g.ReleaseHdc(hdc);
+            }
+            bmp.Save(path, ImageFormat.Png);
+        }
+    }
+}
+'@
+
+Add-Type -TypeDefinition $sig -ReferencedAssemblies 'System.Drawing','System.Drawing.Primitives','System.Drawing.Common','System.Private.Windows.Core' -ErrorAction Stop
+
+[WinShot]::Capture($hwnd, $OutPath)
+$resolved = (Resolve-Path -LiteralPath $OutPath).Path
+Write-Host "Captured PID $($proc.Id) ('$($proc.MainWindowTitle)') -> $resolved"
+$resolved

--- a/scripts/verify-app.ps1
+++ b/scripts/verify-app.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+  Visual smoke-test of Glasswork: build, launch, screenshot, kill, return PNG path.
+
+.DESCRIPTION
+  Agents must run this after implementing changes that could affect the running app,
+  then view the resulting PNG to confirm the change visually before declaring the
+  task done. This catches XAML parse errors, layout regressions, blank screens, and
+  the silent STOWED_EXCEPTION crashes (per architectural hard rule 6 in
+  .github/copilot-instructions.md) that the test suite cannot.
+
+  The script only touches the Debug-build exe under src\Glasswork.App\bin\. Any
+  user-launched Glasswork (e.g. from the published install at
+  %LOCALAPPDATA%\Programs\Glasswork) is left alone — only the spawned dev-build
+  PID is screenshotted and killed.
+
+.PARAMETER NoBuild
+  Skip dotnet build. Use when you've just built and want a pure screenshot pass.
+
+.PARAMETER OutPath
+  Destination PNG. Defaults to $env:TEMP\Glasswork-verify-<timestamp>.png.
+
+.PARAMETER LaunchTimeoutSec
+  Seconds to wait for the dev-build window to appear (default 20).
+
+.EXAMPLE
+  pwsh -File scripts\verify-app.ps1
+#>
+[CmdletBinding()]
+param(
+    [switch]$NoBuild,
+    [string]$OutPath,
+    [int]$LaunchTimeoutSec = 20
+)
+
+$ErrorActionPreference = 'Stop'
+$repo = Split-Path -Parent $PSScriptRoot
+$proj = Join-Path $repo 'src\Glasswork.App\Glasswork.csproj'
+$binDir = Join-Path $repo 'src\Glasswork.App\bin\x64\Debug\net10.0-windows10.0.26100.0\win-x64'
+$exe = Join-Path $binDir 'Glasswork.exe'
+
+# 1. Kill any prior dev-build instance (match by exe path, not name — leaves the
+#    user's installed Glasswork running).
+function Stop-DevBuild {
+    Get-Process -Name Glasswork -ErrorAction SilentlyContinue | Where-Object {
+        try { $_.Path -and ($_.Path -ieq $exe) } catch { $false }
+    } | ForEach-Object {
+        Write-Host "Stopping prior dev-build (PID $($_.Id))..."
+        Stop-Process -Id $_.Id -Force
+    }
+}
+Stop-DevBuild
+Start-Sleep 1
+
+# 2. Build (unless caller already did).
+if (-not $NoBuild) {
+    Write-Host "Building Glasswork.App (Debug|x64)..." -ForegroundColor Cyan
+    & dotnet build $proj -c Debug -p:Platform=x64 --nologo -v quiet -tl:off
+    if ($LASTEXITCODE -ne 0) { throw "Build failed (exit $LASTEXITCODE). Fix compile errors before re-running." }
+}
+if (-not (Test-Path $exe)) { throw "Build succeeded but exe not found at $exe" }
+
+# 3. Launch.
+Write-Host "Launching $exe"
+$spawned = Start-Process -FilePath $exe -PassThru
+$pid_ = $spawned.Id
+
+# 4. Wait for MainWindowHandle. WinUI 3 self-contained init is ~1-3s on warm cache,
+#    longer on cold start. Poll every 250ms up to LaunchTimeoutSec.
+$deadline = (Get-Date).AddSeconds($LaunchTimeoutSec)
+$hwnd = 0
+while ((Get-Date) -lt $deadline) {
+    $p = Get-Process -Id $pid_ -ErrorAction SilentlyContinue
+    if (-not $p) {
+        throw "Glasswork (PID $pid_) exited before showing a window — likely a startup crash. Check Event Viewer > Application for STOWED_EXCEPTION or XamlParseException (architectural hard rule 6)."
+    }
+    if ($p.MainWindowHandle -ne 0) { $hwnd = $p.MainWindowHandle; break }
+    Start-Sleep -Milliseconds 250
+}
+if ($hwnd -eq 0) {
+    Stop-Process -Id $pid_ -Force -ErrorAction SilentlyContinue
+    throw "Glasswork did not show a window within ${LaunchTimeoutSec}s. Either increase -LaunchTimeoutSec or investigate why startup is slow."
+}
+# Give the first frame a moment to compose so the screenshot isn't a blank/loading state.
+Start-Sleep -Milliseconds 800
+
+# 5. Screenshot via the existing primitive (targets the specific PID, so the user's
+#    own Glasswork is never touched).
+if (-not $OutPath) {
+    $ts = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $OutPath = Join-Path $env:TEMP "Glasswork-verify-$ts.png"
+}
+& pwsh -NoProfile -File (Join-Path $PSScriptRoot 'screenshot-app.ps1') -ProcessId $pid_ -OutPath $OutPath | Out-Null
+if ($LASTEXITCODE -ne 0 -or -not (Test-Path $OutPath)) {
+    Stop-Process -Id $pid_ -Force -ErrorAction SilentlyContinue
+    throw "Screenshot capture failed."
+}
+
+# 6. Kill the spawned instance — never leave dev builds running after verification.
+Stop-Process -Id $pid_ -Force -ErrorAction SilentlyContinue
+
+# 7. Print path on last line so callers can pipe / capture it.
+$resolved = (Resolve-Path -LiteralPath $OutPath).Path
+Write-Host "PNG saved to: $resolved" -ForegroundColor Green
+$resolved


### PR DESCRIPTION
## Why

Glasswork is agentic by design, but agents working on the WinUI 3 app today are blind to what their changes actually render. The MSTest suite catches logic regressions in `Glasswork.Core`, but it cannot catch XAML parse errors, layout regressions, blank-screen bugs, or the silent `STOWED_EXCEPTION 0xc000027b` crashes from architectural hard rule 6. Those only surface when a real frame composites, and historically only when a human notices.

This PR closes that loop: any local agent (Copilot CLI, Claude Code, Ralph) can now build, render, screenshot, and view the running app in ~10 seconds, and the instructions make that step mandatory after UI-touching work.

## Approach

Two PowerShell scripts plus one new architectural rule:

- **`scripts/screenshot-app.ps1`** — low-level primitive. Captures any window by `-ProcessName` or `-ProcessId` using `PrintWindow(PW_RENDERFULLCONTENT)` and `DwmGetWindowAttribute(EXTENDED_FRAME_BOUNDS)`. No UI Automation, no desktop enumeration, no extra dependencies. Works on occluded, minimized, and RDP-disconnected windows. This is the same approach Microsoft's UFO research agent uses internally.
- **`scripts/verify-app.ps1`** — the workflow agents actually run. Debug build the App project, launch the dev-build exe, wait for `MainWindowHandle`, screenshot, kill the spawned PID, print the PNG path. Only the exe under `src\Glasswork.App\bin\` is touched, so the user's installed Glasswork (from `publish.ps1`) is never disturbed. Prints clear errors that distinguish "startup crash before window" (points to hard rule 6) from "didn't show window in time".
- **`.github/copilot-instructions.md`** — new architectural hard rule 7 mandates running `verify-app.ps1` and viewing the resulting PNG before declaring any UI-touching task done. Pure `Glasswork.Core` changes may skip. Cloud / Linux agents are explicitly called out as blind to this and must flag UI-touching work for local re-verification before merge.

## Alternatives evaluated and rejected

- **`terminator-mcp-agent`** (mediar-ai). Best-of-class generic Windows MCP, but `IUIAutomation::FindAll(TreeScope::Children, ControlType in [Window, Pane])` crashes deterministically on this machine, even with no Glasswork running. Installed, smoke-tested, uninstalled.
- **FlaUI v5**. Better .NET-native option for full UI driving (click/type/assert), but heavier setup and only worth it once we have a concrete need beyond screenshots. Deferred.
- **Snapshot / visual regression in CI**. Pixel-exact baselines are defeated by ClearType + GPU driver variance; SSIM thresholds work but the ROI is low until we have a specific UI surface worth gating. Not done here.

## Notes for review

- The script writes PNGs to `$env:TEMP`. They self-clean and the path is printed so callers can move it. No repo pollution.
- `verify-app.ps1` invokes `screenshot-app.ps1` via `pwsh -NoProfile` so a slow `$PROFILE` doesn't add latency to the loop.
- Build is `-tl:off -v quiet` to keep agent output scannable; warnings still surface, errors still fail.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>