### PR TITLE
Slice 5: Update-available announcements (My Day InfoBar + Settings nav dot)

### DIFF
--- a/src/Glasswork.App/MainWindow.xaml.cs
+++ b/src/Glasswork.App/MainWindow.xaml.cs
@@ -16,6 +16,10 @@ namespace Glasswork;
 
 public sealed partial class MainWindow : Window
 {
+    // Guards NavView_SelectionChanged from performing a parameter-less navigation while
+    // NavigateToSettingsUpdates() syncs the Settings chrome selection (issue #241).
+    private bool _suppressSettingsNav;
+
     public MainWindow()
     {
         InitializeComponent();
@@ -31,6 +35,13 @@ public sealed partial class MainWindow : Window
         // Land on My Day. The XAML IsSelected="True" sets the chrome state but does not
         // reliably navigate the Frame on first launch — be explicit.
         NavFrame.Navigate(typeof(MyDayPage));
+
+        // Update-available announce surface: badge the built-in Settings nav item whenever
+        // App.Updater reports an update is available (issue #241). SettingsItem isn't
+        // available until the NavigationView template applies, so initialise on Loaded.
+        // ResultChanged covers the fire-and-forget startup check landing after construction.
+        NavView.Loaded += (_, _) => RefreshUpdateBadge();
+        App.Updater.ResultChanged += OnUpdaterResultChanged;
 
         // Status bar: vault path + task count + watcher dot + last-reload time.
         InitStatusBar();
@@ -122,6 +133,11 @@ public sealed partial class MainWindow : Window
 
     private void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
     {
+        // Suppress the selection-driven navigation while NavigateToSettingsUpdates() is
+        // syncing chrome — it navigates directly with a parameter and must not be clobbered
+        // by a second, parameter-less navigation from this handler.
+        if (_suppressSettingsNav) return;
+
         // Selection-driven nav still handles the "click a different section" case where
         // SelectedItem actually changed. The ItemInvoked handler covers re-clicking the
         // already-selected item (e.g. returning from Task Detail to Backlog).
@@ -135,7 +151,7 @@ public sealed partial class MainWindow : Window
         // "user wants to go back to this section from a child page" path.
         if (args.IsSettingsInvoked)
         {
-            NavigateToTopLevel(typeof(SettingsPage));
+            NavigateToSettings(null);
             return;
         }
         if (args.InvokedItemContainer is not NavigationViewItem item) return;
@@ -161,7 +177,7 @@ public sealed partial class MainWindow : Window
     {
         if (isSettings)
         {
-            NavigateToTopLevel(typeof(SettingsPage));
+            NavigateToSettings(null);
             return;
         }
         if (item is null) return;
@@ -197,6 +213,68 @@ public sealed partial class MainWindow : Window
         // back stack so "back" doesn't keep cycling through old detail pages.
         NavFrame.Navigate(pageType);
         NavFrame.BackStack.Clear();
+    }
+
+    private void NavigateToSettings(object? parameter)
+    {
+        if (NavFrame is null) return;
+        NavFrame.Navigate(typeof(SettingsPage), parameter);
+        NavFrame.BackStack.Clear();
+    }
+
+    /// <summary>
+    /// Navigate to the Settings page and surface its "Updates" section. Used by the
+    /// update-available announce surfaces' "Go to Settings" routes (issue #241).
+    /// Navigates directly (with the parameter) and syncs the NavView chrome selection
+    /// behind <see cref="_suppressSettingsNav"/> so the selection change doesn't trigger
+    /// a second, parameter-less navigation.
+    /// </summary>
+    public void NavigateToSettingsUpdates()
+    {
+        if (NavFrame is null) return;
+
+        if (NavView?.SettingsItem is NavigationViewItem settingsItem)
+        {
+            _suppressSettingsNav = true;
+            try { NavView.SelectedItem = settingsItem; }
+            finally { _suppressSettingsNav = false; }
+        }
+
+        NavigateToSettings(SettingsPage.UpdatesSectionParameter);
+    }
+
+    private void OnUpdaterResultChanged(object? sender, EventArgs e)
+    {
+        // ResultChanged may fire on the background startup-check thread; marshal to UI.
+        DispatcherQueue.TryEnqueue(RefreshUpdateBadge);
+    }
+
+    /// <summary>
+    /// Shows a dot <see cref="InfoBadge"/> on the built-in Settings nav item while an
+    /// update is available, and clears it otherwise. Null-guards the built-in
+    /// <c>SettingsItem</c>, which isn't materialised until the template applies.
+    /// </summary>
+    private void RefreshUpdateBadge()
+    {
+        if (NavView?.SettingsItem is not NavigationViewItem settingsItem) return;
+
+        var result = App.Updater.LastResult;
+        // A transient check failure must not retract a prior "update available" cue — the
+        // spec clears the dot only when we positively learn we're up to date (issue #241).
+        if (result?.IsCheckFailed == true) return;
+
+        settingsItem.InfoBadge = result?.IsUpdateAvailable == true ? CreateDotBadge() : null;
+    }
+
+    private static InfoBadge CreateDotBadge()
+    {
+        var badge = new InfoBadge();
+        if (Application.Current.Resources.TryGetValue("AttentionDotInfoBadgeStyle", out var style)
+            && style is Style dotStyle)
+        {
+            badge.Style = dotStyle;
+        }
+        return badge;
     }
 
     /// <summary>

--- a/src/Glasswork.App/Pages/MyDayPage.xaml
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml
@@ -19,21 +19,36 @@
 
     <Grid Padding="32" RowDefinitions="Auto,Auto,*,Auto,Auto,Auto,Auto,Auto">
 
-        <!-- Header -->
-        <Grid Grid.Row="0" ColumnDefinitions="*,Auto">
-            <StackPanel Grid.Column="0">
-                <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="My Day" />
-                <TextBlock Text="{x:Bind TodayDate}" Opacity="0.6" Margin="0,4,0,0" />
-            </StackPanel>
-            <Button Grid.Column="1" Click="RefreshButton_Click"
-                    VerticalAlignment="Top" Margin="0,4,0,0"
-                    ToolTipService.ToolTip="Refresh from vault">
-                <StackPanel Orientation="Horizontal" Spacing="6">
-                    <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE72C;" FontSize="14" />
-                    <TextBlock Text="Refresh" />
+        <!-- Header (with update-available announce InfoBar above it) -->
+        <StackPanel Grid.Row="0">
+            <!-- Update-available announce: dismissible Informational bar routing to Settings (issue #241) -->
+            <InfoBar x:Name="UpdateHint"
+                     IsOpen="False"
+                     IsClosable="True"
+                     Severity="Informational"
+                     Title="Update available"
+                     Margin="0,0,0,12"
+                     CloseButtonClick="UpdateHint_CloseButtonClick">
+                <InfoBar.ActionButton>
+                    <Button Content="Go to Settings" Click="UpdateHintGoToSettings_Click" />
+                </InfoBar.ActionButton>
+            </InfoBar>
+
+            <Grid ColumnDefinitions="*,Auto">
+                <StackPanel Grid.Column="0">
+                    <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="My Day" />
+                    <TextBlock Text="{x:Bind TodayDate}" Opacity="0.6" Margin="0,4,0,0" />
                 </StackPanel>
-            </Button>
-        </Grid>
+                <Button Grid.Column="1" Click="RefreshButton_Click"
+                        VerticalAlignment="Top" Margin="0,4,0,0"
+                        ToolTipService.ToolTip="Refresh from vault">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE72C;" FontSize="14" />
+                        <TextBlock Text="Refresh" />
+                    </StackPanel>
+                </Button>
+            </Grid>
+        </StackPanel>
 
         <!-- Today's tasks header -->
         <TextBlock x:Name="TodayHeader" Grid.Row="1" Text="Today's tasks"

--- a/src/Glasswork.App/Pages/MyDayPage.xaml.cs
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Glasswork.Core.AppUpdate;
 using Glasswork.Core.Models;
 using Glasswork.Services;
 using Glasswork.ViewModels;
@@ -25,6 +26,11 @@ public sealed partial class MyDayPage : Page
     private ScrollSnapshot? _pendingRestore;
 
     private sealed record ScrollSnapshot(double ListOffset);
+
+    // Session-scoped dismissal of the update-available InfoBar (#241). Static so the cue
+    // stays dismissed for the rest of the session even though MyDayPage is cached/recreated.
+    // Dismissing only hides the InfoBar — the Settings nav dot is unaffected.
+    private static bool _updateHintDismissedThisSession;
 
     public MyDayPage()
     {
@@ -74,6 +80,10 @@ public sealed partial class MyDayPage : Page
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
         base.OnNavigatedTo(e);
+        // Subscribe before the first refresh so the fire-and-forget startup update check
+        // can't land in the gap between reading the cache and wiring the handler (#241).
+        App.Updater.ResultChanged += OnUpdaterResultChanged;
+        RefreshUpdateHint();
         Refresh();
         App.Index.Changed += OnIndexChanged;
     }
@@ -81,12 +91,51 @@ public sealed partial class MyDayPage : Page
     protected override void OnNavigatedFrom(NavigationEventArgs e)
     {
         base.OnNavigatedFrom(e);
+        App.Updater.ResultChanged -= OnUpdaterResultChanged;
         App.Index.Changed -= OnIndexChanged;
     }
 
     private void OnIndexChanged(object? sender, Glasswork.Core.Services.TasksChanged e)
     {
         DispatcherQueue.TryEnqueue(Refresh);
+    }
+
+    private void OnUpdaterResultChanged(object? sender, EventArgs e)
+    {
+        // May fire on the background startup-check thread; marshal to UI.
+        DispatcherQueue.TryEnqueue(RefreshUpdateHint);
+    }
+
+    private void RefreshUpdateHint()
+    {
+        if (UpdateHint is null) return;
+
+        var result = App.Updater.LastResult;
+        // A transient check failure must not retract a shown hint — only a positive
+        // up-to-date result clears it (issue #241).
+        if (result?.IsCheckFailed == true) return;
+
+        if (result?.IsUpdateAvailable == true && !_updateHintDismissedThisSession)
+        {
+            UpdateHint.Message = UpdateStatusPresenter.Describe(result);
+            UpdateHint.IsOpen = true;
+        }
+        else
+        {
+            UpdateHint.IsOpen = false;
+        }
+    }
+
+    private void UpdateHint_CloseButtonClick(InfoBar sender, object args)
+    {
+        // User-initiated dismissal only (CloseButtonClick, not Closed) — hides the bar for
+        // the session without clearing the Settings nav dot.
+        _updateHintDismissedThisSession = true;
+    }
+
+    private void UpdateHintGoToSettings_Click(object sender, RoutedEventArgs e)
+    {
+        (App.MainWindow as MainWindow)?.NavigateToSettingsUpdates();
     }
 
     private void Refresh()

--- a/src/Glasswork.App/Pages/SettingsPage.xaml
+++ b/src/Glasswork.App/Pages/SettingsPage.xaml
@@ -95,7 +95,7 @@
             </StackPanel>
 
             <!-- Updates -->
-            <StackPanel Spacing="8">
+            <StackPanel x:Name="UpdatesSection" Spacing="8">
                 <TextBlock
                     Text="Updates"
                     Style="{ThemeResource SubtitleTextBlockStyle}" />

--- a/src/Glasswork.App/Pages/SettingsPage.xaml.cs
+++ b/src/Glasswork.App/Pages/SettingsPage.xaml.cs
@@ -7,12 +7,20 @@ using Glasswork.Core.AppUpdate;
 using Glasswork.Core.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
 using Windows.Storage.Pickers;
 
 namespace Glasswork.Pages;
 
 public sealed partial class SettingsPage : Page
 {
+    /// <summary>
+    /// Navigation parameter that asks the page to surface the "Updates" section
+    /// (bring it into view + focus the check button). Used by the announce
+    /// surfaces' "Go to Settings" routes (issue #241).
+    /// </summary>
+    public const string UpdatesSectionParameter = "updates";
+
     public SettingsPage()
     {
         InitializeComponent();
@@ -28,6 +36,22 @@ public sealed partial class SettingsPage : Page
 
         RefreshVaultInfo();
         RefreshUpdateInfo();
+    }
+
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        base.OnNavigatedTo(e);
+
+        if (e.Parameter as string == UpdatesSectionParameter)
+        {
+            // Defer until layout is ready: StartBringIntoView/Focus from OnNavigatedTo can
+            // run before the ScrollViewer has measured, making the scroll a no-op.
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                UpdatesSection?.StartBringIntoView();
+                CheckForUpdatesButton?.Focus(FocusState.Programmatic);
+            });
+        }
     }
 
     // ── Vault ────────────────────────────────────────────────────────────────

--- a/src/Glasswork.Core/AppUpdate/UpdateCheckService.cs
+++ b/src/Glasswork.Core/AppUpdate/UpdateCheckService.cs
@@ -12,6 +12,14 @@ public sealed class UpdateCheckService
     private readonly IRepoPathProvider _repoPathProvider;
     private UpdateCheckResult? _lastResult;
 
+    /// <summary>
+    /// Raised whenever <see cref="LastResult"/> changes (after any check completes,
+    /// including failures). Lets announce surfaces refresh once the fire-and-forget
+    /// startup check lands, even if they were created before it finished. Handlers
+    /// may be invoked on a background thread; marshal to the UI thread as needed.
+    /// </summary>
+    public event EventHandler? ResultChanged;
+
     public UpdateCheckService(
         GitHubReleaseDetector detector,
         string installedVersionString,
@@ -39,11 +47,16 @@ public sealed class UpdateCheckService
 
         if (!detectionResult.IsSuccess)
         {
-            _lastResult = UpdateCheckResult.Failed(detectionResult.FailureReason ?? "Detection failed");
-            return _lastResult;
+            return SetLastResult(UpdateCheckResult.Failed(detectionResult.FailureReason ?? "Detection failed"));
         }
 
-        _lastResult = UpdateCheckResult.Compare(_installedVersion, detectionResult.Version!);
-        return _lastResult;
+        return SetLastResult(UpdateCheckResult.Compare(_installedVersion, detectionResult.Version!));
+    }
+
+    private UpdateCheckResult SetLastResult(UpdateCheckResult result)
+    {
+        _lastResult = result;
+        ResultChanged?.Invoke(this, EventArgs.Empty);
+        return result;
     }
 }

--- a/tests/Glasswork.Tests/UpdateCheckServiceTests.cs
+++ b/tests/Glasswork.Tests/UpdateCheckServiceTests.cs
@@ -104,6 +104,58 @@ public class UpdateCheckServiceTests
     }
 
     [TestMethod]
+    public async Task CheckForUpdatesAsync_RaisesResultChanged_OnUpdateAvailable()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler();
+        handler.SetResponse(HttpStatusCode.OK, """
+            {
+                "tag_name": "v1.4.0"
+            }
+            """);
+
+        var detector = new GitHubReleaseDetector(handler);
+        var service = new UpdateCheckService(detector, "1.3.0", new FakeRepoPathProvider("/repo"));
+
+        var raised = 0;
+        UpdateCheckResult? observed = null;
+        service.ResultChanged += (_, _) =>
+        {
+            raised++;
+            observed = service.LastResult;
+        };
+
+        // Act
+        var result = await service.CheckForUpdatesAsync();
+
+        // Assert
+        Assert.AreEqual(1, raised);
+        Assert.AreSame(result, observed);
+        Assert.IsTrue(observed!.IsUpdateAvailable);
+    }
+
+    [TestMethod]
+    public async Task CheckForUpdatesAsync_RaisesResultChanged_OnCheckFailed()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler();
+        handler.SetResponse(HttpStatusCode.InternalServerError, "Server error");
+
+        var detector = new GitHubReleaseDetector(handler);
+        var service = new UpdateCheckService(detector, "1.3.0", new FakeRepoPathProvider("/repo"));
+
+        var raised = 0;
+        service.ResultChanged += (_, _) => raised++;
+
+        // Act
+        await service.CheckForUpdatesAsync();
+
+        // Assert
+        Assert.AreEqual(1, raised);
+        Assert.IsTrue(service.LastResult!.IsCheckFailed);
+    }
+
+    [TestMethod]
     public void MissingRepoPath_DoesNotThrow()
     {
         // Arrange


### PR DESCRIPTION
Closes #241.

## What this does
When `App.Updater` reports an update is available, two **announce-only** surfaces appear and route the user to **Settings → Updates**. Neither applies the update.

1. **My Day InfoBar** — a dismissible Informational `InfoBar` reading *"Glasswork X.Y.Z is available."* with a **Go to Settings** action button. Dismissal is **session-scoped** (until restart) and does **not** clear the nav dot.
2. **Settings nav dot** — a persistent `InfoBadge` dot on the NavigationView's built-in **Settings** item, shown while an update is available and cleared when up to date. Survives InfoBar dismissal.

## How it works
- **Core**: added `UpdateCheckService.ResultChanged` (`EventHandler`). Every `_lastResult` assignment now routes through a `SetLastResult()` helper that raises the event, so the fire-and-forget startup check can light up both surfaces *after* the pages are already constructed (they navigate before the async check finishes). Covered by 2 new unit tests (update-available + check-failed paths).
- **Spec compliance**: a transient `CheckFailed` result leaves **both** cues untouched — only a definitive *up-to-date* result clears them. (Prevents a failed manual re-check from retracting a known-available cue.)
- **Threading**: `ResultChanged` may fire on a background thread; all UI handlers marshal via `DispatcherQueue.TryEnqueue`.
- **MainWindow**: `NavigateToSettingsUpdates()` navigates directly with `SettingsPage.UpdatesSectionParameter` and syncs the `NavView` chrome selection behind a `_suppressSettingsNav` guard (prevents a second param-less navigation from clobbering the parameter). Badge initialized on `NavView.Loaded` (SettingsItem is null at construct time) and refreshed on `ResultChanged`.
- **SettingsPage**: on navigation with the updates parameter, brings the Updates section into view and focuses the check-for-updates button.

## Hard rule 6 (XAML init-state) — clear
All new handlers (`NavView.Loaded`, InfoBar buttons) null-guard sibling access; no XAML initial-state attribute touches a later-declared named element. App launches cleanly with no `STOWED_EXCEPTION` / `XamlParseException` in the Application Event Log.

## Hard rule 7 (visual verification) — ✅ PASSED
Ran `scripts\verify-app.ps1` with a temporary fake detector forcing an update-available state (`v9.9.9`), then reverted the stub and rebuilt clean (0 errors, no TEMP-VERIFY remnants). Confirmed visually:

- **My Day InfoBar** renders at the top of My Day: blue ⓘ, *"Update available — Glasswork 9.9.9 is available."*, with **Go to Settings** + close (✕) buttons.
- **Settings nav dot** renders as a blue `InfoBadge` dot on the Settings nav-rail item.
- **Go to Settings** navigation lands on the Settings page (renders correctly: Vault / Appearance / Azure DevOps / Updates sections), and the nav dot **persists** on the selected Settings item (navigation does not clear it).

The real (non-forced) state renders My Day with no InfoBar and no dot, as expected when no update is available.

## Testing
- `dotnet test tests/Glasswork.Tests/ --filter UpdateCheckServiceTests` → **7/7 passed**.
- Full suite: 2 unrelated pre-existing flaky failures (`DebouncesBurstsIntoOneEvent` in `BacklinkIndexIncrementalTests` + `ArtifactWatcherServiceTests` — debounce/file-watcher timing; pass in isolation, fail only under full-suite parallel load).
- `dotnet build src/Glasswork.App/Glasswork.csproj -c Debug -p:Platform=x64` → **0 errors**.

## Follow-up (out of scope, noted from rubber-duck)
The SettingsPage Updates-section **status text** can be momentarily stale if the page is already open during the ~1–3s startup-check window (the nav dot updates via MainWindow's subscription, but the section text only refreshes in SettingsPage's constructor / button-click). SettingsPage is not cached, so opening it fresh always shows current state — only the "already sitting on Settings during startup" edge case is affected. Candidate for a small Slice-4 follow-up.