### PR TITLE
Preserve TodayList scroll across My Day refresh

### DIFF
--- a/src/Glasswork.App/Pages/MyDayPage.xaml.cs
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml.cs
@@ -6,6 +6,7 @@ using Glasswork.Services;
 using Glasswork.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 
 namespace Glasswork.Pages;
@@ -15,10 +16,60 @@ public sealed partial class MyDayPage : Page
     public MyDayViewModel ViewModel { get; }
     public string TodayDate => DateTime.Today.ToString("dddd, MMMM d");
 
+    // Pending scroll-restore snapshot for TodayList. Captured in ViewModel.Refreshing
+    // (before the destructive Clear+Add inside MyDayViewModel.Refresh tears the
+    // ListView's ScrollViewer down to offset 0), applied with bounded retry after
+    // ViewModel.Refreshed once layout has caught up. Null when no restore is queued.
+    // Mirrors the Backlog fix (issue #182). TodayList is the primary (and tallest,
+    // MinHeight 320) scroll surface and the user-reported pain; the short secondary
+    // lists (recently-completed / suggestions, MaxHeight 140-400) are left as-is.
+    private ScrollSnapshot? _pendingRestore;
+
+    private sealed record ScrollSnapshot(double ListOffset);
+
     public MyDayPage()
     {
         ViewModel = new MyDayViewModel(App.Vault, App.Tasks, App.Index, App.UiState);
         InitializeComponent();
+
+        // Snapshot TodayList's scroll position before VM.Refresh() destroys it, then
+        // restore it after Refreshed once layout has caught up. Subscribed AFTER
+        // InitializeComponent so the handlers never dereference XAML controls during
+        // the parse pass (copilot-instructions hard rule 6).
+        ViewModel.Refreshing += () =>
+        {
+            // Visual-tree walks must be on the UI thread.
+            if (!DispatcherQueue.HasThreadAccess) return;
+
+            // ??= preserves the ORIGINAL pre-refresh offset across back-to-back
+            // refreshes (e.g. the 'x' command's Refresh() followed immediately by the
+            // file-watcher echo's Refresh()) — without it the second Refreshing would
+            // capture the post-clear scroll-zero state and clobber the real position.
+            // Defensive try/catch: scroll preservation must never break Refresh().
+            try
+            {
+                _pendingRestore ??= CaptureScrollState();
+            }
+            catch
+            {
+                _pendingRestore = null;
+            }
+        };
+        ViewModel.Refreshed += () =>
+        {
+            // Refreshed fires on whichever thread called VM.Refresh(); all current call
+            // sites are on the UI thread, but marshal to it defensively in case that
+            // changes — hydration, the empty-state decision, and the restore scheduling
+            // all read/touch UI + _pendingRestore and must run together on the UI thread.
+            if (DispatcherQueue.HasThreadAccess)
+            {
+                HandleRefreshed();
+            }
+            else
+            {
+                DispatcherQueue.TryEnqueue(HandleRefreshed);
+            }
+        };
     }
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -41,7 +92,41 @@ public sealed partial class MyDayPage : Page
 
     private void Refresh()
     {
+        // VM.Refresh() raises Refreshing (scroll capture) then Refreshed (collapse
+        // hydration + empty-state + scroll restore). Keeping all post-refresh work in
+        // the Refreshed handler means every path that refreshes — OnNavigatedTo, the
+        // refresh button, the file-watcher echo, AND the command paths that call
+        // VM.XxxCommand.Execute() directly — gets identical treatment.
         ViewModel.Refresh();
+    }
+
+    private void HandleRefreshed()
+    {
+        HydrateAndUpdateAfterRefresh();
+
+        // Empty My Day: nothing scrollable to restore to. Drop any pending snapshot
+        // so a stale retry can't fire against a collapsed/non-scrollable list.
+        if (ViewModel.TodayTasks.Count == 0)
+        {
+            _pendingRestore = null;
+            return;
+        }
+
+        // Dispatch the restore at Low priority so layout can realize containers +
+        // recompute extent before ChangeView lands (UpdateEmptyState above has already
+        // made TodayList visible); bounded retry handles the cases where Low alone
+        // isn't enough (virtualized ListView still measuring).
+        if (_pendingRestore is not null)
+        {
+            var snapshot = _pendingRestore;
+            DispatcherQueue.TryEnqueue(
+                Microsoft.UI.Dispatching.DispatcherQueuePriority.Low,
+                () => TryRestoreWithRetry(snapshot, attempts: 0));
+        }
+    }
+
+    private void HydrateAndUpdateAfterRefresh()
+    {
         // Hydrate per-task manual-collapse state from UI state (persists across nav + restarts).
         foreach (var t in ViewModel.TodayTasks)
         {
@@ -202,6 +287,82 @@ public sealed partial class MyDayPage : Page
         var vaultRelative = VaultPageHelper.ToVaultRelativePath(absolutePath);
         if (vaultRelative is null) return;
         await App.ObsidianLauncher.Open(vaultRelative);
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #182 (extended to My Day): scroll-position capture/restore around
+    // VM.Refresh(). The destructive Clear+Add inside MyDayViewModel.Refresh
+    // tears down TodayList's internal ScrollViewer, snapping it back to offset 0.
+    // We capture in VM.Refreshing (before Clear) and restore in VM.Refreshed via
+    // Low-priority dispatch with bounded retry. Simpler than Backlog's equivalent:
+    // a single list surface, no view-mode/filter/search context to invalidate.
+    // ---------------------------------------------------------------------
+
+    private ScrollSnapshot CaptureScrollState()
+    {
+        double listOffset = 0;
+        var sv = FindDescendantScrollViewer(TodayList);
+        if (sv is not null) listOffset = sv.VerticalOffset;
+        return new ScrollSnapshot(listOffset);
+    }
+
+    private void TryRestoreWithRetry(ScrollSnapshot snapshot, int attempts)
+    {
+        // Stale callback (snapshot was dropped on empty My Day, or superseded by a
+        // newer refresh that overwrote _pendingRestore)? Bail. Reference identity, not
+        // value equality — two distinct cycles can share the same offset value.
+        if (!ReferenceEquals(_pendingRestore, snapshot)) return;
+
+        if (ApplySnapshot(snapshot))
+        {
+            _pendingRestore = null;
+            return;
+        }
+
+        // Layout not yet ready (e.g. ScrollableHeight == 0 but target > 0). Re-queue at
+        // Low up to 5 times; bounded so a degenerate state can't loop forever.
+        if (attempts >= 5)
+        {
+            _pendingRestore = null;
+            return;
+        }
+        DispatcherQueue.TryEnqueue(
+            Microsoft.UI.Dispatching.DispatcherQueuePriority.Low,
+            () => TryRestoreWithRetry(snapshot, attempts + 1));
+    }
+
+    private bool ApplySnapshot(ScrollSnapshot s)
+    {
+        var sv = FindDescendantScrollViewer(TodayList);
+        if (sv is null) return false;
+        // If we want a non-zero offset but the extent hasn't been measured yet, the
+        // request would silently land at 0. Defer and retry.
+        if (s.ListOffset > 0 && sv.ScrollableHeight <= 0) return false;
+        sv.ChangeView(
+            horizontalOffset: null,
+            verticalOffset: Math.Max(0, Math.Min(s.ListOffset, sv.ScrollableHeight)),
+            zoomFactor: null,
+            disableAnimation: true);
+        return true;
+    }
+
+    /// <summary>
+    /// VisualTreeHelper DFS to find the first <see cref="ScrollViewer"/> descendant of
+    /// <paramref name="root"/>. Returns null if none exists or <paramref name="root"/>
+    /// is null. Used to dig the implicit ScrollViewer out of TodayList's template.
+    /// </summary>
+    private static ScrollViewer? FindDescendantScrollViewer(DependencyObject? root)
+    {
+        if (root is null) return null;
+        if (root is ScrollViewer sv) return sv;
+        var count = VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+            var found = FindDescendantScrollViewer(child);
+            if (found is not null) return found;
+        }
+        return null;
     }
 }
 

--- a/src/Glasswork.Core/ViewModels/MyDayViewModel.cs
+++ b/src/Glasswork.Core/ViewModels/MyDayViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -56,6 +57,8 @@ public partial class MyDayViewModel : ObservableObject
     [RelayCommand]
     public void Refresh()
     {
+        Refreshing?.Invoke();
+
         TodayTasks.Clear();
         RecentlyCompletedTasks.Clear();
         Suggestions.Clear();
@@ -107,7 +110,55 @@ public partial class MyDayViewModel : ObservableObject
         {
             Suggestions.Add(s);
         }
+
+        Refreshed?.Invoke();
     }
+
+    /// <summary>
+    /// Raised synchronously at the very top of <see cref="Refresh"/>, BEFORE
+    /// any of <see cref="TodayTasks"/>, <see cref="RecentlyCompletedTasks"/>, or
+    /// <see cref="Suggestions"/> are cleared. Subscribers can read the pre-refresh
+    /// state of those collections (e.g. to snapshot UI state that depends on them,
+    /// like <c>ScrollViewer.VerticalOffset</c> of the bound My Day <c>ListView</c>).
+    ///
+    /// Contract (mirrors <see cref="Refreshed"/>):
+    /// <list type="bullet">
+    ///   <item><description>Fires synchronously on whichever thread called
+    ///     <see cref="Refresh"/>. All current call sites invoke <see cref="Refresh"/>
+    ///     on the UI thread; subscribers that touch XAML controls should still
+    ///     verify <c>HasThreadAccess</c> defensively.</description></item>
+    ///   <item><description>Fires exactly once per <see cref="Refresh"/> call,
+    ///     and always BEFORE <see cref="Refreshed"/>.</description></item>
+    ///   <item><description>Subscribers must not throw — an exception will propagate
+    ///     out of <see cref="Refresh"/> and prevent the refresh from running.</description></item>
+    ///   <item><description>Subscribers must not call <see cref="Refresh"/> re-entrantly.</description></item>
+    /// </list>
+    /// </summary>
+    public event Action? Refreshing;
+
+    /// <summary>
+    /// Raised exactly once at the end of <see cref="Refresh"/> after all collections
+    /// (<see cref="TodayTasks"/>, <see cref="RecentlyCompletedTasks"/>,
+    /// <see cref="Suggestions"/>) have been fully populated. Page hosts subscribe to
+    /// this instead of individual <c>CollectionChanged</c> events so post-refresh work
+    /// (empty-state UI, per-task collapse-state hydration, scroll restore) is computed
+    /// against the final state, not the transient empty state that exists between the
+    /// internal <c>Clear()</c> and <c>Add()</c> calls.
+    ///
+    /// Contract:
+    /// <list type="bullet">
+    ///   <item><description>Fires synchronously on whichever thread called
+    ///     <see cref="Refresh"/>. All current call sites invoke <see cref="Refresh"/>
+    ///     on the UI thread (commands and watcher callbacks dispatched via
+    ///     <c>DispatcherQueue.TryEnqueue</c>); subscribers that touch XAML controls
+    ///     should still verify <c>HasThreadAccess</c> defensively.</description></item>
+    ///   <item><description>Subscribers must not throw — an exception will propagate
+    ///     out of <see cref="Refresh"/> and skip any later subscribers.</description></item>
+    ///   <item><description>Subscribers must not call <see cref="Refresh"/> re-entrantly —
+    ///     <see cref="Refresh"/> is not designed for recursion.</description></item>
+    /// </list>
+    /// </summary>
+    public event Action? Refreshed;
 
     /// <summary>
     /// A task is "recently completed today" if it's done, was completed today, AND was on

--- a/tests/Glasswork.Tests/MyDayViewModelRefreshingEventTests.cs
+++ b/tests/Glasswork.Tests/MyDayViewModelRefreshingEventTests.cs
@@ -1,0 +1,196 @@
+using System;
+using System.IO;
+using System.Linq;
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+using Glasswork.ViewModels;
+
+namespace Glasswork.Tests;
+
+/// <summary>
+/// Contract coverage for the My Day scroll-preservation fix: the
+/// <see cref="MyDayViewModel.Refreshing"/> / <see cref="MyDayViewModel.Refreshed"/>
+/// event pair (mirrors the Backlog fix for issue #182).
+///
+/// The page hooks <c>Refreshing</c> to snapshot the <c>TodayList</c> scroll offset
+/// BEFORE the destructive <c>Clear()</c> inside <see cref="MyDayViewModel.Refresh"/>
+/// tears down the ListView's ScrollViewer, and <c>Refreshed</c> to restore it (and
+/// run empty-state / collapse hydration) against the fully-populated collections.
+/// The contract these tests pin down:
+///
+/// <list type="bullet">
+///   <item><description><c>Refreshing</c> fires exactly once per
+///     <see cref="MyDayViewModel.Refresh"/> call.</description></item>
+///   <item><description><c>Refreshing</c> fires BEFORE <c>TodayTasks.Clear()</c> et al,
+///     so subscribers can read the pre-refresh collection state.</description></item>
+///   <item><description><c>Refreshing</c> fires BEFORE <c>Refreshed</c>.</description></item>
+///   <item><description>The cycle fires regardless of how <see cref="MyDayViewModel.Refresh"/>
+///     was invoked — direct call, remove-from-day command, complete command, etc.</description></item>
+///   <item><description>The events fire even when the vault is empty.</description></item>
+/// </list>
+/// </summary>
+[TestClass]
+public class MyDayViewModelRefreshingEventTests
+{
+    private string _tempDir = null!;
+    private VaultService _vault = null!;
+    private IndexService _index = null!;
+    private TaskService _taskService = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-mdvm-refreshing-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _vault = new VaultService(_tempDir);
+        _index = new IndexService(_vault);
+        _index.EnsureLoaded();
+        _taskService = new TaskService(_vault, _index);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    /// <summary>
+    /// Create a task and pin it to My Day for today, so the VM's seeded index
+    /// surfaces it in <see cref="MyDayViewModel.TodayTasks"/>.
+    /// </summary>
+    private GlassworkTask CreateMyDayTask(string title)
+    {
+        var task = _taskService.CreateTask(title);
+        _taskService.ToggleMyDay(task); // sets my_day = today
+        return task;
+    }
+
+    [TestMethod]
+    public void Refresh_RaisesRefreshingExactlyOnce()
+    {
+        CreateMyDayTask("Task A");
+        var vm = new MyDayViewModel(_vault, _taskService);
+
+        var count = 0;
+        vm.Refreshing += () => count++;
+
+        vm.Refresh();
+
+        Assert.AreEqual(1, count, "Refreshing should fire exactly once per Refresh() call");
+    }
+
+    [TestMethod]
+    public void Refresh_RaisesRefreshingBeforeRefreshed()
+    {
+        CreateMyDayTask("Task A");
+        var vm = new MyDayViewModel(_vault, _taskService);
+
+        var sequence = 0;
+        var refreshingOrder = -1;
+        var refreshedOrder = -1;
+        vm.Refreshing += () => refreshingOrder = ++sequence;
+        vm.Refreshed += () => refreshedOrder = ++sequence;
+
+        vm.Refresh();
+
+        Assert.AreEqual(1, refreshingOrder, "Refreshing must fire first");
+        Assert.AreEqual(2, refreshedOrder, "Refreshed must fire second");
+    }
+
+    [TestMethod]
+    public void Refresh_Refreshing_FiresBeforeTodayTasksAreCleared()
+    {
+        CreateMyDayTask("Task A");
+        CreateMyDayTask("Task B");
+
+        var vm = new MyDayViewModel(_vault, _taskService);
+        vm.Refresh(); // prime TodayTasks with the two My Day tasks
+
+        Assert.AreEqual(2, vm.TodayTasks.Count, "precondition: both tasks land on My Day today");
+
+        var observedTodayCount = -1;
+        vm.Refreshing += () => observedTodayCount = vm.TodayTasks.Count;
+
+        vm.Refresh();
+
+        Assert.AreEqual(2, observedTodayCount,
+            "Refreshing must fire before TodayTasks.Clear() — subscriber should still see the 2 pre-refresh tasks");
+    }
+
+    [TestMethod]
+    public void Refreshed_FiresAfterTodayTasksArePopulated()
+    {
+        CreateMyDayTask("Task A");
+        CreateMyDayTask("Task B");
+
+        var vm = new MyDayViewModel(_vault, _taskService);
+
+        var observedTodayCount = -1;
+        vm.Refreshed += () => observedTodayCount = vm.TodayTasks.Count;
+
+        vm.Refresh();
+
+        Assert.AreEqual(2, observedTodayCount,
+            "Refreshed must fire after TodayTasks is fully populated — subscriber should see both tasks");
+    }
+
+    [TestMethod]
+    public void RemoveFromMyDayCommand_RaisesRefreshingThenRefreshedInOrder()
+    {
+        var a = CreateMyDayTask("Task A");
+        CreateMyDayTask("Task B");
+
+        var vm = new MyDayViewModel(_vault, _taskService);
+        vm.Refresh();
+
+        var sequence = 0;
+        var refreshingOrder = -1;
+        var refreshedOrder = -1;
+        vm.Refreshing += () => refreshingOrder = ++sequence;
+        vm.Refreshed += () => refreshedOrder = ++sequence;
+
+        vm.RemoveFromMyDayCommand.Execute(a);
+
+        Assert.AreEqual(1, refreshingOrder,
+            "RemoveFromMyDay (the 'x') must trigger Refreshing before Refreshed");
+        Assert.AreEqual(2, refreshedOrder,
+            "RemoveFromMyDay must fire exactly one Refreshing/Refreshed cycle");
+    }
+
+    [TestMethod]
+    public void CompleteTaskCommand_RaisesRefreshingThenRefreshedInOrder()
+    {
+        var a = CreateMyDayTask("Task A");
+
+        var vm = new MyDayViewModel(_vault, _taskService);
+        vm.Refresh();
+
+        var sequence = 0;
+        var refreshingOrder = -1;
+        var refreshedOrder = -1;
+        vm.Refreshing += () => refreshingOrder = ++sequence;
+        vm.Refreshed += () => refreshedOrder = ++sequence;
+
+        vm.CompleteTaskCommand.Execute(a);
+
+        Assert.AreEqual(1, refreshingOrder,
+            "CompleteTask must trigger Refreshing before Refreshed");
+        Assert.AreEqual(2, refreshedOrder,
+            "CompleteTask must fire exactly one Refreshing/Refreshed cycle");
+    }
+
+    [TestMethod]
+    public void Refresh_WithNoTasks_StillRaisesRefreshing()
+    {
+        // Empty vault sanity: the event must fire even when there's nothing to clear.
+        var vm = new MyDayViewModel(_vault, _taskService);
+
+        var count = 0;
+        vm.Refreshing += () => count++;
+
+        vm.Refresh();
+
+        Assert.AreEqual(1, count, "Refreshing must fire on every Refresh() call, even when the vault is empty");
+    }
+}


### PR DESCRIPTION
## Why

Removing a task from My Day with the 'x' button snapped the view back to the top of the screen. The same jump happened on complete, uncomplete, add-to-day, carry-all, the manual Refresh button, and the file-watcher auto-refresh. It made My Day feel jarring to use. This mirrors the scroll-preservation fix already shipped for the Backlog page (issue #182).

## Root cause

Every one of those actions funnels through `MyDayViewModel.Refresh()`, which does a `Clear()` + re-`Add()` on the bound collections. That destructive rebuild tears down `TodayList`'s internal `ScrollViewer` and resets its offset to 0. Because all paths share `Refresh()`, fixing it at that single choke point covers every case.

## Approach

- **Moved `MyDayViewModel` into `Glasswork.Core`** so its refresh lifecycle can be unit-tested (the App project is Windows-only and not testable on the Core test runner).
- **Added `Refreshing` / `Refreshed` events** to the VM: `Refreshing` fires before the destructive `Clear()`, `Refreshed` fires after the collections are repopulated.
- **`MyDayPage` snapshots and restores scroll** around those events. On `Refreshing` it captures `TodayList`'s current offset using `??=` so the original pre-removal position survives the back-to-back command refresh + file-watcher echo (without it, the second capture would record the post-clear zero and clobber the real value). On `Refreshed` it restores via a Low-priority, bounded-retry dispatch with an extent-measured guard.
- **Unified all refresh paths.** Collapse-state hydration and empty-state recalculation moved into the `Refreshed` handler, so direct VM command execution (which bypasses the page's own `Refresh()`) gets identical treatment.

## Notes for reviewers

- Scope is intentionally limited to `TodayList`, the tall surface the user actually reported. The short secondary lists (recently completed, suggestions) are left as-is; the helpers take a `ListView` so extending later is trivial.
- The stale-restore guard uses reference identity (`ReferenceEquals`), not record value-equality, so two distinct refresh cycles that happen to share the same offset value can't be confused.
- Event subscriptions are wired after `InitializeComponent()` so the handlers never dereference XAML controls during the parse pass (copilot-instructions hard rule 6).

## Validation

- 7 new unit tests pin the `Refreshing`/`Refreshed` event contract and ordering; all green.
- Full suite: 685 passing. One unrelated, timing-sensitive file-watcher debounce test flakes under full-suite load and passes in isolation.
- Ran `scripts\verify-app.ps1` (hard rule 7) after the final edit: app builds, launches, and renders My Day correctly with no STOWED_EXCEPTION or blank screen.