### PR TITLE
feat: add version comparison and UpdateCheckResult

### DIFF
--- a/src/Glasswork.Core/AppUpdate/AppVersion.cs
+++ b/src/Glasswork.Core/AppUpdate/AppVersion.cs
@@ -1,0 +1,52 @@
+namespace Glasswork.Core.AppUpdate;
+
+public sealed class AppVersion : IComparable<AppVersion>
+{
+    public int Major { get; }
+    public int Minor { get; }
+    public int Patch { get; }
+
+    private AppVersion(int major, int minor, int patch)
+    {
+        Major = major;
+        Minor = minor;
+        Patch = patch;
+    }
+
+    public static bool TryParse(string input, out AppVersion? version)
+    {
+        version = null;
+        if (string.IsNullOrWhiteSpace(input))
+            return false;
+
+        var versionString = input.TrimStart('v', 'V');
+        var parts = versionString.Split('.');
+        
+        if (parts.Length < 3)
+            return false;
+
+        if (!int.TryParse(parts[0], out var major) ||
+            !int.TryParse(parts[1], out var minor) ||
+            !int.TryParse(parts[2], out var patch))
+            return false;
+
+        version = new AppVersion(major, minor, patch);
+        return true;
+    }
+
+    public int CompareTo(AppVersion? other)
+    {
+        if (other is null)
+            return 1;
+
+        var majorComparison = Major.CompareTo(other.Major);
+        if (majorComparison != 0)
+            return majorComparison;
+
+        var minorComparison = Minor.CompareTo(other.Minor);
+        if (minorComparison != 0)
+            return minorComparison;
+
+        return Patch.CompareTo(other.Patch);
+    }
+}

--- a/src/Glasswork.Core/AppUpdate/AppVersion.cs
+++ b/src/Glasswork.Core/AppUpdate/AppVersion.cs
@@ -22,12 +22,18 @@ public sealed class AppVersion : IComparable<AppVersion>
         var versionString = input.TrimStart('v', 'V');
         var parts = versionString.Split('.');
         
-        if (parts.Length < 3)
+        // Require exactly 3 or 4 components
+        if (parts.Length < 3 || parts.Length > 4)
             return false;
 
-        if (!int.TryParse(parts[0], out var major) ||
-            !int.TryParse(parts[1], out var minor) ||
-            !int.TryParse(parts[2], out var patch))
+        // Parse and validate first three components (reject negative)
+        if (!int.TryParse(parts[0], out var major) || major < 0 ||
+            !int.TryParse(parts[1], out var minor) || minor < 0 ||
+            !int.TryParse(parts[2], out var patch) || patch < 0)
+            return false;
+
+        // If 4th component exists, it must be valid numeric (but we ignore its value)
+        if (parts.Length == 4 && !int.TryParse(parts[3], out _))
             return false;
 
         version = new AppVersion(major, minor, patch);

--- a/src/Glasswork.Core/AppUpdate/UpdateCheckResult.cs
+++ b/src/Glasswork.Core/AppUpdate/UpdateCheckResult.cs
@@ -1,0 +1,42 @@
+namespace Glasswork.Core.AppUpdate;
+
+public sealed class UpdateCheckResult
+{
+    private enum ResultType
+    {
+        UpToDate,
+        UpdateAvailable,
+        CheckFailed
+    }
+
+    private readonly ResultType _type;
+
+    public bool IsUpToDate => _type == ResultType.UpToDate;
+    public bool IsUpdateAvailable => _type == ResultType.UpdateAvailable;
+    public bool IsCheckFailed => _type == ResultType.CheckFailed;
+
+    public AppVersion? AvailableVersion { get; }
+    public string? FailureReason { get; }
+
+    private UpdateCheckResult(ResultType type, AppVersion? availableVersion = null, string? failureReason = null)
+    {
+        _type = type;
+        AvailableVersion = availableVersion;
+        FailureReason = failureReason;
+    }
+
+    public static UpdateCheckResult Compare(AppVersion installed, AppVersion available)
+    {
+        var comparison = available.CompareTo(installed);
+        
+        if (comparison > 0)
+            return new UpdateCheckResult(ResultType.UpdateAvailable, available);
+        
+        return new UpdateCheckResult(ResultType.UpToDate);
+    }
+
+    public static UpdateCheckResult Failed(string reason)
+    {
+        return new UpdateCheckResult(ResultType.CheckFailed, failureReason: reason);
+    }
+}

--- a/tests/Glasswork.Tests/AppVersionTests.cs
+++ b/tests/Glasswork.Tests/AppVersionTests.cs
@@ -71,6 +71,33 @@ public class AppVersionTests
     }
 
     [TestMethod]
+    public void Parse_NegativeVersion_ReturnsFalse()
+    {
+        var result = AppVersion.TryParse("-1.2.3", out var version);
+        
+        Assert.IsFalse(result);
+        Assert.IsNull(version);
+    }
+
+    [TestMethod]
+    public void Parse_TooManyComponents_ReturnsFalse()
+    {
+        var result = AppVersion.TryParse("1.2.3.4.5", out var version);
+        
+        Assert.IsFalse(result);
+        Assert.IsNull(version);
+    }
+
+    [TestMethod]
+    public void Parse_FourthComponentGarbage_ReturnsFalse()
+    {
+        var result = AppVersion.TryParse("1.2.3.garbage", out var version);
+        
+        Assert.IsFalse(result);
+        Assert.IsNull(version);
+    }
+
+    [TestMethod]
     public void Compare_EqualVersions_ReturnsZero()
     {
         AppVersion.TryParse("1.3.0", out var v1);

--- a/tests/Glasswork.Tests/AppVersionTests.cs
+++ b/tests/Glasswork.Tests/AppVersionTests.cs
@@ -1,0 +1,100 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Glasswork.Core.AppUpdate;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class AppVersionTests
+{
+    [TestMethod]
+    public void Parse_BasicVersion_Success()
+    {
+        // Tracer bullet: parse "1.3.0"
+        var result = AppVersion.TryParse("1.3.0", out var version);
+        
+        Assert.IsTrue(result);
+        Assert.IsNotNull(version);
+        Assert.AreEqual(1, version.Major);
+        Assert.AreEqual(3, version.Minor);
+        Assert.AreEqual(0, version.Patch);
+    }
+
+    [TestMethod]
+    public void Parse_FourComponentVersion_IgnoresFourthComponent()
+    {
+        var result = AppVersion.TryParse("1.3.0.0", out var version);
+        
+        Assert.IsTrue(result);
+        Assert.IsNotNull(version);
+        Assert.AreEqual(1, version.Major);
+        Assert.AreEqual(3, version.Minor);
+        Assert.AreEqual(0, version.Patch);
+    }
+
+    [TestMethod]
+    public void Parse_VersionWithVPrefix_StripsPrefix()
+    {
+        var result = AppVersion.TryParse("v1.4.0", out var version);
+        
+        Assert.IsTrue(result);
+        Assert.IsNotNull(version);
+        Assert.AreEqual(1, version.Major);
+        Assert.AreEqual(4, version.Minor);
+        Assert.AreEqual(0, version.Patch);
+    }
+
+    [TestMethod]
+    public void Parse_GarbageInput_ReturnsFalse()
+    {
+        var result = AppVersion.TryParse("not-a-version", out var version);
+        
+        Assert.IsFalse(result);
+        Assert.IsNull(version);
+    }
+
+    [TestMethod]
+    public void Parse_EmptyString_ReturnsFalse()
+    {
+        var result = AppVersion.TryParse("", out var version);
+        
+        Assert.IsFalse(result);
+        Assert.IsNull(version);
+    }
+
+    [TestMethod]
+    public void Parse_Null_ReturnsFalse()
+    {
+        var result = AppVersion.TryParse(null!, out var version);
+        
+        Assert.IsFalse(result);
+        Assert.IsNull(version);
+    }
+
+    [TestMethod]
+    public void Compare_EqualVersions_ReturnsZero()
+    {
+        AppVersion.TryParse("1.3.0", out var v1);
+        AppVersion.TryParse("1.3.0", out var v2);
+        
+        Assert.AreEqual(0, v1!.CompareTo(v2));
+    }
+
+    [TestMethod]
+    public void Compare_MinorVersionDifference_OrdersCorrectly()
+    {
+        AppVersion.TryParse("1.10.0", out var v1);
+        AppVersion.TryParse("1.9.0", out var v2);
+        
+        Assert.IsTrue(v1!.CompareTo(v2) > 0);
+        Assert.IsTrue(v2!.CompareTo(v1) < 0);
+    }
+
+    [TestMethod]
+    public void Compare_MajorVersionDifference_OrdersCorrectly()
+    {
+        AppVersion.TryParse("2.0.0", out var v1);
+        AppVersion.TryParse("1.9.9", out var v2);
+        
+        Assert.IsTrue(v1!.CompareTo(v2) > 0);
+    }
+}

--- a/tests/Glasswork.Tests/UpdateCheckResultTests.cs
+++ b/tests/Glasswork.Tests/UpdateCheckResultTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Glasswork.Core.AppUpdate;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class UpdateCheckResultTests
+{
+    [TestMethod]
+    public void CompareVersions_AvailableGreater_ReturnsUpdateAvailable()
+    {
+        AppVersion.TryParse("1.3.0", out var installed);
+        AppVersion.TryParse("1.4.0", out var available);
+
+        var result = UpdateCheckResult.Compare(installed!, available!);
+
+        Assert.IsTrue(result.IsUpdateAvailable);
+        Assert.IsFalse(result.IsUpToDate);
+        Assert.IsFalse(result.IsCheckFailed);
+        Assert.AreEqual(available, result.AvailableVersion);
+    }
+
+    [TestMethod]
+    public void CompareVersions_AvailableEqual_ReturnsUpToDate()
+    {
+        AppVersion.TryParse("1.3.0", out var installed);
+        AppVersion.TryParse("1.3.0", out var available);
+
+        var result = UpdateCheckResult.Compare(installed!, available!);
+
+        Assert.IsTrue(result.IsUpToDate);
+        Assert.IsFalse(result.IsUpdateAvailable);
+        Assert.IsFalse(result.IsCheckFailed);
+    }
+
+    [TestMethod]
+    public void CompareVersions_AvailableLess_ReturnsUpToDate()
+    {
+        AppVersion.TryParse("1.4.0", out var installed);
+        AppVersion.TryParse("1.3.0", out var available);
+
+        var result = UpdateCheckResult.Compare(installed!, available!);
+
+        Assert.IsTrue(result.IsUpToDate);
+        Assert.IsFalse(result.IsUpdateAvailable);
+    }
+
+    [TestMethod]
+    public void CheckFailed_ReturnsFailedResult()
+    {
+        var result = UpdateCheckResult.Failed("Network error");
+
+        Assert.IsTrue(result.IsCheckFailed);
+        Assert.IsFalse(result.IsUpToDate);
+        Assert.IsFalse(result.IsUpdateAvailable);
+        Assert.AreEqual("Network error", result.FailureReason);
+    }
+}


### PR DESCRIPTION
# Version Comparison and UpdateCheckResult

Implements the pure, Windows-free foundation of update detection for Slice 1 of the App Update feature.

## What changed

Added to `Glasswork.Core.AppUpdate`:
- **`AppVersion`**: Parses version strings (`1.3.0`, `1.3.0.0`, `v1.4.0`) into comparable SemVer values with Major/Minor/Patch properties. Implements `IComparable<AppVersion>` for ordering.
- **`UpdateCheckResult`**: Three-state result model (UpToDate, UpdateAvailable, CheckFailed) with appropriate properties for each state.
- **Pure comparison**: `UpdateCheckResult.Compare(installed, available)` returns the correct result based on SemVer ordering.

## How tested

16 MSTest tests in `Glasswork.Tests`:
- Parse tests cover basic formats, v-prefix, 4-component versions, negative versions, too-many components, garbage 4th component, and graceful failure on garbage input
- Comparison tests verify SemVer ordering (1.10.0 > 1.9.0, 2.0.0 > 1.9.9, equality)
- UpdateCheckResult tests verify state transitions and data availability

All tests pass. Core builds cleanly. No Windows dependencies added.

## Validation

``
dotnet build src/Glasswork.Core/Glasswork.Core.csproj -nologo  ✓
dotnet test tests/Glasswork.Tests/Glasswork.Tests.csproj -nologo  ✓ (16/16 new tests passed)
``

## Review notes

Dual-model code review (GPT-5.5 + Claude Opus 4.7):
- **GPT-5.5 finding**: Negative versions and extra components were accepted (fixed in 9f30ef1)
- **Claude Opus 4.7**: No significant issues

Fix adds validation for negative components, enforces exactly 3 or 4 components, and validates 4th component if present.

## Decisions

- Used `TryParse` pattern (not exceptions) for graceful failure on bad input
- Normalized 4-component versions by ignoring the 4th part (but validate it's numeric)
- `AvailableVersion` is only populated on UpdateAvailable state
- `FailureReason` is only populated on CheckFailed state

Closes #236
