### PR TITLE
Improve My Day refresh stability

### DIFF
--- a/src/Glasswork.App/Pages/MyDayPage.xaml.cs
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml.cs
@@ -17,9 +17,8 @@ public sealed partial class MyDayPage : Page
     public string TodayDate => DateTime.Today.ToString("dddd, MMMM d");
 
     // Pending scroll-restore snapshot for TodayList. Captured in ViewModel.Refreshing
-    // (before the destructive Clear+Add inside MyDayViewModel.Refresh tears the
-    // ListView's ScrollViewer down to offset 0), applied with bounded retry after
-    // ViewModel.Refreshed once layout has caught up. Null when no restore is queued.
+    // before MyDayViewModel.Refresh reconciles the bound collection, applied with
+    // bounded retry after ViewModel.Refreshed once layout has caught up. Null when no restore is queued.
     // Mirrors the Backlog fix (issue #182). TodayList is the primary (and tallest,
     // MinHeight 320) scroll surface and the user-reported pain; the short secondary
     // lists (recently-completed / suggestions, MaxHeight 140-400) are left as-is.
@@ -291,9 +290,9 @@ public sealed partial class MyDayPage : Page
 
     // ---------------------------------------------------------------------
     // Issue #182 (extended to My Day): scroll-position capture/restore around
-    // VM.Refresh(). The destructive Clear+Add inside MyDayViewModel.Refresh
-    // tears down TodayList's internal ScrollViewer, snapping it back to offset 0.
-    // We capture in VM.Refreshing (before Clear) and restore in VM.Refreshed via
+    // VM.Refresh(). Refresh now preserves unchanged row instances, but inserts,
+    // removals, and moves can still change ListView layout. We capture in
+    // VM.Refreshing and restore in VM.Refreshed via
     // Low-priority dispatch with bounded retry. Simpler than Backlog's equivalent:
     // a single list surface, no view-mode/filter/search context to invalidate.
     // ---------------------------------------------------------------------

--- a/src/Glasswork.Core/Models/GlassworkTask.cs
+++ b/src/Glasswork.Core/Models/GlassworkTask.cs
@@ -16,13 +16,25 @@ public partial class GlassworkTask : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsDone))]
     public partial string Status { get; set; } = "todo";
-    [ObservableProperty] public partial string Priority { get; set; } = "medium";
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasPriorityChip))]
+    public partial string Priority { get; set; } = "medium";
     [ObservableProperty] public partial DateTime Created { get; set; } = DateTime.Today;
     [ObservableProperty] public partial DateTime? CompletedAt { get; set; }
-    [ObservableProperty] public partial DateTime? Due { get; set; }
-    [ObservableProperty] public partial DateTime? MyDay { get; set; }
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DueUrgency))]
+    [NotifyPropertyChangedFor(nameof(DueChipText))]
+    [NotifyPropertyChangedFor(nameof(HasDue))]
+    public partial DateTime? Due { get; set; }
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsMyDay))]
+    public partial DateTime? MyDay { get; set; }
     
-    [ObservableProperty] public partial List<TaskLink> Links { get; set; } = [];
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(AdoLink))]
+    [NotifyPropertyChangedFor(nameof(AdoTitle))]
+    [NotifyPropertyChangedFor(nameof(HasAdo))]
+    public partial List<TaskLink> Links { get; set; } = [];
     
     [ObservableProperty] public partial string? Parent { get; set; }
     [ObservableProperty]
@@ -35,7 +47,21 @@ public partial class GlassworkTask : ObservableObject
     [ObservableProperty] public partial string Notes { get; set; } = string.Empty;
     [ObservableProperty] public partial List<string> ContextLinks { get; set; } = [];
     [ObservableProperty] public partial List<string> Tags { get; set; } = [];
-    [ObservableProperty] public partial List<SubTask> Subtasks { get; set; } = [];
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsActive))]
+    [NotifyPropertyChangedFor(nameof(IsQuiet))]
+    [NotifyPropertyChangedFor(nameof(ShowCardDetails))]
+    [NotifyPropertyChangedFor(nameof(TotalSubtaskCount))]
+    [NotifyPropertyChangedFor(nameof(DoneSubtaskCount))]
+    [NotifyPropertyChangedFor(nameof(ProgressFraction))]
+    [NotifyPropertyChangedFor(nameof(ProgressLabel))]
+    [NotifyPropertyChangedFor(nameof(UseSegmentedBar))]
+    [NotifyPropertyChangedFor(nameof(UseContinuousBar))]
+    [NotifyPropertyChangedFor(nameof(CurrentStepText))]
+    [NotifyPropertyChangedFor(nameof(HasCurrentStep))]
+    [NotifyPropertyChangedFor(nameof(HasBlocker))]
+    [NotifyPropertyChangedFor(nameof(FirstBlockerText))]
+    public partial List<SubTask> Subtasks { get; set; } = [];
     [ObservableProperty] public partial List<RelatedLink> RelatedLinks { get; set; } = [];
 
     /// <summary>
@@ -335,6 +361,7 @@ public partial class GlassworkTask : ObservableObject
             }
             OnPropertyChanged(nameof(AdoLink));
             OnPropertyChanged(nameof(AdoTitle));
+            OnPropertyChanged(nameof(HasAdo));
             OnPropertyChanged(nameof(Links));
         }
     }
@@ -366,6 +393,7 @@ public partial class GlassworkTask : ObservableObject
             }
             OnPropertyChanged(nameof(AdoTitle));
             OnPropertyChanged(nameof(AdoLink));
+            OnPropertyChanged(nameof(HasAdo));
             OnPropertyChanged(nameof(Links));
         }
     }

--- a/src/Glasswork.Core/ViewModels/MyDayViewModel.cs
+++ b/src/Glasswork.Core/ViewModels/MyDayViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -59,10 +60,6 @@ public partial class MyDayViewModel : ObservableObject
     {
         Refreshing?.Invoke();
 
-        TodayTasks.Clear();
-        RecentlyCompletedTasks.Clear();
-        Suggestions.Clear();
-
         var all = _index.Tasks;
         var today = System.DateOnly.FromDateTime(System.DateTime.Today);
 
@@ -72,6 +69,7 @@ public partial class MyDayViewModel : ObservableObject
 
         // Today's tasks via MyDayQueries.Today (issue #186/189)
         var todayTasks = MyDayQueries.Today(all, today, dismissed);
+        var targetTodayTasks = new List<GlassworkTask>();
         foreach (var task in todayTasks)
         {
             // Attach TodaysSubtasks for virtually-promoted tasks per ADR 0008
@@ -83,20 +81,22 @@ public partial class MyDayViewModel : ObservableObject
             task.TodaysSubtasks = directlyPromoted
                 ? null
                 : MyDayPromotionPolicy.TodaysSubtasks(task, today);
-            TodayTasks.Add(task);
+            targetTodayTasks.Add(task);
         }
+        ReconcileTaskCollection(TodayTasks, targetTodayTasks);
 
         // Recently completed: tasks completed today that were on My Day today (real or virtual).
-        foreach (var task in all.Values.Where(IsRecentlyCompleted).OrderByDescending(t => t.CompletedAt))
-        {
-            RecentlyCompletedTasks.Add(task);
-        }
+        var recentlyCompleted = all.Values
+            .Where(IsRecentlyCompleted)
+            .OrderByDescending(t => t.CompletedAt)
+            .ToList();
+        ReconcileTaskCollection(RecentlyCompletedTasks, recentlyCompleted);
 
         // Suggestions: yesterday's incomplete + high priority not on My Day (and not already shown).
         // Note: due-today/overdue tasks are no longer in suggestions because they're virtually
         // included in TodayTasks above.
         var yesterday = System.DateTime.Today.AddDays(-1);
-        var alreadyToday = TodayTasks.Select(t => t.Id).ToHashSet();
+        var alreadyToday = targetTodayTasks.Select(t => t.Id).ToHashSet();
         var suggestions = all.Values.Where(t =>
             t.Status != GlassworkTask.Statuses.Done &&
             !alreadyToday.Contains(t.Id) &&
@@ -104,20 +104,90 @@ public partial class MyDayViewModel : ObservableObject
                 (t.MyDay.HasValue && t.MyDay.Value.Date < System.DateTime.Today) || // carryover
                 t.Priority is "high" or "urgent"                                      // high priority
             ))
-            .Take(10);
-
-        foreach (var s in suggestions)
-        {
-            Suggestions.Add(s);
-        }
+            .Take(10)
+            .ToList();
+        ReconcileTaskCollection(Suggestions, suggestions);
 
         Refreshed?.Invoke();
+    }
+
+    private static void ReconcileTaskCollection(
+        ObservableCollection<GlassworkTask> collection,
+        IReadOnlyList<GlassworkTask> target)
+    {
+        var liveIds = target.Select(t => t.Id).ToHashSet(StringComparer.Ordinal);
+        for (var i = collection.Count - 1; i >= 0; i--)
+        {
+            if (!liveIds.Contains(collection[i].Id))
+            {
+                collection.RemoveAt(i);
+            }
+        }
+
+        for (var targetIndex = 0; targetIndex < target.Count; targetIndex++)
+        {
+            var desired = target[targetIndex];
+            var existingIndex = IndexOfTask(collection, desired.Id, targetIndex);
+            if (existingIndex < 0)
+            {
+                collection.Insert(targetIndex, desired);
+                continue;
+            }
+
+            if (existingIndex != targetIndex)
+            {
+                collection.Move(existingIndex, targetIndex);
+            }
+
+            CopyTaskState(collection[targetIndex], desired);
+        }
+    }
+
+    private static int IndexOfTask(
+        ObservableCollection<GlassworkTask> collection,
+        string taskId,
+        int startIndex)
+    {
+        for (var i = startIndex; i < collection.Count; i++)
+        {
+            if (string.Equals(collection[i].Id, taskId, StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static void CopyTaskState(GlassworkTask target, GlassworkTask source)
+    {
+        var isManuallyCollapsed = target.IsManuallyCollapsed;
+
+        target.Id = source.Id;
+        target.Title = source.Title;
+        target.Status = source.Status;
+        target.Priority = source.Priority;
+        target.Created = source.Created;
+        target.CompletedAt = source.CompletedAt;
+        target.Due = source.Due;
+        target.MyDay = source.MyDay;
+        target.Links = [.. source.Links];
+        target.Parent = source.Parent;
+        target.Description = source.Description;
+        target.Notes = source.Notes;
+        target.ContextLinks = [.. source.ContextLinks];
+        target.Tags = [.. source.Tags];
+        target.Subtasks = source.Subtasks;
+        target.RelatedLinks = source.RelatedLinks;
+        target.IsV1Format = source.IsV1Format;
+        target.TodaysSubtasks = source.TodaysSubtasks;
+        target.IsManuallyCollapsed = isManuallyCollapsed;
     }
 
     /// <summary>
     /// Raised synchronously at the very top of <see cref="Refresh"/>, BEFORE
     /// any of <see cref="TodayTasks"/>, <see cref="RecentlyCompletedTasks"/>, or
-    /// <see cref="Suggestions"/> are cleared. Subscribers can read the pre-refresh
+    /// <see cref="Suggestions"/> are reconciled. Subscribers can read the pre-refresh
     /// state of those collections (e.g. to snapshot UI state that depends on them,
     /// like <c>ScrollViewer.VerticalOffset</c> of the bound My Day <c>ListView</c>).
     ///
@@ -142,8 +212,7 @@ public partial class MyDayViewModel : ObservableObject
     /// <see cref="Suggestions"/>) have been fully populated. Page hosts subscribe to
     /// this instead of individual <c>CollectionChanged</c> events so post-refresh work
     /// (empty-state UI, per-task collapse-state hydration, scroll restore) is computed
-    /// against the final state, not the transient empty state that exists between the
-    /// internal <c>Clear()</c> and <c>Add()</c> calls.
+    /// against the final state after any inserts, removes, moves, or item updates.
     ///
     /// Contract:
     /// <list type="bullet">

--- a/tests/Glasswork.Tests/MyDayViewModelRefreshingEventTests.cs
+++ b/tests/Glasswork.Tests/MyDayViewModelRefreshingEventTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using Glasswork.Core.Models;
@@ -13,15 +14,15 @@ namespace Glasswork.Tests;
 /// event pair (mirrors the Backlog fix for issue #182).
 ///
 /// The page hooks <c>Refreshing</c> to snapshot the <c>TodayList</c> scroll offset
-/// BEFORE the destructive <c>Clear()</c> inside <see cref="MyDayViewModel.Refresh"/>
-/// tears down the ListView's ScrollViewer, and <c>Refreshed</c> to restore it (and
-/// run empty-state / collapse hydration) against the fully-populated collections.
+/// before <see cref="MyDayViewModel.Refresh"/> reconciles the bound collections, and
+/// <c>Refreshed</c> to restore it (and run empty-state / collapse hydration) against
+/// the fully-populated collections.
 /// The contract these tests pin down:
 ///
 /// <list type="bullet">
 ///   <item><description><c>Refreshing</c> fires exactly once per
 ///     <see cref="MyDayViewModel.Refresh"/> call.</description></item>
-///   <item><description><c>Refreshing</c> fires BEFORE <c>TodayTasks.Clear()</c> et al,
+///   <item><description><c>Refreshing</c> fires BEFORE collection reconciliation,
 ///     so subscribers can read the pre-refresh collection state.</description></item>
 ///   <item><description><c>Refreshing</c> fires BEFORE <c>Refreshed</c>.</description></item>
 ///   <item><description>The cycle fires regardless of how <see cref="MyDayViewModel.Refresh"/>
@@ -99,7 +100,7 @@ public class MyDayViewModelRefreshingEventTests
     }
 
     [TestMethod]
-    public void Refresh_Refreshing_FiresBeforeTodayTasksAreCleared()
+    public void Refresh_Refreshing_FiresBeforeTodayTasksAreReconciled()
     {
         CreateMyDayTask("Task A");
         CreateMyDayTask("Task B");
@@ -115,7 +116,7 @@ public class MyDayViewModelRefreshingEventTests
         vm.Refresh();
 
         Assert.AreEqual(2, observedTodayCount,
-            "Refreshing must fire before TodayTasks.Clear() — subscriber should still see the 2 pre-refresh tasks");
+            "Refreshing must fire before TodayTasks is reconciled — subscriber should still see the 2 pre-refresh tasks");
     }
 
     [TestMethod]
@@ -192,5 +193,46 @@ public class MyDayViewModelRefreshingEventTests
         vm.Refresh();
 
         Assert.AreEqual(1, count, "Refreshing must fire on every Refresh() call, even when the vault is empty");
+    }
+
+    [TestMethod]
+    public void Refresh_WithSameTasks_DoesNotResetTodayTasks()
+    {
+        CreateMyDayTask("Task A");
+        CreateMyDayTask("Task B");
+
+        var vm = new MyDayViewModel(_vault, _taskService, _index);
+        vm.Refresh();
+        var firstRow = vm.TodayTasks[0];
+        var actions = new List<NotifyCollectionChangedAction>();
+        vm.TodayTasks.CollectionChanged += (_, e) => actions.Add(e.Action);
+
+        vm.Refresh();
+
+        CollectionAssert.DoesNotContain(actions, NotifyCollectionChangedAction.Reset,
+            "A stable refresh should not clear the bound My Day list and force the ListView to rebuild.");
+        Assert.AreSame(firstRow, vm.TodayTasks[0],
+            "A stable refresh should preserve unchanged task row instances so realized containers stay warm.");
+    }
+
+    [TestMethod]
+    public void Refresh_WithUpdatedTask_UpdatesExistingTodayTaskInstance()
+    {
+        var task = CreateMyDayTask("Original title");
+        var vm = new MyDayViewModel(_vault, _taskService, _index);
+        vm.Refresh();
+        var row = vm.TodayTasks.Single();
+        row.IsManuallyCollapsed = true;
+
+        task.Title = "Updated title";
+        _vault.Save(task);
+
+        vm.Refresh();
+
+        Assert.AreSame(row, vm.TodayTasks.Single(),
+            "Refreshing changed task data should update the existing row instead of replacing it.");
+        Assert.AreEqual("Updated title", row.Title);
+        Assert.IsTrue(row.IsManuallyCollapsed,
+            "Domain refresh must not wipe per-page transient collapse state before the page hydrates it.");
     }
 }


### PR DESCRIPTION
My Day refreshes were rebuilding bound task collections even when the visible tasks had not changed, which can make the WinUI list feel jittery and force scroll/container recovery work. This change keeps stable rows warm so routine refreshes feel snappier while preserving the vault/index as the source of truth.

## Approach

- Reconcile `TodayTasks`, `RecentlyCompletedTasks`, and `Suggestions` instead of clearing and repopulating them on every refresh.
- Copy fresh task state into existing row objects while preserving transient UI state like manual collapse.
- Add dependent `GlassworkTask` notifications so in-place row updates still refresh derived chips, due state, progress, and ADO display properties.
- Update My Day refresh tests to cover no-reset stable refreshes and changed-task in-place updates.

## Validation

- `dotnet test tests\Glasswork.Tests\ --nologo --verbosity quiet --filter FullyQualifiedName~MyDayViewModelRefreshingEventTests`
- `pwsh -File scripts\verify-app.ps1`
- Full suite still fails only on the pre-existing watcher debounce tests observed before this change: `ArtifactWatcherServiceTests.DebouncesBurstsIntoOneEvent` and `BacklinksWatcherTests.DebouncesBurstsIntoOneEvent`.

## Post-merge

Rebuild the app after merging this PR.