### PR TITLE
Persist My Day dismiss state on add/remove

### DIFF
--- a/src/Glasswork.App/Pages/MyDayPage.xaml.cs
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml.cs
@@ -256,6 +256,9 @@ public sealed partial class MyDayPage : Page
         if (sender is FrameworkElement { DataContext: GlassworkTask task })
         {
             ViewModel.RemoveFromMyDayCommand.Execute(task);
+            // The command mutates the dismiss key in IUiStateService in memory;
+            // schedule a debounced persist so it survives restart (mirrors TaskRow_DoubleTapped).
+            App.ScheduleUiStateSave();
         }
     }
 
@@ -264,6 +267,9 @@ public sealed partial class MyDayPage : Page
         if (sender is FrameworkElement { DataContext: GlassworkTask task })
         {
             ViewModel.AddToMyDayCommand.Execute(task);
+            // The command clears the dismiss key in IUiStateService in memory;
+            // schedule a debounced persist so it survives restart (mirrors TaskRow_DoubleTapped).
+            App.ScheduleUiStateSave();
         }
     }
 


### PR DESCRIPTION
## Root cause

When a user removes a task from **My Day**, `MyDayPage.RemoveFromDay_Click` runs `ViewModel.RemoveFromMyDayCommand`, which sets a dismiss-for-today key via `_uiState.Set(DismissKey(task.Id), true)`. The reverse handler `AddToDay_Click` → `AddToMyDayCommand` clears it with `_uiState.Remove(...)`.

The durable vault write (`TaskService.ToggleMyDay`) survives, but the **dismiss key is an in-memory `IUiStateService` mutation** and **nothing scheduled a flush** to `%LocalAppData%\Glasswork\ui-state.json`. There is no save-on-exit, so the in-memory dismiss was lost on the next launch and the task got re-promoted to My Day — the user-reported *"tasks I remove from My Day reappear after a couple hours / after a restart"* bug.

## The fix

One line added after the command executes in each of the two Page handlers, mirroring the established pattern already used by `TaskRow_DoubleTapped` (~line 227) in the same file:

- `RemoveFromDay_Click` → `App.ScheduleUiStateSave();`
- `AddToDay_Click` → `App.ScheduleUiStateSave();`

`App.ScheduleUiStateSave()` (`App.xaml.cs:25`, `public static`) is the canonical debounced persist hook; calling it after every add/remove is safe and idempotent even when the command was a partial no-op. The change is confined to the Page layer — the Core `MyDayViewModel` stays UI-agnostic (`App.ScheduleUiStateSave` is a WinUI `App` static).

## Testing

- **Full suite passed:** `dotnet test tests\Glasswork.Tests\Glasswork.Tests.csproj` → 724/728 passed. The 4 failures were all load-flaky `Debouncer`/`FileSystemWatcher` 2s-quiet-period timing tests (`Trigger_FiresActionAfterQuietPeriod`, `Trigger_FiresAgainAfterQuietPeriodElapses`, `TypedEvent_FiresForCrossProcessWrites_RegisteredOnlyInMarkerFile`, `Trigger_CoalescesRapidCallsIntoSingleAction`) — **re-running them in isolation passed 4/4**, confirming they're unrelated timing flakes. This change touches no Core code.
- This is WinUI code-behind calling a static `App` member, so it is not unit-testable in `Glasswork.Core` (MSTest can't drive the WinUI `App` singleton). No brittle test was invented.

## Visual verification (hard rule 7)

Debug build succeeded with **0 errors, 0 warnings**. `verify-app.ps1` launched the dev build and the process **stayed alive across ~50s and four window-state changes** (restore/foreground/maximize/recompose) — a real XAML parse / `STOWED_EXCEPTION 0xc000027b` crash would have terminated the process instantly.

**Caveat — blank capture:** `PrintWindow(PW_RENDERFULLCONTENT)` returned an all-white frame on every attempt. Per hard rule 7, **a blank capture with the process still ALIVE = first-frame / compositor timing, not a crash.** This agent session additionally has no interactive desktop (a fallback `CopyFromScreen` BitBlt failed with *"handle is invalid"*), which prevents the swapchain output from being captured here under heavy machine load. Because the change is a single `App.ScheduleUiStateSave()` call in **code-behind (not XAML)** — categorically unable to produce a `XamlParseException`, and identical to the proven call already at line 227 — and the process never crashed, the render is sound. Flagging for a quick local re-confirm of the My Day page if desired.

## Scope

Sibling work already covers the other root causes and is intentionally **not** touched here:
- PR #253 — GC stale My Day dismissals at startup
- Issue #254 — decision on `my_day` semantics
- Issue #255 — Ralph slice for cross-process merge-on-save

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>