### PR TITLE
test(board): fix flaky AbortsOnSecondConflict (unblocks v1.4.0 release)

### DIFF
--- a/tests/Glasswork.Tests/BoardDragStatusWriterTests.cs
+++ b/tests/Glasswork.Tests/BoardDragStatusWriterTests.cs
@@ -95,6 +95,8 @@ public class BoardDragStatusWriterTests
 
         // Force two consecutive conflicts by intercepting the retry
         var attemptCount = 0;
+        var conflictPath = Path.Combine(_tempDir, "conflict-twice.md");
+        var stampBase = DateTime.UtcNow;
         _writer.OnBeforeWrite = () =>
         {
             attemptCount++;
@@ -103,6 +105,10 @@ public class BoardDragStatusWriterTests
                 var ext = _vault.Load("conflict-twice")!;
                 ext.Description = $"Change {attemptCount}";
                 _vault.Save(ext);
+                // Stamp a strictly-increasing mtime so the writer's mtime-based
+                // conflict check fires deterministically, independent of the
+                // filesystem's timestamp granularity (coarse on some CI runners).
+                File.SetLastWriteTimeUtc(conflictPath, stampBase.AddSeconds(attemptCount));
             }
         };
 


### PR DESCRIPTION
Unblocks the v1.4.0 release run, which failed at *Run Core tests* on a single flaky test.

**Failing test:** `BoardDragStatusWriterTests.WriteStatusChange_AbortsOnSecondConflict` — `Assert.IsFalse(result.Success)` failed (write succeeded when it should have aborted).

**Root cause:** `BoardDragStatusWriter` detects conflicts by comparing `File.GetLastWriteTimeUtc` before/after each write attempt. The test simulates two external conflicts *inside* the writer loop via the `OnBeforeWrite` hook, relying on back-to-back `_vault.Save` calls producing distinct mtimes. On runners with coarse filesystem timestamp granularity the setup save and the first simulated save land in the same tick, so the writer sees no mtime change, detects no conflict, and writes successfully — Success=true. Pre-existing flakiness, unrelated to the release change; it only surfaced now because the release workflow runs Core tests serialized.

**Fix:** Stamp a strictly-increasing `LastWriteTimeUtc` after each simulated external save so the mtime-based conflict check fires deterministically. Test-only — production conflict-detection semantics are unchanged. Verified green 5/5 locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>