### PR TITLE
Fix compiler warnings in TaskDetailPage.xaml.cs

### DIFF
--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -45,7 +45,8 @@ public sealed partial class TaskDetailPage : Page
             // Navigated from My Day's "flagged subtasks" section — display the parent task
             // (FocusSubtaskTitle is currently informational; UI affordance for scrolling could
             // be added later).
-            App.Watcher.TaskFileChanged += OnTaskFileChangedExternally;
+            if (App.Watcher is not null)
+                App.Watcher.TaskFileChanged += OnTaskFileChangedExternally;
             App.ArtifactChangedExternally += OnArtifactChangedExternally;
             App.BacklinksChangedExternally += OnBacklinksChangedExternally;
             ApplyTask(nav.Task);
@@ -53,7 +54,8 @@ public sealed partial class TaskDetailPage : Page
         }
         if (e.Parameter is GlassworkTask task)
         {
-            App.Watcher.TaskFileChanged += OnTaskFileChangedExternally;
+            if (App.Watcher is not null)
+                App.Watcher.TaskFileChanged += OnTaskFileChangedExternally;
             App.ArtifactChangedExternally += OnArtifactChangedExternally;
             App.BacklinksChangedExternally += OnBacklinksChangedExternally;
             ApplyTask(task);
@@ -525,7 +527,8 @@ public sealed partial class TaskDetailPage : Page
     protected override void OnNavigatedFrom(NavigationEventArgs e)
     {
         base.OnNavigatedFrom(e);
-        App.Watcher.TaskFileChanged -= OnTaskFileChangedExternally;
+        if (App.Watcher is not null)
+            App.Watcher.TaskFileChanged -= OnTaskFileChangedExternally;
         App.ArtifactChangedExternally -= OnArtifactChangedExternally;
         App.BacklinksChangedExternally -= OnBacklinksChangedExternally;
         App.ObsidianLauncher.NotInstalled -= OnObsidianNotInstalled;
@@ -548,7 +551,9 @@ public sealed partial class TaskDetailPage : Page
 
     private void HandleExternalFileChange()
     {
-        var id = Task?.Id;
+        var task = Task;
+        if (task is null) return;
+        var id = task.Id;
         if (string.IsNullOrEmpty(id)) return;
 
         // Reload to compare. We never blanket-replace Task here — that would
@@ -568,7 +573,7 @@ public sealed partial class TaskDetailPage : Page
         {
             case NotesExternalChangeAction.SilentRefresh:
                 _notesEdit.ApplySilentRefresh(newDiskNotes);
-                Task.Notes = newDiskNotes;
+                task.Notes = newDiskNotes;
                 if (_notesEdit.Mode == NotesEditMode.Edit)
                     NotesBox.Text = newDiskNotes;
                 else
@@ -671,7 +676,7 @@ public sealed partial class TaskDetailPage : Page
     private void Field_LostFocus(object sender, RoutedEventArgs e)
     {
         if (_isLoading) return;
-        if (sender == NotesBox && _suppressNextNotesSave)
+        if ((TextBox)sender == NotesBox && _suppressNextNotesSave)
         {
             _suppressNextNotesSave = false;
             return;


### PR DESCRIPTION
Resolves the 10 Release-publish warnings (5 unique sites × 2 compile passes) emitted by `src/Glasswork.App/Pages/TaskDetailPage.xaml.cs`.

## Fixes

- **CS8602 (lines 48, 56, 528)** — `App.Watcher` is declared `FileWatcherService?`. The `TaskFileChanged` event (un)subscriptions are now guarded with `if (App.Watcher is not null)`. The sibling `ArtifactChangedExternally` / `BacklinksChangedExternally` subscriptions are static events and were never flagged.
- **CS8602 (line 571)** — `HandleExternalFileChange` reached `Task.Notes` after flow analysis had narrowed `Task` to maybe-null via the earlier `Task?.Id`. Captured the task in a non-null local (`var task = Task; if (task is null) return;`) and used it for the `Id` read and the `Notes` assignment. `Task` is a non-nullable property, so the guard is a no-op at runtime but makes the invariant explicit for the compiler.
- **CS0252 (line 674)** — `Field_LostFocus` compared `sender` (`object`) against `NotesBox` (`TextBox`). The handler is only wired to `TextBox` controls, so the left-hand side is cast to `TextBox` per the compiler hint. The comparison stays reference-based (intent unchanged: detect whether the event came from `NotesBox`).

## Verification

- `dotnet build src\Glasswork.App -c Release -p:Platform=x64` → **0 warnings, 0 errors**.
- `dotnet test tests\Glasswork.Tests\` → 724 passed. The 2 failures (`ArtifactWatcherServiceTests.DebouncesBurstsIntoOneEvent`) are a pre-existing flaky filesystem-watcher timing test unrelated to this change; they pass when re-run in isolation.
- Visual verification per repo hard rule 7: ran `scripts\verify-app.ps1`; the app renders cleanly (no `STOWED_EXCEPTION`). Changes are code-behind only — no XAML touched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>