### PR TITLE
Slice 12: Self-update UI wiring (Restart-to-update button + click handler)

### DIFF
--- a/src/Glasswork.App/Pages/SettingsPage.xaml
+++ b/src/Glasswork.App/Pages/SettingsPage.xaml
@@ -122,7 +122,8 @@
                         x:Name="RestartToUpdateButton"
                         Content="Restart to update"
                         IsEnabled="False"
-                        ToolTipService.ToolTip="Coming soon" />
+                        Click="RestartToUpdateButton_Click"
+                        ToolTipService.ToolTip="Rebuild from source and restart" />
                 </StackPanel>
             </StackPanel>
         </StackPanel>

--- a/src/Glasswork.App/Pages/SettingsPage.xaml.cs
+++ b/src/Glasswork.App/Pages/SettingsPage.xaml.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using Glasswork.Core.AppUpdate;
 using Glasswork.Core.Services;
+using Glasswork.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
@@ -177,6 +179,9 @@ public sealed partial class SettingsPage : Page
     {
         InstalledVersionText.Text = $"Installed version: {App.Updater.InstalledVersion}";
         UpdateStatusText.Text = UpdateStatusPresenter.Describe(App.Updater.LastResult);
+        RestartToUpdateButton.IsEnabled =
+            App.Updater.LastResult?.IsUpdateAvailable == true &&
+            !string.IsNullOrWhiteSpace(App.Updater.RepoPath);
     }
 
     private async void CheckForUpdatesButton_Click(object sender, RoutedEventArgs e)
@@ -188,6 +193,8 @@ public sealed partial class SettingsPage : Page
         {
             var result = await App.Updater.CheckForUpdatesAsync();
             UpdateStatusText.Text = UpdateStatusPresenter.Describe(result);
+            // Re-evaluate the restart button so it lights up once an update is found.
+            RefreshUpdateInfo();
         }
         catch (Exception ex)
         {
@@ -197,6 +204,61 @@ public sealed partial class SettingsPage : Page
         finally
         {
             CheckForUpdatesButton.IsEnabled = true;
+        }
+    }
+
+    private void RestartToUpdateButton_Click(object sender, RoutedEventArgs e)
+    {
+        var plan = new SelfUpdateLauncher().CreatePlan(
+            isUpdateAvailable: App.Updater.LastResult?.IsUpdateAvailable == true,
+            repoPath: App.Updater.RepoPath,
+            installExePath: Environment.ProcessPath ?? Process.GetCurrentProcess().MainModule?.FileName ?? string.Empty,
+            processId: Environment.ProcessId,
+            executableResolver: new PwshExecutableResolver(),
+            directoryExists: Directory.Exists);
+
+        if (plan.IsOpenReleasePage || plan.ProcessSpec is null)
+        {
+            OpenReleasePage();
+            return;
+        }
+
+        try
+        {
+            var spec = plan.ProcessSpec;
+            var psi = new ProcessStartInfo
+            {
+                FileName = spec.FileName,
+                CreateNoWindow = spec.CreateNoWindow,
+                UseShellExecute = spec.UseShellExecute,
+                WorkingDirectory = spec.WorkingDirectory,
+            };
+            foreach (var arg in spec.ArgumentList)
+                psi.ArgumentList.Add(arg);
+
+            Process.Start(psi);
+
+            // Exit only after the detached updater has started: it waits on this PID
+            // before pulling+rebuilding, so the app must stay alive until the spawn succeeds.
+            Application.Current.Exit();
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Self-update spawn failed: {ex.Message}");
+            OpenReleasePage();
+        }
+    }
+
+    private static void OpenReleasePage()
+    {
+        const string url = "https://github.com/tjegbejimba/Glasswork/releases/latest";
+        try
+        {
+            Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Failed to open release page: {ex.Message}");
         }
     }
 }

--- a/src/Glasswork.App/Services/PwshExecutableResolver.cs
+++ b/src/Glasswork.App/Services/PwshExecutableResolver.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using Glasswork.Core.AppUpdate;
+
+namespace Glasswork.Services;
+
+/// <summary>
+/// Resolves the PowerShell 7 (<c>pwsh</c>) executable for the self-update launcher.
+/// Modeled on <see cref="GhCliIssueFiler"/>'s ResolveGhPath: WinUI apps often launch
+/// without inheriting the user PATH that contains pwsh, so we probe the common install
+/// location first and fall back to the bare command name on PATH.
+/// </summary>
+public sealed class PwshExecutableResolver : IExecutableResolver
+{
+    public string? Resolve(string command)
+    {
+        if (!OperatingSystem.IsWindows()) return command;
+
+        var candidates = new[]
+        {
+            Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\PowerShell\7\pwsh.exe"),
+            Environment.ExpandEnvironmentVariables(@"%ProgramFiles(x86)%\PowerShell\7\pwsh.exe"),
+            Environment.ExpandEnvironmentVariables(@"%LOCALAPPDATA%\Microsoft\WinGet\Links\pwsh.exe"),
+        };
+        foreach (var c in candidates)
+        {
+            try { if (File.Exists(c)) return c; } catch { }
+        }
+        return "pwsh.exe";
+    }
+}


### PR DESCRIPTION
Closes #242.

WinUI half of the source-build self-update feature. The Core decision logic + updater scripts already merged via #268 (Slice 11); this slice wires them to the UI. **Scope: `src/Glasswork.App` only** — `Glasswork.Core` and the scripts are untouched.

## What I wired

**`src/Glasswork.App/Services/PwshExecutableResolver.cs`** (new) — `IExecutableResolver` for `pwsh`, modeled on `GhCliIssueFiler.ResolveGhPath()`: probes `%ProgramFiles%\PowerShell\7\pwsh.exe` (+ x86 + WinGet Links) and falls back to the bare `pwsh.exe` on PATH so it's always resolvable.

**`src/Glasswork.App/Pages/SettingsPage.xaml`** — added `Click="RestartToUpdateButton_Click"`, replaced the `"Coming soon"` tooltip with `"Rebuild from source and restart"`. Kept `IsEnabled="False"` as the static default (no initial-state binding) to respect **hard rule 6**; the button is enabled from code-behind after `InitializeComponent`.

**`src/Glasswork.App/Pages/SettingsPage.xaml.cs`**:
- `RefreshUpdateInfo()` now sets `RestartToUpdateButton.IsEnabled = LastResult?.IsUpdateAvailable == true && !string.IsNullOrWhiteSpace(RepoPath)`. It's called from the ctor and re-called at the end of a successful `CheckForUpdatesButton_Click`, so the button lights up as soon as a check finds an update.
- `RestartToUpdateButton_Click` builds a `SelfUpdatePlan` via `new SelfUpdateLauncher().CreatePlan(...)` (using `Environment.ProcessPath`/`MainModule` for the exe, `Environment.ProcessId`, `PwshExecutableResolver`, `Directory.Exists`). **Close-ordering contract:** on a `SpawnUpdater` plan it copies the `ProcessSpec` onto a `ProcessStartInfo`, `Process.Start`s it, and **only then** calls `Application.Current.Exit()` (the detached updater waits on this PID). Any `OpenReleasePage` plan, a null spec, or a `Process.Start` throw falls back to opening `releases/latest` with the **app left running**.

No new dependencies, no DI, no `Glasswork.Core` changes.

## Build + test results

| Step | Result |
| --- | --- |
| `dotnet build Glasswork.Core -c Debug` | ✅ 0 warnings / 0 errors |
| `dotnet build Glasswork.App (Glasswork.csproj) -c Debug -r win-x64` | ✅ 0 warnings / 0 errors |
| `dotnet test tests/Glasswork.Tests/` | 768 passed / **2 failed** |

The 2 failures are both `DebouncesBurstsIntoOneEvent` — the known load-flaky Debouncer timing test. It **passes 6/6 in isolation** (`--filter FullyQualifiedName~Debounc`) and is unrelated to this change (no Debouncer code touched).

## verify-app.ps1 (hard rule 7)

Ran `scripts/verify-app.ps1`. Debug build succeeded, the dev-build exe launched and stayed alive (no immediate `XamlParseException`/`STOWED_EXCEPTION`), and the PNG was **not blank** — it rendered the default My Day view fully. Note: the harness screenshots the default page, not Settings, so it doesn't show the button itself. Authoritative visual of the enabled button on Settings is left for human verification below.

## Needs human verification (TJ)

- [ ] `verify-app.ps1` (or manual launch) → navigate to **Settings → Updates**, capture a non-blank PNG showing the **enabled** "Restart to update" button after a successful check.
- [ ] **Live end-to-end:** real pending update → click → detached progress window → ff-only `git pull` + `publish.ps1` rebuild → relaunch into the new version.
- [ ] **Mid-publish failure** leaves the existing installed app relaunchable (no half-broken state).

Do not merge until the above are confirmed.