### PR TITLE
feat: Slice 2 - GitHub release detection client

### DIFF
--- a/src/Glasswork.Core/AppUpdate/GitHubReleaseDetector.cs
+++ b/src/Glasswork.Core/AppUpdate/GitHubReleaseDetector.cs
@@ -1,0 +1,65 @@
+using System.Net.Http;
+using System.Text.Json;
+
+namespace Glasswork.Core.AppUpdate;
+
+public sealed class GitHubReleaseDetector
+{
+    private readonly HttpClient _httpClient;
+    private const string LatestReleaseUrl = "https://api.github.com/repos/tjegbejimba/Glasswork/releases/latest";
+    
+    public GitHubReleaseDetector(HttpMessageHandler handler)
+    {
+        _httpClient = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(10)
+        };
+        _httpClient.DefaultRequestHeaders.Add("User-Agent", "Glasswork-UpdateChecker");
+    }
+    
+    public async Task<ReleaseDetectionResult> GetLatestReleaseAsync()
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync(LatestReleaseUrl);
+            
+            if (!response.IsSuccessStatusCode)
+            {
+                return ReleaseDetectionResult.Failed($"HTTP {(int)response.StatusCode}");
+            }
+            
+            var content = await response.Content.ReadAsStringAsync();
+            var jsonDoc = JsonDocument.Parse(content);
+            
+            if (!jsonDoc.RootElement.TryGetProperty("tag_name", out var tagNameElement))
+            {
+                return ReleaseDetectionResult.Failed("Missing tag_name in response");
+            }
+            
+            var tagName = tagNameElement.GetString();
+            if (string.IsNullOrEmpty(tagName))
+            {
+                return ReleaseDetectionResult.Failed("Empty tag_name in response");
+            }
+            
+            if (!AppVersion.TryParse(tagName, out var version) || version == null)
+            {
+                return ReleaseDetectionResult.Failed($"Invalid version format: {tagName}");
+            }
+            
+            return ReleaseDetectionResult.Success(version);
+        }
+        catch (HttpRequestException ex)
+        {
+            return ReleaseDetectionResult.Failed($"Network error: {ex.Message}");
+        }
+        catch (TaskCanceledException)
+        {
+            return ReleaseDetectionResult.Failed("Request timeout");
+        }
+        catch (JsonException ex)
+        {
+            return ReleaseDetectionResult.Failed($"Malformed JSON: {ex.Message}");
+        }
+    }
+}

--- a/src/Glasswork.Core/AppUpdate/GitHubReleaseDetector.cs
+++ b/src/Glasswork.Core/AppUpdate/GitHubReleaseDetector.cs
@@ -29,11 +29,16 @@ public sealed class GitHubReleaseDetector
             }
             
             var content = await response.Content.ReadAsStringAsync();
-            var jsonDoc = JsonDocument.Parse(content);
+            using var jsonDoc = JsonDocument.Parse(content);
             
             if (!jsonDoc.RootElement.TryGetProperty("tag_name", out var tagNameElement))
             {
                 return ReleaseDetectionResult.Failed("Missing tag_name in response");
+            }
+            
+            if (tagNameElement.ValueKind != JsonValueKind.String)
+            {
+                return ReleaseDetectionResult.Failed("tag_name is not a string");
             }
             
             var tagName = tagNameElement.GetString();

--- a/src/Glasswork.Core/AppUpdate/ReleaseDetectionResult.cs
+++ b/src/Glasswork.Core/AppUpdate/ReleaseDetectionResult.cs
@@ -1,0 +1,25 @@
+namespace Glasswork.Core.AppUpdate;
+
+public sealed class ReleaseDetectionResult
+{
+    public bool IsSuccess { get; }
+    public AppVersion? Version { get; }
+    public string? FailureReason { get; }
+    
+    private ReleaseDetectionResult(bool isSuccess, AppVersion? version = null, string? failureReason = null)
+    {
+        IsSuccess = isSuccess;
+        Version = version;
+        FailureReason = failureReason;
+    }
+    
+    public static ReleaseDetectionResult Success(AppVersion version)
+    {
+        return new ReleaseDetectionResult(true, version);
+    }
+    
+    public static ReleaseDetectionResult Failed(string reason)
+    {
+        return new ReleaseDetectionResult(false, failureReason: reason);
+    }
+}

--- a/tests/Glasswork.Tests/GitHubReleaseDetectorTests.cs
+++ b/tests/Glasswork.Tests/GitHubReleaseDetectorTests.cs
@@ -52,6 +52,28 @@ public class GitHubReleaseDetectorTests
     }
     
     [TestMethod]
+    public async Task GetLatestReleaseAsync_NonStringTagName_ReturnsFailedWithTypeError()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler();
+        handler.SetResponse(HttpStatusCode.OK, """
+            {
+                "tag_name": 123
+            }
+            """);
+        
+        var detector = new GitHubReleaseDetector(handler);
+        
+        // Act
+        var result = await detector.GetLatestReleaseAsync();
+        
+        // Assert
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsTrue(result.FailureReason.Contains("not a string"), 
+            $"Expected 'not a string' in failure reason but got: {result.FailureReason}");
+    }
+    
+    [TestMethod]
     public async Task GetLatestReleaseAsync_ServerError_ReturnsFailedWithErrorCode()
     {
         // Arrange

--- a/tests/Glasswork.Tests/GitHubReleaseDetectorTests.cs
+++ b/tests/Glasswork.Tests/GitHubReleaseDetectorTests.cs
@@ -1,0 +1,222 @@
+using System.Net;
+using Glasswork.Core.AppUpdate;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class GitHubReleaseDetectorTests
+{
+    [TestMethod]
+    public async Task GetLatestReleaseAsync_SuccessfulResponse_ReturnsAvailableVersion()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler();
+        handler.SetResponse(HttpStatusCode.OK, """
+            {
+                "tag_name": "v1.4.0",
+                "name": "Release 1.4.0"
+            }
+            """);
+        
+        var detector = new GitHubReleaseDetector(handler);
+        
+        // Act
+        var result = await detector.GetLatestReleaseAsync();
+        
+        // Assert
+        Assert.IsTrue(result.IsSuccess);
+        Assert.IsNotNull(result.Version);
+        Assert.AreEqual(1, result.Version.Major);
+        Assert.AreEqual(4, result.Version.Minor);
+        Assert.AreEqual(0, result.Version.Patch);
+    }
+    
+    [TestMethod]
+    public async Task GetLatestReleaseAsync_NotFound_ReturnsFailedWithNotFoundReason()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler();
+        handler.SetResponse(HttpStatusCode.NotFound, "");
+        
+        var detector = new GitHubReleaseDetector(handler);
+        
+        // Act
+        var result = await detector.GetLatestReleaseAsync();
+        
+        // Assert
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNull(result.Version);
+        Assert.IsNotNull(result.FailureReason);
+        Assert.IsTrue(result.FailureReason.Contains("404"), 
+            $"Expected 404 in failure reason but got: {result.FailureReason}");
+    }
+    
+    [TestMethod]
+    public async Task GetLatestReleaseAsync_ServerError_ReturnsFailedWithErrorCode()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler();
+        handler.SetResponse(HttpStatusCode.InternalServerError, "");
+        
+        var detector = new GitHubReleaseDetector(handler);
+        
+        // Act
+        var result = await detector.GetLatestReleaseAsync();
+        
+        // Assert
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNull(result.Version);
+        Assert.IsNotNull(result.FailureReason);
+        Assert.IsTrue(result.FailureReason.Contains("500"), 
+            $"Expected 500 in failure reason but got: {result.FailureReason}");
+    }
+    
+    [TestMethod]
+    public async Task GetLatestReleaseAsync_MalformedJson_ReturnsFailedWithMalformedReason()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler();
+        handler.SetResponse(HttpStatusCode.OK, "{ invalid json ");
+        
+        var detector = new GitHubReleaseDetector(handler);
+        
+        // Act
+        var result = await detector.GetLatestReleaseAsync();
+        
+        // Assert
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNull(result.Version);
+        Assert.IsNotNull(result.FailureReason);
+        Assert.IsTrue(result.FailureReason.Contains("Malformed") || result.FailureReason.Contains("JSON"), 
+            $"Expected malformed/JSON in failure reason but got: {result.FailureReason}");
+    }
+    
+    [TestMethod]
+    public async Task GetLatestReleaseAsync_MissingTagName_ReturnsFailedWithMissingFieldReason()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler();
+        handler.SetResponse(HttpStatusCode.OK, """
+            {
+                "name": "Release 1.4.0"
+            }
+            """);
+        
+        var detector = new GitHubReleaseDetector(handler);
+        
+        // Act
+        var result = await detector.GetLatestReleaseAsync();
+        
+        // Assert
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNull(result.Version);
+        Assert.IsNotNull(result.FailureReason);
+        Assert.IsTrue(result.FailureReason.Contains("tag_name"), 
+            $"Expected tag_name in failure reason but got: {result.FailureReason}");
+    }
+    
+    [TestMethod]
+    public async Task GetLatestReleaseAsync_NetworkError_ReturnsFailedWithNetworkReason()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler();
+        handler.ThrowOnSend(new HttpRequestException("Network unreachable"));
+        
+        var detector = new GitHubReleaseDetector(handler);
+        
+        // Act
+        var result = await detector.GetLatestReleaseAsync();
+        
+        // Assert
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNull(result.Version);
+        Assert.IsNotNull(result.FailureReason);
+        Assert.IsTrue(result.FailureReason.Contains("Network"), 
+            $"Expected Network in failure reason but got: {result.FailureReason}");
+    }
+    
+    [TestMethod]
+    public async Task GetLatestReleaseAsync_Timeout_ReturnsFailedWithTimeoutReason()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler();
+        handler.ThrowOnSend(new TaskCanceledException());
+        
+        var detector = new GitHubReleaseDetector(handler);
+        
+        // Act
+        var result = await detector.GetLatestReleaseAsync();
+        
+        // Assert
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNull(result.Version);
+        Assert.IsNotNull(result.FailureReason);
+        Assert.IsTrue(result.FailureReason.Contains("timeout"), 
+            $"Expected timeout in failure reason but got: {result.FailureReason}");
+    }
+    
+    [TestMethod]
+    public async Task GetLatestReleaseAsync_SendsUserAgentHeader()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler();
+        handler.SetResponse(HttpStatusCode.OK, """
+            {
+                "tag_name": "v1.0.0"
+            }
+            """);
+        
+        var detector = new GitHubReleaseDetector(handler);
+        
+        // Act
+        await detector.GetLatestReleaseAsync();
+        
+        // Assert
+        Assert.IsNotNull(handler.LastRequest);
+        Assert.IsTrue(handler.LastRequest.Headers.Contains("User-Agent"), 
+            "Request must include User-Agent header");
+    }
+}
+
+/// <summary>
+/// Test double for HttpMessageHandler to avoid real network calls.
+/// </summary>
+internal class FakeHttpMessageHandler : HttpMessageHandler
+{
+    private HttpStatusCode _statusCode;
+    private string _content = string.Empty;
+    private Exception? _exceptionToThrow;
+    
+    public HttpRequestMessage? LastRequest { get; private set; }
+    
+    public void SetResponse(HttpStatusCode statusCode, string content)
+    {
+        _statusCode = statusCode;
+        _content = content;
+        _exceptionToThrow = null;
+    }
+    
+    public void ThrowOnSend(Exception exception)
+    {
+        _exceptionToThrow = exception;
+    }
+    
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, 
+        CancellationToken cancellationToken)
+    {
+        LastRequest = request;
+        
+        if (_exceptionToThrow != null)
+        {
+            throw _exceptionToThrow;
+        }
+        
+        var response = new HttpResponseMessage(_statusCode)
+        {
+            Content = new StringContent(_content)
+        };
+        
+        return Task.FromResult(response);
+    }
+}


### PR DESCRIPTION
# Slice 2: GitHub release detection client

## Summary

Implements a release-detection client that fetches the latest published version from the public GitHub releases API and returns it as an Available Version or a classified failure.

## Changes

- **`GitHubReleaseDetector`**: HTTPS client that queries `api.github.com/repos/tjegbejimba/Glasswork/releases/latest`
  - Sends `User-Agent` header (required by GitHub)
  - 10-second timeout
  - Accepts `HttpMessageHandler` for testability
  - Parses `tag_name` using `AppVersion.TryParse` from Slice 1

- **`ReleaseDetectionResult`**: Result type with `Success(AppVersion)` or `Failed(string reason)` factories
  - Similar shape to `UpdateCheckResult` from Slice 1
  - Exposes `IsSuccess`, `Version`, and `FailureReason`

- **`FakeHttpMessageHandler`**: Test double for mocking HTTP responses
  - Avoids real network calls in tests
  - Supports response setup and exception throwing

## Testing

9 tests covering:
- ✅ Success with valid `tag_name` (200 + parseable version)
- ✅ 404 Not Found
- ✅ 500 Server Error
- ✅ Malformed JSON
- ✅ Missing `tag_name` field
- ✅ Non-string `tag_name` (numeric, array, etc.) - added per review
- ✅ Network error (HttpRequestException)
- ✅ Timeout (TaskCanceledException)
- ✅ User-Agent header sent

All tests pass via `dotnet test --filter GitHubReleaseDetector`.

## Validation

Ran per-repo checks:
- ✅ `dotnet build src/Glasswork.Core/Glasswork.Core.csproj` - succeeds
- ✅ `dotnet test tests/Glasswork.Tests/ --filter GitHubReleaseDetector` - 9/9 pass

(Note: Pre-existing timing-sensitive test failures in `DebouncerTests`, `ArtifactWatcherServiceTests`, `BacklinksWatcherTests`, and `FileWatcherServiceTests` are unrelated to this slice - no changes to those files or their dependencies)

## Decisions

- Used `HttpMessageHandler` injection rather than `IHttpClientFactory` - simpler for this single-use client and sufficient for testing.
- Set timeout to 10 seconds - balances responsiveness on startup checks vs. tolerating slow networks.
- Classified failures distinctly (HTTP status, network, timeout, malformed) so the caller (Slice 3) can stay silent on startup but explain on manual checks.

## Code Review (Dual-Model)

Ran parallel reviews with `gpt-5.5` and `claude-opus-4.7`. Both identified:

**HIGH: `JsonElement.GetString()` throws on non-string `tag_name`**
- `GetString()` throws `InvalidOperationException` for numeric/array/object JSON values
- Not in catch list → would crash instead of returning classified failure
- **Fixed**: Added `JsonValueKind.String` check before `GetString()` + test for numeric case

**MEDIUM: `JsonDocument` not disposed**
- `JsonDocument.Parse()` rents buffers from `ArrayPool<byte>` that must be returned
- Without disposal, buffers leak under repeated use (update checks are periodic)
- **Fixed**: Added `using var jsonDoc = JsonDocument.Parse(content);`

All findings adopted and addressed in commit `f038a66`.

Closes #237
