### PR TITLE
test(release): update tag-check contract test for v1.4.0 publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,14 +41,18 @@ jobs:
           RELEASE_VERSION: ${{ inputs.version }}
         run: |
           $ErrorActionPreference = "Stop"
+          # Inspect git's exit code manually; do not let a non-zero native exit
+          # auto-throw (PS 7.4 defaults $PSNativeCommandUseErrorActionPreference
+          # to $true, which would promote ls-remote's "no match" into a fault).
+          $PSNativeCommandUseErrorActionPreference = $false
           $tag = "v$env:RELEASE_VERSION"
 
-          & git ls-remote --exit-code --tags origin "refs/tags/$tag" *> $null
-          if ($LASTEXITCODE -eq 0) {
-              throw "Release tag already exists: $tag"
-          }
-          if ($LASTEXITCODE -ne 2) {
+          $matchingRefs = & git ls-remote --tags origin "refs/tags/$tag"
+          if ($LASTEXITCODE -ne 0) {
               throw "Unable to check release tag '$tag' (git exited $LASTEXITCODE)."
+          }
+          if (-not [string]::IsNullOrWhiteSpace($matchingRefs)) {
+              throw "Release tag already exists: $tag"
           }
 
           $releaseUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/tags/$tag"

--- a/tests/scripts/ReleaseWorkflow.Tests.ps1
+++ b/tests/scripts/ReleaseWorkflow.Tests.ps1
@@ -47,7 +47,8 @@ Describe "Release workflow" {
     It "treats missing tags and releases as success paths" {
         $workflow = Get-Content $script:WorkflowPath -Raw
 
-        $workflow | Should -Match "LASTEXITCODE -ne 2"
+        $workflow | Should -Match 'PSNativeCommandUseErrorActionPreference = \$false'
+        $workflow | Should -Match 'IsNullOrWhiteSpace\(\$matchingRefs\)'
         $workflow | Should -Match "SkipHttpErrorCheck"
         $workflow | Should -Match "StatusCode -eq 200"
         $workflow | Should -Match "StatusCode -ne 404"


### PR DESCRIPTION
Follow-up to #264. The release run got past the tag-check step (the #264 fix worked) but failed at *Run release script tests*: ReleaseWorkflow.Tests.ps1 still pinned the old LASTEXITCODE -ne 2 implementation string.

Updates that contract test to assert the new output-based behavior (native-error promotion disabled + IsNullOrWhiteSpace(\) emptiness check). All 13 release script tests pass locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>