### PR TITLE
Garbage-collect stale My Day dismissals at startup

### DIFF
--- a/src/Glasswork.App/App.xaml.cs
+++ b/src/Glasswork.App/App.xaml.cs
@@ -317,6 +317,14 @@ public partial class App : Application
                 Index.Tasks.Keys,
                 StringComparer.Ordinal);
             uiStateImpl.RemoveKeysNotIn(CollapsedTaskKeyPrefix, liveIds);
+
+            // Also drop dismissed.{date}.{taskId} entries from past days: a My Day
+            // dismissal only ever applies to the day it was created, so stale-dated
+            // keys are dead weight that otherwise accumulate forever (issue: day-view
+            // stale dismissals). Today's and (defensively) future-dated keys are kept.
+            var today = System.DateOnly.FromDateTime(System.DateTime.Today);
+            uiStateImpl.RemoveKeysWhere(k => Glasswork.Core.Services.MyDayDismissals.IsStale(k, today));
+
             uiStateImpl.Save();
         }
         catch (Exception ex)

--- a/src/Glasswork.Core/Services/JsonFileUiStateService.cs
+++ b/src/Glasswork.Core/Services/JsonFileUiStateService.cs
@@ -89,6 +89,25 @@ public sealed class JsonFileUiStateService : IUiStateService
         }
     }
 
+    /// <summary>
+    /// Removes every key for which <paramref name="shouldRemove"/> returns true.
+    /// Generic key-level prune used by startup GC (e.g. stale dismissals). Mutates
+    /// the in-memory store only; call <see cref="Save"/> to persist.
+    /// </summary>
+    public void RemoveKeysWhere(Func<string, bool> shouldRemove)
+    {
+        ArgumentNullException.ThrowIfNull(shouldRemove);
+        lock (_lock)
+        {
+            var toRemove = new List<string>();
+            foreach (var key in _state.Keys)
+            {
+                if (shouldRemove(key)) toRemove.Add(key);
+            }
+            foreach (var k in toRemove) _state.Remove(k);
+        }
+    }
+
     private static Dictionary<string, JsonElement> Load(string filePath)
     {
         if (!File.Exists(filePath)) return new Dictionary<string, JsonElement>();

--- a/src/Glasswork.Core/Services/MyDayDismissals.cs
+++ b/src/Glasswork.Core/Services/MyDayDismissals.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Globalization;
+
+namespace Glasswork.Core.Services;
+
+/// <summary>
+/// Single source of truth for the "dismissed from My Day" ui-state key shape
+/// (<c>dismissed.{yyyy-MM-dd}.{taskId}</c>) and for deciding when such a key is
+/// stale. A dismissal only ever applies to the day it was created (see
+/// <c>MyDayViewModel.IsDismissedToday</c>), so any key whose embedded date is
+/// strictly before today is dead weight and can be garbage-collected at startup.
+/// </summary>
+public static class MyDayDismissals
+{
+    public const string Prefix = "dismissed.";
+
+    /// <summary>Builds the ui-state key recording that <paramref name="taskId"/> was dismissed on <paramref name="date"/>.</summary>
+    public static string KeyFor(string taskId, DateOnly date) =>
+        $"{Prefix}{date:yyyy-MM-dd}.{taskId}";
+
+    /// <summary>
+    /// True only for a well-formed dismiss key whose embedded date is strictly
+    /// before <paramref name="today"/>. Non-dismiss keys, malformed keys, today's
+    /// keys, and (defensively) future-dated keys are all kept.
+    /// </summary>
+    public static bool IsStale(string key, DateOnly today)
+    {
+        if (key is null || !key.StartsWith(Prefix, StringComparison.Ordinal)) return false;
+
+        var rest = key.Substring(Prefix.Length);
+        var dot = rest.IndexOf('.');
+        if (dot <= 0) return false;
+
+        var datePart = rest.Substring(0, dot);
+        if (!DateOnly.TryParseExact(datePart, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
+            return false;
+
+        return date < today;
+    }
+}

--- a/src/Glasswork.Core/ViewModels/MyDayViewModel.cs
+++ b/src/Glasswork.Core/ViewModels/MyDayViewModel.cs
@@ -50,7 +50,7 @@ public partial class MyDayViewModel : ObservableObject
         => MyDayPromotionPolicy.IsTaskInMyDayToday(t, today, dismissed);
 
     private static string DismissKey(string taskId) =>
-        $"dismissed.{System.DateTime.Today:yyyy-MM-dd}.{taskId}";
+        MyDayDismissals.KeyFor(taskId, System.DateOnly.FromDateTime(System.DateTime.Today));
 
     private bool IsDismissedToday(string taskId) =>
         _uiState?.Get<bool>(DismissKey(taskId)) ?? false;

--- a/tests/Glasswork.Tests/MyDayDismissalsTests.cs
+++ b/tests/Glasswork.Tests/MyDayDismissalsTests.cs
@@ -1,0 +1,59 @@
+using System;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class MyDayDismissalsTests
+{
+    private static readonly DateOnly Today = new(2026, 6, 6);
+
+    [TestMethod]
+    public void IsStale_ReturnsTrue_ForPastDatedDismissKey()
+    {
+        Assert.IsTrue(MyDayDismissals.IsStale("dismissed.2026-04-25.task-1", Today));
+    }
+
+    [TestMethod]
+    public void IsStale_ReturnsFalse_ForTodaysDismissKey()
+    {
+        Assert.IsFalse(MyDayDismissals.IsStale("dismissed.2026-06-06.task-1", Today));
+    }
+
+    [TestMethod]
+    public void IsStale_ReturnsFalse_ForFutureDatedDismissKey()
+    {
+        // Defensive: a future date (clock skew / tests) is not "stale".
+        Assert.IsFalse(MyDayDismissals.IsStale("dismissed.2026-12-31.task-1", Today));
+    }
+
+    [TestMethod]
+    public void IsStale_ReturnsFalse_ForNonDismissKey()
+    {
+        Assert.IsFalse(MyDayDismissals.IsStale("collapsed.task-1", Today));
+        Assert.IsFalse(MyDayDismissals.IsStale("nav.last-page", Today));
+    }
+
+    [TestMethod]
+    public void IsStale_ReturnsFalse_ForMalformedDismissKey()
+    {
+        Assert.IsFalse(MyDayDismissals.IsStale("dismissed.", Today), "empty remainder");
+        Assert.IsFalse(MyDayDismissals.IsStale("dismissed.not-a-date.task-1", Today), "unparseable date");
+        Assert.IsFalse(MyDayDismissals.IsStale("dismissed.2026-04-25", Today), "no taskId separator");
+    }
+
+    [TestMethod]
+    public void IsStale_HandlesTaskIdsContainingDots()
+    {
+        // The date is the first segment, so a dotted taskId must not break parsing.
+        Assert.IsTrue(MyDayDismissals.IsStale("dismissed.2026-04-25.task.with.dots", Today));
+        Assert.IsFalse(MyDayDismissals.IsStale("dismissed.2026-06-06.task.with.dots", Today));
+    }
+
+    [TestMethod]
+    public void KeyFor_RoundTripsWith_IsStale()
+    {
+        Assert.IsFalse(MyDayDismissals.IsStale(MyDayDismissals.KeyFor("t1", Today), Today));
+        Assert.IsTrue(MyDayDismissals.IsStale(MyDayDismissals.KeyFor("t1", new DateOnly(2026, 4, 25)), Today));
+    }
+}

--- a/tests/Glasswork.Tests/UiStateServiceTests.cs
+++ b/tests/Glasswork.Tests/UiStateServiceTests.cs
@@ -115,6 +115,41 @@ public class UiStateServiceTests
     }
 
     [TestMethod]
+    public void RemoveKeysWhere_RemovesMatching_KeepsRest()
+    {
+        var dir = NewTempDir();
+        var svc = new JsonFileUiStateService(Path.Combine(dir, "ui-state.json"));
+        svc.Set("a.1", true);
+        svc.Set("a.2", true);
+        svc.Set("b.1", true);
+
+        svc.RemoveKeysWhere(k => k.StartsWith("a.", System.StringComparison.Ordinal));
+
+        Assert.IsFalse(svc.Get<bool>("a.1"));
+        Assert.IsFalse(svc.Get<bool>("a.2"));
+        Assert.IsTrue(svc.Get<bool>("b.1"), "non-matching keys must survive");
+    }
+
+    [TestMethod]
+    public void RemoveKeysWhere_PrunesStaleDismissals_KeepsTodaysAndUnrelated()
+    {
+        var today = new System.DateOnly(2026, 6, 6);
+        var dir = NewTempDir();
+        var svc = new JsonFileUiStateService(Path.Combine(dir, "ui-state.json"));
+        svc.Set(MyDayDismissals.KeyFor("task-1", new System.DateOnly(2026, 4, 25)), true); // stale
+        svc.Set(MyDayDismissals.KeyFor("task-2", new System.DateOnly(2026, 6, 1)), true);  // stale
+        svc.Set(MyDayDismissals.KeyFor("task-3", today), true);                            // today — keep
+        svc.Set("collapsed.task-9", true);                                                 // unrelated — keep
+
+        svc.RemoveKeysWhere(k => MyDayDismissals.IsStale(k, today));
+
+        Assert.IsFalse(svc.Get<bool>(MyDayDismissals.KeyFor("task-1", new System.DateOnly(2026, 4, 25))));
+        Assert.IsFalse(svc.Get<bool>(MyDayDismissals.KeyFor("task-2", new System.DateOnly(2026, 6, 1))));
+        Assert.IsTrue(svc.Get<bool>(MyDayDismissals.KeyFor("task-3", today)), "today's dismissal must survive");
+        Assert.IsTrue(svc.Get<bool>("collapsed.task-9"), "unrelated keys must survive");
+    }
+
+    [TestMethod]
     public void BacklogViewMode_DefaultsToList_WhenNotSet()
     {
         var dir = NewTempDir();


### PR DESCRIPTION
## What

Adds a startup garbage-collection pass that prunes stale `dismissed.{yyyy-MM-dd}.{taskId}` keys from `ui-state.json`, alongside the existing `collapsed.*` sweep.

## Why

This is fix #4 from an investigation into "tasks I removed from My Day reappear a couple hours later." My Day dismissals are recorded as ui-state keys shaped `dismissed.{date}.{taskId}` and only ever apply to the day they were created (`IsDismissedToday` reads only *today's* key). Nothing pruned past-dated keys, so they accumulated indefinitely — the real `ui-state.json` had grown **40 dead `dismissed.*` entries**. The startup GC already pruned stale `collapsed.*` keys but left dismissals untouched.

This is the *stale-data hygiene* fix; it is **not** the primary cause of the reappearance complaint (that's the missing `ScheduleUiStateSave()` on add/remove handlers, handled in a separate UI session) but it removes accumulated dead weight and a class of confusing stale state.

## How

- New `MyDayDismissals` helper in `Glasswork.Core.Services` — single source of truth for the dismiss-key shape (`KeyFor`) and the staleness rule (`IsStale`). Conservative: only a **well-formed** key whose embedded date is **strictly before today** is stale. Non-dismiss keys, malformed keys, today's keys, and (defensively) future-dated keys are all kept.
- `JsonFileUiStateService.RemoveKeysWhere(Func<string,bool>)` — generic key-level prune (mutates in-memory store; caller persists via `Save`).
- Wire the prune into the existing startup GC try/catch in `App.xaml.cs`, before `Save()`.
- Refactor `MyDayViewModel.DismissKey` to build keys through `MyDayDismissals.KeyFor` so the writer and the collector can never disagree on shape.

## Tests

- New `MyDayDismissalsTests` (7): `IsStale` for past/today/future/non-dismiss/malformed/dotted-taskId, plus `KeyFor` round-trip.
- `UiStateServiceTests` (+2): `RemoveKeysWhere` removes matching/keeps rest; prunes stale dismissals while keeping today's and unrelated keys.
- Full suite green except the pre-existing load-flaky `DebouncesBurstsIntoOneEvent` timing test (passes in isolation).

## Verification

- `dotnet test tests/Glasswork.Tests/` — 735 passing (2 flaky-timing failures unrelated to this change, confirmed passing in isolation).
- `scripts/verify-app.ps1` — app renders My Day correctly with the change present. (Note: capture can come back blank under heavy machine load before the WinUI first frame composes; confirmed full render on a clean capture.)
- **Functional proof:** running the dev build pruned the real `ui-state.json` from 40 stale `dismissed.*` keys to 0 (none were for today, so all correctly removed).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>