### PR TITLE
feat: merge-on-save for ui-state to prevent cross-process clobber

### DIFF
--- a/src/Glasswork.Core/Services/JsonFileUiStateService.cs
+++ b/src/Glasswork.Core/Services/JsonFileUiStateService.cs
@@ -8,12 +8,15 @@ namespace Glasswork.Core.Services;
 /// <summary>
 /// JSON-file backed implementation of <see cref="IUiStateService"/>.
 /// Default location is <c>%LocalAppData%\Glasswork\ui-state.json</c>.
-/// Not thread-safe across processes; single-instance app assumption (see App.OnLaunched).
+/// Uses merge-on-save to avoid cross-process clobber: each process tracks only
+/// the keys it mutated, then merges those changes on top of the current disk state.
 /// </summary>
 public sealed class JsonFileUiStateService : IUiStateService
 {
     private readonly string _filePath;
     private readonly Dictionary<string, JsonElement> _state;
+    private readonly HashSet<string> _dirtyKeys = new();
+    private readonly HashSet<string> _deletedKeys = new();
     private readonly object _lock = new();
 
     public JsonFileUiStateService(string filePath)
@@ -43,6 +46,8 @@ public sealed class JsonFileUiStateService : IUiStateService
         lock (_lock)
         {
             _state[key] = JsonSerializer.SerializeToElement(value);
+            _dirtyKeys.Add(key);
+            _deletedKeys.Remove(key); // If we set it, it's not deleted
         }
     }
 
@@ -51,26 +56,47 @@ public sealed class JsonFileUiStateService : IUiStateService
         lock (_lock)
         {
             _state.Remove(key);
+            _deletedKeys.Add(key);
+            _dirtyKeys.Remove(key); // If we deleted it, it's not dirty (no value to merge)
         }
     }
 
     public void Save()
     {
-        Dictionary<string, JsonElement> snapshot;
         lock (_lock)
         {
-            snapshot = new Dictionary<string, JsonElement>(_state);
+            // Merge-on-save: re-read current disk state, apply our changes on top
+            var diskState = Load(_filePath);
+            
+            // Apply this instance's dirty keys
+            foreach (var key in _dirtyKeys)
+            {
+                if (_state.TryGetValue(key, out var value))
+                {
+                    diskState[key] = value;
+                }
+            }
+            
+            // Apply this instance's deletions
+            foreach (var key in _deletedKeys)
+            {
+                diskState.Remove(key);
+            }
+            
+            // Write merged state atomically
+            var dir = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+            
+            var json = JsonSerializer.Serialize(diskState, new JsonSerializerOptions { WriteIndented = true });
+            var tmp = _filePath + ".tmp";
+            File.WriteAllText(tmp, json);
+            if (File.Exists(_filePath)) File.Replace(tmp, _filePath, null);
+            else File.Move(tmp, _filePath);
+            
+            // Clear dirty tracking after successful save
+            _dirtyKeys.Clear();
+            _deletedKeys.Clear();
         }
-
-        var dir = Path.GetDirectoryName(_filePath);
-        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
-
-        var json = JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = true });
-        // Atomic-ish write: temp file + rename
-        var tmp = _filePath + ".tmp";
-        File.WriteAllText(tmp, json);
-        if (File.Exists(_filePath)) File.Replace(tmp, _filePath, null);
-        else File.Move(tmp, _filePath);
     }
 
     public void RemoveKeysNotIn(string keyPrefix, IReadOnlyCollection<string> liveSuffixes)
@@ -85,7 +111,12 @@ public sealed class JsonFileUiStateService : IUiStateService
                 var suffix = key.Substring(keyPrefix.Length);
                 if (!live.Contains(suffix)) toRemove.Add(key);
             }
-            foreach (var k in toRemove) _state.Remove(k);
+            foreach (var k in toRemove)
+            {
+                _state.Remove(k);
+                _deletedKeys.Add(k);
+                _dirtyKeys.Remove(k);
+            }
         }
     }
 
@@ -104,7 +135,12 @@ public sealed class JsonFileUiStateService : IUiStateService
             {
                 if (shouldRemove(key)) toRemove.Add(key);
             }
-            foreach (var k in toRemove) _state.Remove(k);
+            foreach (var k in toRemove)
+            {
+                _state.Remove(k);
+                _deletedKeys.Add(k);
+                _dirtyKeys.Remove(k);
+            }
         }
     }
 

--- a/tests/Glasswork.Tests/UiStateServiceTests.cs
+++ b/tests/Glasswork.Tests/UiStateServiceTests.cs
@@ -173,4 +173,104 @@ public class UiStateServiceTests
 
         Assert.AreEqual("board", svc2.Get<string>("backlog.viewMode"));
     }
+
+    // Cross-process merge-on-save tests (Slice 8 - Issue #255)
+
+    [TestMethod]
+    public void MergeOnSave_PreservesForeignKeys_WhenTwoProcessesSaveDifferentKeys()
+    {
+        var dir = NewTempDir();
+        var path = Path.Combine(dir, "ui-state.json");
+        
+        // BOTH processes start before any save (simulates two app instances)
+        var processA = new JsonFileUiStateService(path);
+        var processB = new JsonFileUiStateService(path);
+        
+        // Process A sets x and saves
+        processA.Set("x", 1);
+        processA.Save();
+        
+        // Process B (never loaded A's changes) sets y and saves
+        // Without merge-on-save, this will CLOBBER x
+        processB.Set("y", 2);
+        processB.Save();
+        
+        // After B's save, disk should have BOTH x and y
+        var verify = new JsonFileUiStateService(path);
+        Assert.AreEqual(1, verify.Get<int>("x"), "Process A's key must survive Process B's save");
+        Assert.AreEqual(2, verify.Get<int>("y"), "Process B's key must be present");
+    }
+
+    [TestMethod]
+    public void MergeOnSave_PreservesDismissal_WhenAnotherProcessSavesUnrelatedKey()
+    {
+        var dir = NewTempDir();
+        var path = Path.Combine(dir, "ui-state.json");
+        
+        var processA = new JsonFileUiStateService(path);
+        var processB = new JsonFileUiStateService(path);
+        
+        // Process A writes a dismissal key and saves
+        processA.Set("dismissed.2025-01-01.task-1", true);
+        processA.Save();
+        
+        // Process B (never saw the dismissal) sets unrelated key and saves
+        processB.Set("collapsed.task-9", true);
+        processB.Save();
+        
+        // Dismissal must still be present after B's save
+        var verify = new JsonFileUiStateService(path);
+        Assert.IsTrue(verify.Get<bool>("dismissed.2025-01-01.task-1"), "Dismissal must survive foreign save");
+        Assert.IsTrue(verify.Get<bool>("collapsed.task-9"), "Unrelated key must be present");
+    }
+
+    [TestMethod]
+    public void MergeOnSave_AppliesDeletions_AcrossMerge()
+    {
+        var dir = NewTempDir();
+        var path = Path.Combine(dir, "ui-state.json");
+        
+        // Both processes start with a pre-existing key
+        var setupSvc = new JsonFileUiStateService(path);
+        setupSvc.Set("k", "initial");
+        setupSvc.Save();
+        
+        var processA = new JsonFileUiStateService(path);
+        var processB = new JsonFileUiStateService(path);
+        
+        // Process A removes the key and saves
+        processA.Remove("k");
+        processA.Save();
+        
+        // Process B sets another key and saves (would re-read disk with k deleted)
+        processB.Set("other", "value");
+        processB.Save();
+        
+        // After merge, k should still be gone
+        var verify = new JsonFileUiStateService(path);
+        Assert.IsNull(verify.Get<string>("k"), "Deleted key must stay deleted after merge");
+        Assert.AreEqual("value", verify.Get<string>("other"));
+    }
+
+    [TestMethod]
+    public void MergeOnSave_LastWriterWinsPerKey_WhenSameKeyModifiedByBothProcesses()
+    {
+        var dir = NewTempDir();
+        var path = Path.Combine(dir, "ui-state.json");
+        
+        var processA = new JsonFileUiStateService(path);
+        var processB = new JsonFileUiStateService(path);
+        
+        // Process A sets k=1 and saves
+        processA.Set("k", 1);
+        processA.Save();
+        
+        // Process B sets k=2 and saves (overwrites A's value)
+        processB.Set("k", 2);
+        processB.Save();
+        
+        // Last writer (B) wins for the same key
+        var verify = new JsonFileUiStateService(path);
+        Assert.AreEqual(2, verify.Get<int>("k"), "Last writer must win for the same key");
+    }
 }


### PR DESCRIPTION
# Merge-on-save for ui-state to prevent cross-process clobber

Closes #255

## Summary

Implements merge-on-save in `JsonFileUiStateService` to fix cross-process key clobber. Each process now tracks only the keys it mutated (`_dirtyKeys` and `_deletedKeys`), then merges those changes on top of the current disk state when saving.

**Problem:** Two app instances (e.g., installed app + dev/MCP process) each held an independent in-memory copy of `ui-state.json`. When Process B saved, it would overwrite the entire file with its own dict, erasing keys that Process A had written (like My Day dismissals).

**Solution:** On `Save()`, re-read the file from disk, apply only this instance's dirty keys and deletions, write the merged result atomically. Keys this instance never touched are preserved.

## Changes

- **`JsonFileUiStateService`**:
  - Added `_dirtyKeys` and `_deletedKeys` HashSets to track mutations
  - `Set()` adds to `_dirtyKeys`
  - `Remove()`, `RemoveKeysWhere()`, `RemoveKeysNotIn()` add to `_deletedKeys`
  - `Save()` re-reads disk, merges changes, clears tracking sets
  
- **Tests** (4 new cross-process tests in `UiStateServiceTests`):
  - Foreign keys preserved when two processes save different keys
  - Dismissals survive foreign saves
  - Deletions apply correctly across merge
  - Last-writer-wins per key (expected behavior)
  - All 741 existing tests still pass

## Validation

```
dotnet test tests/Glasswork.Tests/ -nologo
# Test summary: total: 741, failed: 0, succeeded: 741
```

## Review notes (dual-model code review: gpt-5.5 + claude-opus-4.7)

Both models identified valid adjacent issues **outside #255's scope**:

### 1. Concurrent save races (GPT-5.5)
**Finding**: Two processes can both read disk → both merge → last write wins, dropping the earlier save's keys.
**Status**: Valid but out of scope. #255 scoped to "stale-sequential" clobber (Process A saves, then B saves later). Concurrent writes require interprocess locking (named mutex, file lock) — that's a broader architectural decision beyond this slice's "mechanical Core-only piece."
**Follow-up**: Needs dedicated issue for lock strategy (Windows `Mutex` + Unix `flock`, or retry-on-conflict, or write-ahead log).

### 2. GC sweep foreign-key blind spot (Claude Opus)
**Finding**: `RemoveKeysWhere`/`RemoveKeysNotIn` only iterate in-memory `_state.Keys`, so stale dismissals written by other processes survive forever even when they match the GC predicate.
**Status**: Valid and more urgent than #1, but also out of scope. #255 focused on "save clobber," not GC semantics. This requires a product decision: single-instance GC (app enforces one writer) vs. distributed GC (sweep predicates evaluate against full disk state).
**Follow-up**: Separate issue to either (a) make GC predicates apply to `diskState` in `Save()`, or (b) document GC as single-instance and wire app-level coordination.

**Both findings are accurate** — I'm not disputing them. But #255's acceptance criteria are met (all 5 tests pass, existing tests unaffected, Core-only, Linux-buildable). The tactical "prevent Process B from erasing Process A's keys" problem is solved; the strategic "what about concurrent saves and foreign-key GC" questions are valid next steps.

## Notes

- Interface (`IUiStateService`) unchanged — this is purely an implementation fix
- Atomic write (temp + rename) preserved
- Single-process behavior unchanged
- Per-key last-write-wins is acceptable; whole-dict clobber was the bug
