### PR TITLE
release: prepare v1.4.0

### DIFF
--- a/docs/releases/v1.4.0.md
+++ b/docs/releases/v1.4.0.md
@@ -1,0 +1,34 @@
+# Glasswork v1.4.0
+
+Reliability and self-update release. "My Day" now keeps your dismissals durable
+across restarts and processes, direct pins are date-scoped so the list clears
+each day, and Glasswork can detect and surface its own updates.
+
+## Changes
+
+- **My Day "Remove" is now durable.** Dismissing a task from My Day persists
+  across add/remove actions and app restarts, and is no longer clobbered when
+  another process writes UI state. Stale per-day dismissals are garbage-collected
+  at startup. (#253, #256, #258)
+- **Date-scoped My Day pins.** A directly pinned task now promotes into My Day
+  only on its pinned day instead of staying forever; a future date is treated as
+  a scheduled pin. A one-time migration rolls your existing pins forward so
+  nothing disappears on upgrade. (#262)
+- **Self-update.** Glasswork checks for new GitHub releases on startup and
+  surfaces an update via a My Day info bar, a Settings nav indicator, and a new
+  Settings → Updates section. (#243, #244, #245, #248, #251)
+- **Backlog task search.** Filter the Backlog by typing. (#230)
+- **My Day polish.** Scroll position is preserved across refreshes, today's
+  subtasks no longer overlap card details, and refresh is more stable.
+  (#232, #233, #234)
+- **Internals.** Auto-saving UI-state decorator with flush-on-exit closes the
+  rapid-exit data-loss window; repeatable release-publication workflow; MCP
+  server v0.5.0 polish. (#261, #252, #229)
+
+## Validation
+
+- Release workflow gates run: input/version validation, release-script Pester
+  tests, Core unit tests (`Glasswork.Tests`), and a Release x64 build of the
+  Windows app.
+- All My Day reliability and self-update changes shipped via PRs with passing
+  CI and code review on `main`.

--- a/src/Glasswork.App/Glasswork.csproj
+++ b/src/Glasswork.App/Glasswork.csproj
@@ -15,10 +15,10 @@
     <WindowsPackageType>None</WindowsPackageType>
     <Nullable>enable</Nullable>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
-    <Version>1.3.0</Version>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
-    <FileVersion>1.3.0.0</FileVersion>
-    <InformationalVersion>1.3.0</InformationalVersion>
+    <Version>1.4.0</Version>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <FileVersion>1.4.0.0</FileVersion>
+    <InformationalVersion>1.4.0</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Prepares the **v1.4.0** release.

- Bumps `src/Glasswork.App/Glasswork.csproj` → `1.4.0` (Version, InformationalVersion) / `1.4.0.0` (AssemblyVersion, FileVersion).
- Adds `docs/releases/v1.4.0.md` (passes `Test-ReleasePublicationInputs` locally — title, `## Changes`, `## Validation` present).

Covers everything merged since `v1.3.0`: My Day reliability fixes (#253, #256, #258, #262), self-update (#243–#251), backlog search (#230), My Day polish (#232–#234), and the auto-saving ui-state decorator (#261).

Once merged, I'll dispatch the `Release` workflow with `version=1.4.0` to build and publish the GitHub Release.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>