### PR TITLE
docs(adr): My Day date-scoped pins (0013) + ui-state auto-saving decorator (0014)

### DIFF
--- a/docs/adr/0013-my-day-date-scoped-pins.md
+++ b/docs/adr/0013-my-day-date-scoped-pins.md
@@ -1,0 +1,109 @@
+# ADR 0013: My Day direct pins are date-scoped (`my_day == today`), not pin-forever
+
+**Status**: Accepted
+**Context slice**: `MyDayPromotionPolicy`, `my_day` frontmatter semantics, My Day promotion model
+**Supersedes**: clause 1 ("direct pin") of ADR 0008's promotion rule
+
+## Context
+
+This records the decision for root cause **#3** of the "tasks reappear in My Day
+after I removed them" investigation (issue #254).
+
+`my_day` is stored in frontmatter as a **date**, but
+`MyDayPromotionPolicy.IsTaskInMyDayToday` only consults `task.MyDay.HasValue`:
+
+```csharp
+// Direct pin: MyDay frontmatter is set (any non-null value).
+if (task.MyDay.HasValue) return true;
+```
+
+So a directly-pinned task promotes into My Day **every day, forever**, regardless
+of how old the pin is. On the real vault ~16 tasks carry `my_day` dates that are
+weeks or months old (e.g. `2026-04-17`) yet still surface today. Dismissing such
+a task only suppresses it for the current day via the in-memory
+`dismissed.{yyyy-MM-dd}.{taskId}` key; the next day the `HasValue` pin
+re-promotes it — "it came back."
+
+The feature is named **My Day** (cf. Microsoft To Do) and the app already has a
+**Suggestions** section. Both point at the *daily-list* mental model: My Day is
+for **today**; yesterday's items don't auto-return — they resurface as
+suggestions the user can re-add.
+
+## Decision
+
+A **direct pin promotes only when `my_day == today`.** The promotion rule's
+clause 1 changes from `task.MyDay.HasValue` to
+`task.MyDay == today` (compared as `DateOnly`). A `my_day` date in the **future**
+does not promote until that day arrives (a natural "schedule for a day" capability);
+a `my_day` date in the **past** does not promote at all.
+
+The other promotion clauses from ADR 0008 are unchanged:
+
+1. `task.MyDay == today` *(direct pin — **was** `HasValue`)*
+2. `task.Due <= today && Status != Done` *(direct virtual)*
+3. any subtask `IsMyDay == true` *(virtual — flagged subtask)*
+4. any subtask `Due <= today && Status != Done` *(virtual — due subtask)*
+
+Dismiss-for-today still overrides all four and remains necessary for the
+**virtual** promotions (due-date / subtask), where there is no pin date to clear.
+`RemoveFromMyDay` continues to durably clear `my_day` for a direct pin.
+
+### One-time migration (no eviction on ship)
+
+Switching to date-scoped semantics would, on first run, drop all ~16 existing
+past-dated pins out of today. To avoid a jarring mass-eviction, a **one-time,
+idempotency-guarded migration** runs at startup:
+
+- For every task whose `my_day` is a date **strictly before today**, rewrite
+  `my_day` to **today's date**. Tasks with `my_day == today` or a future date are
+  left untouched.
+- The migration is **guarded by a version flag** in ui-state
+  (e.g. `migration.myDayDateScoped` / `IUiStateService`) and runs **exactly
+  once**. It must **not** re-run on subsequent launches — otherwise yesterday's
+  pins would be rewritten to each new "today" and we would silently recreate
+  pin-forever.
+- The migration writes to the vault and therefore **must register with
+  `SelfWriteCoordinator`** (cross-cutting rule 5) so `FileWatcherService` does not
+  fire spurious external-change events.
+
+Net effect: every currently-pinned task appears today exactly as before, then
+expires naturally tomorrow under the new rule.
+
+## Considered alternatives
+
+- **Option 1 — pin-forever (status quo).** Predictable "pin" mental model, but
+  stale pins accumulate and "My Day" degrades into "My Everything"; it is the
+  direct cause of the next-day recurrence. Rejected.
+- **Option 3 — normalize-on-promote.** Keep `HasValue` but rewrite `my_day` to
+  today whenever the task is shown. No eviction, but it mutates the vault on
+  *read*, churns Obsidian Sync/git, and destroys "when did I actually pin this."
+  Rejected.
+- **Option 4 — separate `my_day_pinned` boolean distinct from the date.**
+  Cleanest conceptual split, but a schema change plus migration for a property
+  that the date already encodes. Rejected as more work than the problem warrants;
+  the date field already carries enough information.
+
+## Consequences
+
+- `MyDayPromotionPolicy.IsTaskInMyDayToday` clause 1 becomes a date equality
+  check; existing tests that assert "any non-null `my_day` promotes" must be
+  updated to the date-scoped expectation.
+- A new one-time, flag-guarded startup migration is added (Core-testable: given a
+  set of tasks + a fake clock + fake ui-state, past-dated pins are rewritten to
+  today, today/future pins are untouched, and a second run is a no-op).
+- Future-dated `my_day` becomes a *scheduled* pin (promotes on its day). This is a
+  new, intentional capability; document it in `UBIQUITOUS_LANGUAGE.md` alongside
+  the refined definition of "pin."
+- "Remove from My Day" on a direct pin is now fully durable (clears the date) and
+  cannot recur next day. Virtual promotions (due/subtask) still rely on
+  dismiss-for-today, unchanged.
+- No frontmatter *schema* change — `my_day` remains a user-owned date; only its
+  interpretation narrows.
+
+## Why this ADR exists
+
+It is hard to reverse (the migration rewrites user vault data once and changes
+what "pinned" means), surprising without context (a contributor would ask why a
+set `my_day` no longer always shows), and a real trade-off (Option 1 is the
+intuitive "pin" model we are explicitly choosing against in favor of the daily
+My Day model the app's name and Suggestions section already imply).

--- a/docs/adr/0014-uistate-autosaving-decorator.md
+++ b/docs/adr/0014-uistate-autosaving-decorator.md
@@ -1,0 +1,91 @@
+# ADR 0014: UI-state persistence is centralized in an auto-saving decorator with flush-on-exit
+
+**Status**: Accepted
+**Context slice**: `IUiStateService`, `JsonFileUiStateService`, `App` ui-state wiring
+**Extends**: ADR 0001 (UI state storage), composes with the merge-on-save behavior added in #258
+
+## Context
+
+This records the decision for the hardening follow-up (issue #257) raised
+independently by both reviewers of #253 and #256.
+
+Per ADR 0001, `IUiStateService` is a generic key/value store whose `Save()` is
+**debounced ~500ms**. The debounce is currently scheduled by **callers** —
+`App.ScheduleUiStateSave()` is invoked from individual page click-handlers
+(`MyDayPage`, `BacklogPage`, `SettingsPage`). Two weaknesses follow:
+
+1. **Wrong seam.** The dismiss key is *mutated* in `MyDayViewModel`
+   (`Set`/`Remove`), but persistence is *triggered* in the page. PR #256 patched
+   the only two current entry points, but any future caller of the dismiss
+   commands — a keyboard shortcut, command binding, automation, test harness —
+   can reintroduce the exact "dismissed task reappears" bug simply by forgetting
+   to schedule a save. It is also awkward to unit-test, because the trigger is a
+   static, page-layer call.
+2. **No flush-on-exit.** The only synchronous `Save()` calls run at vault-init GC
+   and vault-switch — neither runs on shutdown. If the user mutates state and
+   closes the app inside the ~500ms debounce window, the pending save is
+   cancelled and the write is lost (a smaller version of the original bug). This
+   is systemic to every `ScheduleUiStateSave` caller.
+
+## Decision
+
+Centralize persistence at the **service boundary** with an **auto-saving
+decorator** around `IUiStateService`, and add an explicit **flush-on-exit** path.
+
+- A decorator (e.g. `AutoSavingUiStateService`) implements `IUiStateService` and
+  wraps the concrete `JsonFileUiStateService`. Every `Set`/`Remove` mutates the
+  inner store **and** schedules a debounced `inner.Save()` via a `Debouncer` the
+  decorator owns. `Get` passes through.
+- `App.Vault`-style wiring points `App.UiState` at the decorator, so **all
+  callers** (current and future, VM or page) persist automatically. No caller can
+  forget to save.
+- The decorator exposes **`Flush()`** (cancel-and-run the pending save
+  synchronously). `App` calls `Flush()` on shutdown (`MainWindow.Closed` / app
+  exit), closing the rapid-exit data-loss window for *all* ui-state, not just My
+  Day.
+- The page-layer `App.ScheduleUiStateSave()` calls become redundant; they are
+  removed (or reduced to a no-op/`Flush`-schedule shim) once the decorator is in
+  place.
+- The decorator composes with **#258's merge-on-save**: it calls the inner
+  `Save()`, which still re-reads, merges, and writes ui-state.json to avoid
+  cross-process clobber. The two mechanisms are orthogonal — the decorator
+  decides *when* to save; merge-on-save decides *how* to write safely.
+
+This lives in **`Glasswork.Core`** (pure .NET, like `JsonFileUiStateService` and
+`Debouncer`), so it is unit-testable on the Core/Linux runner.
+
+## Considered alternatives
+
+- **(a) `Changed` event on `IUiStateService` + `App` debounces globally.**
+  Achieves the same "can't forget" guarantee, but splits the wiring across the
+  service (raises event) and `App` (subscribes + debounces), leaving the debounce
+  in the WinUI layer and thus harder to cover in a Core test. Rejected in favor of
+  the decorator, which keeps the trigger *and* the debounce in Core.
+- **(c) Inject an `IUiStateSaveScheduler` into the ViewModels.** Better than the
+  page layer (moves the trigger next to the mutation), but every ViewModel must
+  still remember to call the scheduler after `Set`/`Remove` — the same
+  forgettable contract, one layer down. Rejected.
+- **Do only flush-on-exit, leave the seam.** Fixes weakness 2 but not weakness 1;
+  the page-layer trigger remains forgettable. Rejected — the decorator delivers
+  both, and its `Flush()` *is* the flush-on-exit path.
+
+## Consequences
+
+- New `AutoSavingUiStateService` decorator in `Glasswork.Core.Services`;
+  `App` constructs `JsonFileUiStateService` wrapped in it.
+- Core test: a `Set`/`Remove` schedules a save (verified with a fake/synchronous
+  `Debouncer` or injectable clock), and `Flush()` forces an immediate `Save()`.
+  This is the "mutation gets persisted" regression test that the page-layer design
+  could not express cleanly.
+- The explicit `App.ScheduleUiStateSave()` calls in pages are deleted; reviewers
+  no longer need to police "did this handler schedule a save."
+- A shutdown hook (`MainWindow.Closed` / app exit) calls `Flush()`.
+- Behavior is unchanged in the happy path (still ~500ms debounce); only the
+  guarantees tighten.
+
+## Why this ADR exists
+
+It changes *where* a cross-cutting concern lives (every ui-state write now routes
+through the decorator) and is the kind of structural decision a future
+contributor would otherwise reverse by re-adding caller-side `ScheduleUiStateSave`
+calls. Recording it fixes the seam as the intended one.


### PR DESCRIPTION
Records the two decisions made with the user for the My Day stale-task follow-ups.

- **ADR 0013 — `my_day` date-scoped pins** (issue #254): a direct pin promotes only when `my_day == today` (was `HasValue`). Includes a **one-time, flag-guarded** startup migration that rewrites past-dated pins to today so none of the ~16 current pins are evicted on ship. Refines clause 1 of ADR 0008.
- **ADR 0014 — ui-state auto-saving decorator** (issue #257): centralize persistence in an `AutoSavingUiStateService` decorator (every `Set`/`Remove` auto-schedules a debounced save) plus `Flush()` on shutdown. Composes with #258's merge-on-save. Extends ADR 0001.

Both decisions were explicitly approved by the user. Implementation is tracked in separate `ready-for-agent` issues that reference these ADRs.

Docs-only; no code or tests changed.