### PR TITLE
fix(my-day): stop today's subtasks overlapping card details

### DIFF
--- a/src/Glasswork.App/Pages/MyDayPage.xaml
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml
@@ -69,7 +69,7 @@
             </ListView.ItemContainerStyle>
             <ListView.ItemTemplate>
                 <DataTemplate>
-                    <Grid Padding="10,8" RowDefinitions="Auto,Auto"
+                    <Grid Padding="10,8" RowDefinitions="Auto,Auto,Auto"
                           DoubleTapped="TaskRow_DoubleTapped"
                           ContextRequested="TaskRow_ContextRequested"
                           Background="Transparent">
@@ -191,8 +191,9 @@
                         <!-- Today's subtasks (ADR 0008): flagged or due-today subtasks rendered
                              inline beneath the parent. Visible whenever any qualify, even when
                              the parent's card details are collapsed, since these subtasks are
-                             the reason this parent appears in My Day. -->
-                        <ItemsControl Grid.Row="1" ItemsSource="{Binding TodaysSubtasks}"
+                             the reason this parent appears in My Day. Placed in its own row so
+                             it stacks below card details rather than overlapping them. -->
+                        <ItemsControl Grid.Row="2" ItemsSource="{Binding TodaysSubtasks}"
                                       Visibility="{Binding HasTodaysSubtasks, Converter={StaticResource BoolVis}}"
                                       Margin="32,4,0,0">
                             <ItemsControl.ItemTemplate>


### PR DESCRIPTION
An in-progress task with a flagged or due-today subtask rendered with the today-subtask line painted on top of the current-step / progress bar, producing visible text overlap in the My Day list.

Root cause: the task-row `DataTemplate` in `MyDayPage.xaml` declared a 2-row grid (`RowDefinitions="Auto,Auto"`), but two sibling containers were both assigned `Grid.Row="1"`:

- the card-details `StackPanel` (progress bar, current-step accent line, blocker, blurb)
- the `TodaysSubtasks` `ItemsControl` (ADR 0008 inline promotions)

When both were visible they Z-stacked into the same cell. Fix: add a third `Auto` row and move `TodaysSubtasks` to `Grid.Row="2"` so it stacks cleanly underneath instead.

Net diff: 4 added / 3 changed lines in one XAML file. Build is clean; full test suite passes (the two `DebouncesBurstsIntoOneEvent` flakes are pre-existing timing-sensitive tests unrelated to this change and pass in isolation on both base and fix branches).