### PR TITLE
fix(release): robust tag-existence check (unblocks v1.4.0 publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,14 +41,18 @@ jobs:
           RELEASE_VERSION: ${{ inputs.version }}
         run: |
           $ErrorActionPreference = "Stop"
+          # Inspect git's exit code manually; do not let a non-zero native exit
+          # auto-throw (PS 7.4 defaults $PSNativeCommandUseErrorActionPreference
+          # to $true, which would promote ls-remote's "no match" into a fault).
+          $PSNativeCommandUseErrorActionPreference = $false
           $tag = "v$env:RELEASE_VERSION"
 
-          & git ls-remote --exit-code --tags origin "refs/tags/$tag" *> $null
-          if ($LASTEXITCODE -eq 0) {
-              throw "Release tag already exists: $tag"
-          }
-          if ($LASTEXITCODE -ne 2) {
+          $matchingRefs = & git ls-remote --tags origin "refs/tags/$tag"
+          if ($LASTEXITCODE -ne 0) {
               throw "Unable to check release tag '$tag' (git exited $LASTEXITCODE)."
+          }
+          if (-not [string]::IsNullOrWhiteSpace($matchingRefs)) {
+              throw "Release tag already exists: $tag"
           }
 
           $releaseUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/tags/$tag"


### PR DESCRIPTION
Fixes the first-run failure of the `Release` workflow.

**Symptom:** Dispatching `Release` (v1.4.0) failed at *"Ensure release tag does not already exist"* with `exit code 1` and no message — even though no `v1.4.0` tag or release existed.

**Root cause:** The step used `git ls-remote --exit-code --tags origin refs/tags/$tag`, which returns **2** when the tag is absent (the desired "all clear" path). Under PowerShell 7.4 the runner defaults `$PSNativeCommandUseErrorActionPreference = $true`, and with `$ErrorActionPreference = "Stop"` a non-zero native exit is promoted to a terminating error *before* the `if ($LASTEXITCODE …)` checks run. The `*> $null` redirect swallowed the message, so the step just died on the happy path. This is the workflow's first execution (added in #252, after v1.3.0 shipped), so the bug was latent.

**Fix:** Drop `--exit-code` and check ls-remote's *output* for emptiness instead, and set `$PSNativeCommandUseErrorActionPreference = $false` for this step so the exit code is inspected explicitly. Behavior preserved: throws if the tag exists, throws with a clear message on a genuine git failure, otherwise proceeds.

After merge I'll re-dispatch `Release` with `version=1.4.0`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>