### PR TITLE
Add autonomous visual verification runner

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -151,19 +151,31 @@ inside Ubuntu.
 
 7. **Visual verification before declaring a local task done.** After any
    change touching `src\Glasswork.App\` (XAML, code-behind, ViewModels,
-   `App.xaml.cs`, services that affect what's drawn), you **must** run
-   [`scripts\verify-app.ps1`](../scripts/verify-app.ps1) and view the
-   resulting PNG before signing off. The test suite cannot catch XAML
-   parse errors, layout regressions, blank screens, or the silent
-   `STOWED_EXCEPTION` crashes from hard rule 6 — only a real render can.
-   The script does Debug build → launch dev-build exe → wait for window →
-   screenshot via `PrintWindow(PW_RENDERFULLCONTENT)` → kill the spawned
-   instance → print the PNG path. It only touches the exe under
-   `src\Glasswork.App\bin\`, so the user's installed Glasswork (from
-   `publish.ps1`) is left alone. Pure `Glasswork.Core` changes (no UI
-   surface affected) may skip this. **Cloud / Linux agents cannot run
-   this** — they must flag UI-touching work for local re-verification
-   before merge.
+   `App.xaml.cs`, services that affect what's drawn), you **must** run a
+   real render and view the resulting PNG before signing off. The test suite
+   cannot catch XAML parse errors, layout regressions, blank screens, or the
+   silent `STOWED_EXCEPTION` crashes from hard rule 6 — only a real render can.
+
+   Use [`scripts\invoke-visual-verification.ps1`](../scripts/invoke-visual-verification.ps1)
+   for behavior-specific changes. It runs a JSON scenario from
+   [`scripts\visual-verification\`](../scripts/visual-verification/), seeds an
+   isolated temporary Vault + UI state file, launches a unique dev-build app
+   instance, optionally drives UI Automation actions, captures named PNGs, and
+   rejects blank/uniform screenshots. Add or update a scenario that covers the
+   behavior you changed, then inspect the captured PNG(s). Example:
+
+   ```powershell
+   pwsh -File scripts\invoke-visual-verification.ps1 -Scenario scripts\visual-verification\backlog-smoke.json
+   ```
+
+   Use [`scripts\verify-app.ps1`](../scripts/verify-app.ps1) for a generic
+   startup smoke test when no scenario exists yet. Both scripts launch the
+   Debug build with a verification-only AppInstance key and skip protocol
+   registration/update checks, so they do not touch the user's installed
+   Glasswork, real Vault, normal UI state, or `glasswork://` handler. Pure
+   `Glasswork.Core` changes (no UI surface affected) may skip this. **Cloud /
+   Linux agents cannot run this** — they must flag UI-touching work for local
+   re-verification before merge.
 
 ## Investigation guidance (for issue triage & root-cause analysis)
 

--- a/Glasswork.slnx
+++ b/Glasswork.slnx
@@ -14,4 +14,7 @@
     <Project Path="tests/Glasswork.Tests/Glasswork.Tests.csproj" />
     <Project Path="tests/Glasswork.Mcp.Tests/Glasswork.Mcp.Tests.csproj" />
   </Folder>
+  <Folder Name="/tools/">
+    <Project Path="tools/Glasswork.VisualVerification/Glasswork.VisualVerification.csproj" />
+  </Folder>
 </Solution>

--- a/scripts/invoke-visual-verification.ps1
+++ b/scripts/invoke-visual-verification.ps1
@@ -1,0 +1,50 @@
+<#
+.SYNOPSIS
+  Run a Glasswork visual verification scenario in an isolated temporary Vault.
+
+.DESCRIPTION
+  Builds the dev WinUI app, creates a scenario-specific Vault/UI-state sandbox,
+  launches Glasswork with verification-only environment variables, optionally
+  drives UI Automation actions, captures named screenshots, and writes result.json.
+
+.EXAMPLE
+  pwsh -File scripts\invoke-visual-verification.ps1 -Scenario scripts\visual-verification\backlog-smoke.json
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Scenario,
+
+    [string]$OutDir,
+
+    [switch]$NoBuild,
+
+    [switch]$KeepWorkingDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+$repo = Split-Path -Parent $PSScriptRoot
+$project = Join-Path $repo 'tools\Glasswork.VisualVerification\Glasswork.VisualVerification.csproj'
+
+$runnerArgs = @(
+    'run',
+    '--project', $project,
+    '--',
+    '--scenario', (Resolve-Path -LiteralPath $Scenario).Path,
+    '--repo-root', $repo
+)
+
+if ($OutDir) {
+    $runnerArgs += @('--out-dir', $OutDir)
+}
+if ($NoBuild) {
+    $runnerArgs += '--no-build'
+}
+if ($KeepWorkingDirectory) {
+    $runnerArgs += '--keep-working-directory'
+}
+
+& dotnet @runnerArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "Visual verification failed with exit code $LASTEXITCODE."
+}

--- a/scripts/verify-app.ps1
+++ b/scripts/verify-app.ps1
@@ -39,20 +39,7 @@ $proj = Join-Path $repo 'src\Glasswork.App\Glasswork.csproj'
 $binDir = Join-Path $repo 'src\Glasswork.App\bin\x64\Debug\net10.0-windows10.0.26100.0\win-x64'
 $exe = Join-Path $binDir 'Glasswork.exe'
 
-# 1. Kill any prior dev-build instance (match by exe path, not name — leaves the
-#    user's installed Glasswork running).
-function Stop-DevBuild {
-    Get-Process -Name Glasswork -ErrorAction SilentlyContinue | Where-Object {
-        try { $_.Path -and ($_.Path -ieq $exe) } catch { $false }
-    } | ForEach-Object {
-        Write-Host "Stopping prior dev-build (PID $($_.Id))..."
-        Stop-Process -Id $_.Id -Force
-    }
-}
-Stop-DevBuild
-Start-Sleep 1
-
-# 2. Build (unless caller already did).
+# 1. Build (unless caller already did).
 if (-not $NoBuild) {
     Write-Host "Building Glasswork.App (Debug|x64)..." -ForegroundColor Cyan
     & dotnet build $proj -c Debug -p:Platform=x64 --nologo -v quiet -tl:off
@@ -60,18 +47,49 @@ if (-not $NoBuild) {
 }
 if (-not (Test-Path $exe)) { throw "Build succeeded but exe not found at $exe" }
 
-# 3. Launch.
+# 2. Launch.
 Write-Host "Launching $exe"
-$spawned = Start-Process -FilePath $exe -PassThru
+$verifyRoot = Join-Path $env:TEMP ("Glasswork-verify-work-" + [guid]::NewGuid().ToString("N"))
+$verifyVault = Join-Path $verifyRoot 'Vault\wiki\todo'
+$verifyUiState = Join-Path $verifyRoot 'ui-state.json'
+New-Item -ItemType Directory -Path $verifyVault -Force | Out-Null
+
+$oldVaultPath = $env:GLASSWORK_VERIFY_VAULT_PATH
+$oldUiStatePath = $env:GLASSWORK_VERIFY_UI_STATE_PATH
+$oldInstanceKey = $env:GLASSWORK_VERIFY_INSTANCE_KEY
+$oldSkipProtocol = $env:GLASSWORK_SKIP_PROTOCOL_REGISTRATION
+$oldSkipUpdate = $env:GLASSWORK_SKIP_UPDATE_CHECK
+try {
+    $env:GLASSWORK_VERIFY_VAULT_PATH = $verifyVault
+    $env:GLASSWORK_VERIFY_UI_STATE_PATH = $verifyUiState
+    $env:GLASSWORK_VERIFY_INSTANCE_KEY = "verify-" + [guid]::NewGuid().ToString("N")
+    $env:GLASSWORK_SKIP_PROTOCOL_REGISTRATION = "1"
+    $env:GLASSWORK_SKIP_UPDATE_CHECK = "1"
+    try {
+        $spawned = Start-Process -FilePath $exe -PassThru
+    }
+    catch {
+        Remove-Item -LiteralPath $verifyRoot -Recurse -Force -ErrorAction SilentlyContinue
+        throw
+    }
+}
+finally {
+    if ($null -eq $oldVaultPath) { Remove-Item Env:\GLASSWORK_VERIFY_VAULT_PATH -ErrorAction SilentlyContinue } else { $env:GLASSWORK_VERIFY_VAULT_PATH = $oldVaultPath }
+    if ($null -eq $oldUiStatePath) { Remove-Item Env:\GLASSWORK_VERIFY_UI_STATE_PATH -ErrorAction SilentlyContinue } else { $env:GLASSWORK_VERIFY_UI_STATE_PATH = $oldUiStatePath }
+    if ($null -eq $oldInstanceKey) { Remove-Item Env:\GLASSWORK_VERIFY_INSTANCE_KEY -ErrorAction SilentlyContinue } else { $env:GLASSWORK_VERIFY_INSTANCE_KEY = $oldInstanceKey }
+    if ($null -eq $oldSkipProtocol) { Remove-Item Env:\GLASSWORK_SKIP_PROTOCOL_REGISTRATION -ErrorAction SilentlyContinue } else { $env:GLASSWORK_SKIP_PROTOCOL_REGISTRATION = $oldSkipProtocol }
+    if ($null -eq $oldSkipUpdate) { Remove-Item Env:\GLASSWORK_SKIP_UPDATE_CHECK -ErrorAction SilentlyContinue } else { $env:GLASSWORK_SKIP_UPDATE_CHECK = $oldSkipUpdate }
+}
 $pid_ = $spawned.Id
 
-# 4. Wait for MainWindowHandle. WinUI 3 self-contained init is ~1-3s on warm cache,
+# 3. Wait for MainWindowHandle. WinUI 3 self-contained init is ~1-3s on warm cache,
 #    longer on cold start. Poll every 250ms up to LaunchTimeoutSec.
 $deadline = (Get-Date).AddSeconds($LaunchTimeoutSec)
 $hwnd = 0
 while ((Get-Date) -lt $deadline) {
     $p = Get-Process -Id $pid_ -ErrorAction SilentlyContinue
     if (-not $p) {
+        Remove-Item -LiteralPath $verifyRoot -Recurse -Force -ErrorAction SilentlyContinue
         throw "Glasswork (PID $pid_) exited before showing a window — likely a startup crash. Check Event Viewer > Application for STOWED_EXCEPTION or XamlParseException (architectural hard rule 6)."
     }
     if ($p.MainWindowHandle -ne 0) { $hwnd = $p.MainWindowHandle; break }
@@ -79,27 +97,30 @@ while ((Get-Date) -lt $deadline) {
 }
 if ($hwnd -eq 0) {
     Stop-Process -Id $pid_ -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $verifyRoot -Recurse -Force -ErrorAction SilentlyContinue
     throw "Glasswork did not show a window within ${LaunchTimeoutSec}s. Either increase -LaunchTimeoutSec or investigate why startup is slow."
 }
 # Give the first frame a moment to compose so the screenshot isn't a blank/loading state.
 Start-Sleep -Milliseconds 800
 
-# 5. Screenshot via the existing primitive (targets the specific PID, so the user's
+# 4. Screenshot via the existing primitive (targets the specific PID, so the user's
 #    own Glasswork is never touched).
 if (-not $OutPath) {
     $ts = Get-Date -Format 'yyyyMMdd-HHmmss'
-    $OutPath = Join-Path $env:TEMP "Glasswork-verify-$ts.png"
+    $OutPath = Join-Path $env:TEMP "Glasswork-verify-$ts-$([guid]::NewGuid().ToString('N')).png"
 }
 & pwsh -NoProfile -File (Join-Path $PSScriptRoot 'screenshot-app.ps1') -ProcessId $pid_ -OutPath $OutPath | Out-Null
 if ($LASTEXITCODE -ne 0 -or -not (Test-Path $OutPath)) {
     Stop-Process -Id $pid_ -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $verifyRoot -Recurse -Force -ErrorAction SilentlyContinue
     throw "Screenshot capture failed."
 }
 
-# 6. Kill the spawned instance — never leave dev builds running after verification.
+# 5. Kill the spawned instance — never leave dev builds running after verification.
 Stop-Process -Id $pid_ -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $verifyRoot -Recurse -Force -ErrorAction SilentlyContinue
 
-# 7. Print path on last line so callers can pipe / capture it.
+# 6. Print path on last line so callers can pipe / capture it.
 $resolved = (Resolve-Path -LiteralPath $OutPath).Path
 Write-Host "PNG saved to: $resolved" -ForegroundColor Green
 $resolved

--- a/scripts/visual-verification/backlog-smoke.json
+++ b/scripts/visual-verification/backlog-smoke.json
@@ -1,0 +1,44 @@
+{
+  "name": "Backlog smoke",
+  "startUri": "glasswork://backlog",
+  "tasks": [
+    {
+      "id": "visual-backlog-card",
+      "title": "Visual verification backlog card",
+      "description": "This seeded task proves agents can launch Glasswork against an isolated Vault and verify a deterministic Backlog screen.",
+      "status": "todo",
+      "priority": "high",
+      "subtasks": [
+        {
+          "text": "Rendered by the visual verification runner",
+          "status": "in_progress"
+        },
+        {
+          "text": "Captured without touching the real Vault"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "type": "select",
+      "automationId": "NavBacklog",
+      "timeoutMilliseconds": 10000
+    },
+    {
+      "type": "wait-for",
+      "automationId": "BacklogHeader",
+      "timeoutMilliseconds": 10000
+    },
+    {
+      "type": "wait-for",
+      "name": "Visual verification backlog card",
+      "timeoutMilliseconds": 10000
+    }
+  ],
+  "captures": [
+    {
+      "name": "backlog"
+    }
+  ]
+}

--- a/src/Glasswork.App/App.xaml.cs
+++ b/src/Glasswork.App/App.xaml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Glasswork.Core.Models;
 using Glasswork.Core.Services;
+using Glasswork.Core.VisualVerification;
 using Glasswork.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
@@ -183,8 +184,9 @@ public partial class App : Application
         // URIs from a second instance to the already-running primary instance.
         var currentInstance = AppInstance.GetCurrent();
         var activationArgs = currentInstance.GetActivatedEventArgs();
+        var launchOptions = VerificationLaunchOptions.FromProcessEnvironment();
 
-        _mainAppInstance = AppInstance.FindOrRegisterForKey("main");
+        _mainAppInstance = AppInstance.FindOrRegisterForKey(launchOptions.InstanceKey);
         if (!_mainAppInstance.IsCurrent)
         {
             // Already running — forward the activation (carries the glasswork:// URI)
@@ -199,7 +201,8 @@ public partial class App : Application
         _mainAppInstance.Activated += OnAppInstanceActivated;
 
         // UI state must be initialised first so that vault path can be read from it.
-        _uiStateImpl = new JsonFileUiStateService(JsonFileUiStateService.DefaultFilePath());
+        _uiStateImpl = new JsonFileUiStateService(
+            launchOptions.UiStatePath ?? JsonFileUiStateService.DefaultFilePath());
         var uiStateDebouncer = new Debouncer(TimeSpan.FromMilliseconds(500), () =>
         {
             try { _uiStateImpl.Save(); }
@@ -220,17 +223,22 @@ public partial class App : Application
         var repoPathProvider = new Services.UiStateRepoPathProvider(_uiStateImpl, RepoPathKey);
         Updater = new Glasswork.Core.AppUpdate.UpdateCheckService(detector, installedVersion, repoPathProvider);
         
-        // Fire-and-forget startup check: runs in background, failures cached/never surfaced at startup (ADR 0011).
-        _ = System.Threading.Tasks.Task.Run(async () =>
+        if (!launchOptions.SkipUpdateCheck)
         {
-            try { await Updater.CheckForUpdatesAsync(); }
-            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Startup update check failed: {ex.Message}"); }
-        });
+            // Fire-and-forget startup check: runs in background, failures cached/never surfaced at startup (ADR 0011).
+            _ = System.Threading.Tasks.Task.Run(async () =>
+            {
+                try { await Updater.CheckForUpdatesAsync(); }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Startup update check failed: {ex.Message}"); }
+            });
+        }
 
         // Resolve vault path: persisted setting wins; fall back to the hard-coded default
         // so first-run behaviour is unchanged until the user picks a different vault.
         var persistedVaultPath = _uiStateImpl.Get<string>(VaultPathKey);
-        var vaultPath = !string.IsNullOrWhiteSpace(persistedVaultPath) && Directory.Exists(persistedVaultPath)
+        var vaultPath = !string.IsNullOrWhiteSpace(launchOptions.VaultPath)
+            ? launchOptions.VaultPath
+            : !string.IsNullOrWhiteSpace(persistedVaultPath) && Directory.Exists(persistedVaultPath)
             ? persistedVaultPath
             : Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
@@ -241,7 +249,8 @@ public partial class App : Application
         // Register glasswork:// URL scheme for this executable so links work even
         // without MSIX packaging. Idempotent: re-running on every launch is cheap
         // and ensures the path stays correct after the binary is moved.
-        RegisterUrlScheme();
+        if (!launchOptions.SkipProtocolRegistration)
+            RegisterUrlScheme();
 
         _window = new MainWindow();
         ApplyTheme(_window);

--- a/src/Glasswork.App/MainWindow.xaml
+++ b/src/Glasswork.App/MainWindow.xaml
@@ -34,12 +34,14 @@
         <NavigationView
             x:Name="NavView"
             Grid.Row="1"
+            AutomationProperties.AutomationId="ShellNavigation"
             IsBackButtonVisible="Collapsed"
             IsPaneToggleButtonVisible="False"
             SelectionChanged="NavView_SelectionChanged"
             ItemInvoked="NavView_ItemInvoked">
             <NavigationView.MenuItems>
                 <NavigationViewItem
+                    AutomationProperties.AutomationId="NavMyDay"
                     Content="My Day"
                     IsSelected="True"
                     Tag="myday">
@@ -47,19 +49,19 @@
                         <FontIcon Glyph="&#xE706;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Content="Backlog" Tag="backlog">
+                <NavigationViewItem AutomationProperties.AutomationId="NavBacklog" Content="Backlog" Tag="backlog">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE8FD;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Content="Work Log" Tag="worklog">
+                <NavigationViewItem AutomationProperties.AutomationId="NavWorkLog" Content="Work Log" Tag="worklog">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE9D5;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
             </NavigationView.MenuItems>
             <NavigationView.FooterMenuItems>
-                <NavigationViewItem Content="Feedback" Tag="feedback">
+                <NavigationViewItem AutomationProperties.AutomationId="NavFeedback" Content="Feedback" Tag="feedback">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xED15;" />
                     </NavigationViewItem.Icon>
@@ -72,7 +74,7 @@
                          IsClosable="True"
                          Severity="Warning"
                          Margin="8,8,8,0" />
-                <Frame x:Name="NavFrame" Grid.Row="1">
+                <Frame x:Name="NavFrame" Grid.Row="1" AutomationProperties.AutomationId="ContentFrame">
                     <Frame.ContentTransitions>
                         <TransitionCollection>
                             <NavigationThemeTransition />
@@ -90,10 +92,12 @@
                 Padding="12,4">
             <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto" ColumnSpacing="14">
                 <TextBlock Grid.Column="0" x:Name="StatusVaultText"
+                           AutomationProperties.AutomationId="StatusVaultText"
                            FontSize="11" Opacity="0.7"
                            TextTrimming="CharacterEllipsis"
                            VerticalAlignment="Center" />
                 <TextBlock Grid.Column="1" x:Name="StatusTaskCountText"
+                           AutomationProperties.AutomationId="StatusTaskCountText"
                            FontSize="11" Opacity="0.7"
                            VerticalAlignment="Center" />
                 <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="6"

--- a/src/Glasswork.App/Pages/BacklogPage.xaml
+++ b/src/Glasswork.App/Pages/BacklogPage.xaml
@@ -234,6 +234,7 @@
         <!-- Header -->
         <TextBlock
             Grid.Row="0"
+            AutomationProperties.AutomationId="BacklogHeader"
             Style="{StaticResource TitleTextBlockStyle}"
             Text="Backlog" />
 
@@ -259,6 +260,7 @@
                     Padding="1">
                 <StackPanel Orientation="Horizontal" Spacing="1">
                     <ToggleButton x:Name="ListViewToggle"
+                                  AutomationProperties.AutomationId="BacklogListViewToggle"
                                   IsChecked="True"
                                   Checked="ListViewToggle_Checked"
                                   Width="40" Height="32"
@@ -268,6 +270,7 @@
                         <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE8FD;" FontSize="13" />
                     </ToggleButton>
                     <ToggleButton x:Name="BoardViewToggle"
+                                  AutomationProperties.AutomationId="BacklogBoardViewToggle"
                                   IsChecked="False"
                                   Checked="BoardViewToggle_Checked"
                                   Width="40" Height="32"
@@ -280,6 +283,7 @@
             </Border>
 
             <ComboBox x:Name="StatusFilter"
+                      AutomationProperties.AutomationId="BacklogStatusFilter"
                       SelectedIndex="0"
                       SelectionChanged="StatusFilter_Changed"
                       Width="160">
@@ -290,12 +294,14 @@
             </ComboBox>
 
             <TextBox x:Name="SearchBox"
+                     AutomationProperties.AutomationId="BacklogSearchBox"
                      Width="240"
                      PlaceholderText="Search tasks"
                      AutomationProperties.Name="Search Backlog tasks"
                      TextChanged="SearchBox_TextChanged" />
 
             <ToggleButton x:Name="GroupToggle"
+                          AutomationProperties.AutomationId="BacklogGroupToggle"
                           IsChecked="{x:Bind ViewModel.IsGrouped, Mode=TwoWay}"
                           ToolTipService.ToolTip="Group by parent">
                 <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE71D;" FontSize="13" />
@@ -316,6 +322,7 @@
         <ListView
             Grid.Row="3"
             x:Name="TaskList"
+            AutomationProperties.AutomationId="BacklogTaskList"
             ItemsSource="{x:Bind ViewModel.Rows}"
             ItemTemplateSelector="{StaticResource BacklogRowSelector}"
             SelectionMode="None"
@@ -335,6 +342,7 @@
         <!-- Board view (two columns: To Do | In Progress) -->
         <ScrollViewer
             x:Name="BoardView"
+            AutomationProperties.AutomationId="BacklogBoardView"
             Grid.Row="3"
             Visibility="Collapsed"
             HorizontalScrollBarVisibility="Auto"
@@ -392,6 +400,7 @@
         <!-- Empty state: shown when the filtered Backlog has no tasks -->
         <controls:EmptyState
             x:Name="EmptyStateView"
+            AutomationProperties.AutomationId="BacklogEmptyState"
             Grid.Row="3"
             Glyph="&#xE8FD;"
             Headline="Nothing in the Backlog yet."

--- a/src/Glasswork.App/Pages/MyDayPage.xaml
+++ b/src/Glasswork.App/Pages/MyDayPage.xaml
@@ -52,6 +52,7 @@
 
         <!-- Today's tasks header -->
         <TextBlock x:Name="TodayHeader" Grid.Row="1" Text="Today's tasks"
+                   AutomationProperties.AutomationId="MyDayTodayHeader"
                    Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,16,0,8" />
 
         <!-- Clipboard hint: brief feedback when an agent-command line is copied -->
@@ -67,6 +68,7 @@
         <ListView
             Grid.Row="2"
             x:Name="TodayList"
+            AutomationProperties.AutomationId="MyDayTaskList"
             ItemsSource="{x:Bind ViewModel.TodayTasks}"
             SelectionMode="Single"
             IsItemClickEnabled="False"
@@ -234,6 +236,7 @@
         <!-- Empty state: shown when My Day has no tasks. -->
         <controls:EmptyState
             x:Name="EmptyStateView"
+            AutomationProperties.AutomationId="MyDayEmptyState"
             Grid.Row="2"
             Margin="0,16,0,0"
             Glyph="&#xE706;"

--- a/src/Glasswork.Core/VisualVerification/VerificationLaunchOptions.cs
+++ b/src/Glasswork.Core/VisualVerification/VerificationLaunchOptions.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Glasswork.Core.VisualVerification;
+
+public sealed record VerificationLaunchOptions(
+    string? VaultPath,
+    string? UiStatePath,
+    string InstanceKey,
+    bool SkipProtocolRegistration,
+    bool SkipUpdateCheck)
+{
+    public const string VaultPathVariable = "GLASSWORK_VERIFY_VAULT_PATH";
+    public const string UiStatePathVariable = "GLASSWORK_VERIFY_UI_STATE_PATH";
+    public const string InstanceKeyVariable = "GLASSWORK_VERIFY_INSTANCE_KEY";
+    public const string SkipProtocolRegistrationVariable = "GLASSWORK_SKIP_PROTOCOL_REGISTRATION";
+    public const string SkipUpdateCheckVariable = "GLASSWORK_SKIP_UPDATE_CHECK";
+
+    public bool IsVerificationRun =>
+        !string.IsNullOrWhiteSpace(VaultPath) ||
+        !string.IsNullOrWhiteSpace(UiStatePath) ||
+        !string.IsNullOrWhiteSpace(InstanceKey) && InstanceKey != "main" ||
+        SkipProtocolRegistration ||
+        SkipUpdateCheck;
+
+    public static VerificationLaunchOptions FromProcessEnvironment() =>
+        FromEnvironment(ToStringDictionary(Environment.GetEnvironmentVariables()));
+
+    public static VerificationLaunchOptions FromEnvironment(IReadOnlyDictionary<string, string?> environment)
+    {
+        var vaultPath = Read(environment, VaultPathVariable);
+        var uiStatePath = Read(environment, UiStatePathVariable);
+        var instanceKey = Read(environment, InstanceKeyVariable) ?? "main";
+
+        var explicitSkipProtocol = ReadBool(environment, SkipProtocolRegistrationVariable);
+        var explicitSkipUpdate = ReadBool(environment, SkipUpdateCheckVariable);
+
+        var isVerificationRun =
+            !string.IsNullOrWhiteSpace(vaultPath) ||
+            !string.IsNullOrWhiteSpace(uiStatePath) ||
+            instanceKey != "main";
+
+        return new VerificationLaunchOptions(
+            vaultPath,
+            uiStatePath,
+            instanceKey,
+            explicitSkipProtocol || isVerificationRun,
+            explicitSkipUpdate || isVerificationRun);
+    }
+
+    private static string? Read(IReadOnlyDictionary<string, string?> environment, string key)
+    {
+        if (environment.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value))
+            return value;
+
+        foreach (var entry in environment)
+        {
+            if (string.Equals(entry.Key, key, StringComparison.OrdinalIgnoreCase) &&
+                !string.IsNullOrWhiteSpace(entry.Value))
+                return entry.Value;
+        }
+
+        return null;
+    }
+
+    private static bool ReadBool(IReadOnlyDictionary<string, string?> environment, string key)
+    {
+        var value = Read(environment, key);
+        return value is not null &&
+               (value == "1" ||
+                value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+                value.Equals("yes", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static Dictionary<string, string?> ToStringDictionary(IDictionary source)
+    {
+        var result = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (DictionaryEntry entry in source)
+        {
+            if (entry.Key is string key)
+                result[key] = entry.Value as string;
+        }
+        return result;
+    }
+}

--- a/src/Glasswork.Core/VisualVerification/VisualVerificationScenario.cs
+++ b/src/Glasswork.Core/VisualVerification/VisualVerificationScenario.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Glasswork.Core.Models;
+
+namespace Glasswork.Core.VisualVerification;
+
+public sealed partial class VisualVerificationScenario
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+    };
+
+    public string Name { get; init; } = string.Empty;
+    public string? StartUri { get; init; }
+    public int LaunchTimeoutSeconds { get; init; } = 20;
+    public int InitialWaitMilliseconds { get; init; } = 800;
+    public List<VisualVerificationTask> Tasks { get; init; } = [];
+    public List<VisualVerificationAction> Actions { get; init; } = [];
+    public List<VisualVerificationCapture> Captures { get; init; } = [];
+
+    public static VisualVerificationScenario FromFile(string path) =>
+        FromJson(File.ReadAllText(path));
+
+    public static VisualVerificationScenario FromJson(string json)
+    {
+        var scenario = JsonSerializer.Deserialize<VisualVerificationScenario>(json, JsonOptions)
+            ?? throw new FormatException("Scenario JSON did not deserialize to an object.");
+
+        scenario.Validate();
+        return scenario;
+    }
+
+    public void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(Name))
+            throw new FormatException("Scenario requires a non-empty name.");
+        if (Captures.Count == 0)
+            throw new FormatException("Scenario requires at least one capture.");
+        if (LaunchTimeoutSeconds <= 0)
+            throw new FormatException("launchTimeoutSeconds must be greater than zero.");
+        if (InitialWaitMilliseconds < 0)
+            throw new FormatException("initialWaitMilliseconds must not be negative.");
+
+        foreach (var task in Tasks)
+        {
+            if (string.IsNullOrWhiteSpace(task.Id))
+                throw new FormatException("Every scenario task requires a non-empty id.");
+            if (!IsSafeTaskId(task.Id))
+                throw new FormatException($"Scenario task id '{task.Id}' must be a safe filename slug.");
+            if (string.IsNullOrWhiteSpace(task.Title))
+                throw new FormatException($"Scenario task '{task.Id}' requires a non-empty title.");
+            foreach (var subtask in task.Subtasks)
+            {
+                if (string.IsNullOrWhiteSpace(subtask.Text))
+                    throw new FormatException($"Scenario task '{task.Id}' contains a subtask without text.");
+            }
+        }
+
+        foreach (var action in Actions)
+        {
+            if (string.IsNullOrWhiteSpace(action.Type))
+                throw new FormatException("Every scenario action requires a non-empty type.");
+        }
+
+        foreach (var capture in Captures)
+        {
+            if (string.IsNullOrWhiteSpace(capture.Name))
+                throw new FormatException("Every scenario capture requires a non-empty name.");
+        }
+    }
+
+    private static bool IsSafeTaskId(string taskId)
+    {
+        var trimmed = taskId.Trim();
+        return trimmed == taskId
+            && trimmed is not "." and not ".."
+            && SafeTaskIdRegex().IsMatch(trimmed);
+    }
+
+    [GeneratedRegex(@"^[A-Za-z0-9][A-Za-z0-9._-]*$")]
+    private static partial Regex SafeTaskIdRegex();
+}
+
+public sealed class VisualVerificationTask
+{
+    public string Id { get; init; } = string.Empty;
+    public string Title { get; init; } = string.Empty;
+    public string Status { get; init; } = GlassworkTask.Statuses.Todo;
+    public string Priority { get; init; } = GlassworkTask.Priorities.Medium;
+    public string? Description { get; init; }
+    public string? Notes { get; init; }
+    public string? Due { get; init; }
+    public string? MyDay { get; init; }
+    public string? Parent { get; init; }
+    public List<VisualVerificationSubtask> Subtasks { get; init; } = [];
+    public List<VisualVerificationArtifact> Artifacts { get; init; } = [];
+
+    public GlassworkTask ToGlassworkTask(DateTime today)
+    {
+        var task = new GlassworkTask
+        {
+            Id = Id,
+            Title = Title,
+            Status = Status,
+            Priority = Priority,
+            Created = today.Date,
+            Due = ParseScenarioDate(Due, today),
+            MyDay = ParseScenarioDate(MyDay, today),
+            Parent = Parent,
+            Description = Description ?? string.Empty,
+            Notes = Notes ?? string.Empty,
+        };
+
+        foreach (var subtask in Subtasks)
+        {
+            task.Subtasks.Add(subtask.ToSubTask(today));
+        }
+
+        return task;
+    }
+
+    internal static DateTime? ParseScenarioDate(string? value, DateTime today)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "today" => today.Date,
+            "yesterday" => today.Date.AddDays(-1),
+            "tomorrow" => today.Date.AddDays(1),
+            _ => DateTime.TryParse(value, out var parsed)
+                ? parsed.Date
+                : throw new FormatException($"Invalid scenario date '{value}'. Use yyyy-MM-dd, today, yesterday, or tomorrow.")
+        };
+    }
+}
+
+public sealed class VisualVerificationSubtask
+{
+    public string Text { get; init; } = string.Empty;
+    public bool IsCompleted { get; init; }
+    public string? Status { get; init; }
+    public Dictionary<string, string> Metadata { get; init; } = [];
+    public string? Notes { get; init; }
+    public string? Due { get; init; }
+    public string? MyDay { get; init; }
+
+    public SubTask ToSubTask(DateTime today)
+    {
+        var metadata = new Dictionary<string, string>(Metadata, StringComparer.Ordinal);
+        if (Due is not null)
+            metadata["due"] = VisualVerificationTask.ParseScenarioDate(Due, today)!.Value.ToString("yyyy-MM-dd");
+        if (MyDay is not null)
+            metadata["my_day"] = VisualVerificationTask.ParseScenarioDate(MyDay, today)!.Value.ToString("yyyy-MM-dd");
+
+        return new SubTask
+        {
+            Text = Text,
+            IsCompleted = IsCompleted,
+            Status = Status,
+            Metadata = metadata,
+            Notes = Notes ?? string.Empty,
+        };
+    }
+}
+
+public sealed class VisualVerificationArtifact
+{
+    public string Name { get; init; } = string.Empty;
+    public string Markdown { get; init; } = string.Empty;
+}
+
+public sealed class VisualVerificationAction
+{
+    public string Type { get; init; } = string.Empty;
+    public string? AutomationId { get; init; }
+    public string? Name { get; init; }
+    public string? Value { get; init; }
+    public int TimeoutMilliseconds { get; init; } = 5000;
+}
+
+public sealed class VisualVerificationCapture
+{
+    public string Name { get; init; } = string.Empty;
+    public int WaitMilliseconds { get; init; }
+}

--- a/tests/Glasswork.Tests/ArtifactWatcherServiceTests.cs
+++ b/tests/Glasswork.Tests/ArtifactWatcherServiceTests.cs
@@ -98,7 +98,12 @@ public class ArtifactWatcherServiceTests
 
         using var watcher = new ArtifactWatcherService(_tempDir, TimeSpan.FromMilliseconds(150));
         int count = 0;
-        watcher.ArtifactChanged += (_, _) => Interlocked.Increment(ref count);
+        var signal = new ManualResetEventSlim(false);
+        watcher.ArtifactChanged += (_, _) =>
+        {
+            Interlocked.Increment(ref count);
+            signal.Set();
+        };
 
         watcher.Start();
         var path = Path.Combine(artifactsDir, "plan.md");
@@ -107,7 +112,8 @@ public class ArtifactWatcherServiceTests
             File.WriteAllText(path, $"# Plan v{i}");
         }
 
-        Thread.Sleep(700); // > quiet period
+        Assert.IsTrue(signal.Wait(TimeSpan.FromSeconds(5)), "At least one event must fire");
+        Thread.Sleep(500); // allow any duplicate debounced tick to arrive
         Assert.IsTrue(count >= 1, "At least one event must fire");
         Assert.IsTrue(count <= 2, $"Burst must coalesce — got {count} events");
     }

--- a/tests/Glasswork.Tests/BacklinkIndexIncrementalTests.cs
+++ b/tests/Glasswork.Tests/BacklinkIndexIncrementalTests.cs
@@ -309,7 +309,12 @@ public class BacklinksWatcherTests
 
         using var w = new BacklinksWatcher(_vault, idx, TimeSpan.FromMilliseconds(150));
         int count = 0;
-        w.BacklinksChanged += (_, _) => Interlocked.Increment(ref count);
+        var signal = new ManualResetEventSlim(false);
+        w.BacklinksChanged += (_, _) =>
+        {
+            Interlocked.Increment(ref count);
+            signal.Set();
+        };
         w.Start();
 
         for (int i = 0; i < 5; i++)
@@ -318,7 +323,8 @@ public class BacklinksWatcherTests
             Thread.Sleep(20);
         }
 
-        Thread.Sleep(800); // > quiet period
+        Assert.IsTrue(signal.Wait(TimeSpan.FromSeconds(5)), $"At least one event must fire (got {count})");
+        Thread.Sleep(500); // allow any duplicate debounced tick to arrive
         Assert.IsTrue(count >= 1, $"At least one event must fire (got {count})");
         Assert.IsTrue(count <= 2, $"Burst must coalesce — got {count} events");
     }

--- a/tests/Glasswork.Tests/VerificationLaunchOptionsTests.cs
+++ b/tests/Glasswork.Tests/VerificationLaunchOptionsTests.cs
@@ -1,0 +1,40 @@
+using Glasswork.Core.VisualVerification;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class VerificationLaunchOptionsTests
+{
+    [TestMethod]
+    public void FromEnvironment_WhenUnset_UsesProductionDefaults()
+    {
+        var options = VerificationLaunchOptions.FromEnvironment(new Dictionary<string, string?>());
+
+        Assert.IsFalse(options.IsVerificationRun);
+        Assert.IsNull(options.VaultPath);
+        Assert.IsNull(options.UiStatePath);
+        Assert.AreEqual("main", options.InstanceKey);
+        Assert.IsFalse(options.SkipProtocolRegistration);
+        Assert.IsFalse(options.SkipUpdateCheck);
+    }
+
+    [TestMethod]
+    public void FromEnvironment_WhenVerificationPathsAreSet_IsolatesLaunchAndSkipsSideEffects()
+    {
+        var env = new Dictionary<string, string?>
+        {
+            [VerificationLaunchOptions.VaultPathVariable] = @"C:\tmp\glasswork-vault\wiki\todo",
+            [VerificationLaunchOptions.UiStatePathVariable] = @"C:\tmp\glasswork-ui-state.json",
+            [VerificationLaunchOptions.InstanceKeyVariable] = "visual-123",
+        };
+
+        var options = VerificationLaunchOptions.FromEnvironment(env);
+
+        Assert.IsTrue(options.IsVerificationRun);
+        Assert.AreEqual(@"C:\tmp\glasswork-vault\wiki\todo", options.VaultPath);
+        Assert.AreEqual(@"C:\tmp\glasswork-ui-state.json", options.UiStatePath);
+        Assert.AreEqual("visual-123", options.InstanceKey);
+        Assert.IsTrue(options.SkipProtocolRegistration);
+        Assert.IsTrue(options.SkipUpdateCheck);
+    }
+}

--- a/tests/Glasswork.Tests/VisualVerificationScenarioTests.cs
+++ b/tests/Glasswork.Tests/VisualVerificationScenarioTests.cs
@@ -1,0 +1,82 @@
+using Glasswork.Core.VisualVerification;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class VisualVerificationScenarioTests
+{
+    [TestMethod]
+    public void FromJson_LoadsTasksActionsAndCaptures()
+    {
+        const string json = """
+        {
+          "name": "backlog smoke",
+          "startUri": "glasswork://backlog",
+          "tasks": [
+            {
+              "id": "verify-backlog-task",
+              "title": "Verify backlog task",
+              "description": "Shows up in Backlog.",
+              "status": "todo",
+              "priority": "high",
+              "subtasks": [
+                { "text": "First visible subtask", "status": "in_progress" }
+              ]
+            }
+          ],
+          "actions": [
+            { "type": "wait-for", "name": "Verify backlog task" }
+          ],
+          "captures": [
+            { "name": "backlog" }
+          ]
+        }
+        """;
+
+        var scenario = VisualVerificationScenario.FromJson(json);
+
+        Assert.AreEqual("backlog smoke", scenario.Name);
+        Assert.AreEqual("glasswork://backlog", scenario.StartUri);
+        Assert.AreEqual(1, scenario.Tasks.Count);
+        Assert.AreEqual("verify-backlog-task", scenario.Tasks[0].Id);
+        Assert.AreEqual("First visible subtask", scenario.Tasks[0].Subtasks[0].Text);
+        Assert.AreEqual("wait-for", scenario.Actions[0].Type);
+        Assert.AreEqual("backlog", scenario.Captures[0].Name);
+    }
+
+    [TestMethod]
+    public void FromJson_TaskWithoutId_Throws()
+    {
+        const string json = """
+        {
+          "name": "invalid",
+          "tasks": [
+            { "title": "Missing ID" }
+          ],
+          "captures": [
+            { "name": "screen" }
+          ]
+        }
+        """;
+
+        Assert.ThrowsExactly<FormatException>(() => VisualVerificationScenario.FromJson(json));
+    }
+
+    [TestMethod]
+    public void FromJson_TaskIdWithPathSyntax_Throws()
+    {
+        const string json = """
+        {
+          "name": "invalid",
+          "tasks": [
+            { "id": "..\\outside", "title": "Escapes sandbox" }
+          ],
+          "captures": [
+            { "name": "screen" }
+          ]
+        }
+        """;
+
+        Assert.ThrowsExactly<FormatException>(() => VisualVerificationScenario.FromJson(json));
+    }
+}

--- a/tools/Glasswork.VisualVerification/Glasswork.VisualVerification.csproj
+++ b/tools/Glasswork.VisualVerification/Glasswork.VisualVerification.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Glasswork.Core\Glasswork.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Glasswork.VisualVerification/Program.cs
+++ b/tools/Glasswork.VisualVerification/Program.cs
@@ -1,0 +1,465 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Automation;
+using Glasswork.Core.Services;
+using Glasswork.Core.VisualVerification;
+
+var exitCode = await VisualVerificationRunner.RunAsync(args);
+return exitCode;
+
+internal static partial class VisualVerificationRunner
+{
+    private const string AppRelativePath = @"src\Glasswork.App\Glasswork.csproj";
+    private const string AppExeRelativePath = @"src\Glasswork.App\bin\x64\Debug\net10.0-windows10.0.26100.0\win-x64\Glasswork.exe";
+
+    public static async Task<int> RunAsync(string[] args)
+    {
+        try
+        {
+            var options = RunnerOptions.Parse(args);
+            var scenario = VisualVerificationScenario.FromFile(options.ScenarioPath);
+            Directory.CreateDirectory(options.OutDir);
+
+            if (!options.NoBuild)
+                await RunProcessAsync("dotnet", $"build \"{Path.Combine(options.RepoRoot, AppRelativePath)}\" -c Debug -p:Platform=x64 --nologo -v quiet -tl:off", options.RepoRoot);
+
+            var appExe = Path.Combine(options.RepoRoot, AppExeRelativePath);
+            if (!File.Exists(appExe))
+                throw new FileNotFoundException($"Glasswork dev executable not found. Build first or remove --no-build. Expected: {appExe}", appExe);
+
+            var workDir = Path.Combine(Path.GetTempPath(), "glasswork-visual-work-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(workDir);
+
+            try
+            {
+                var result = await RunScenarioAsync(scenario, options, appExe, workDir);
+                var resultPath = Path.Combine(options.OutDir, "result.json");
+                File.WriteAllText(resultPath, JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true }));
+                Console.WriteLine(resultPath);
+                return 0;
+            }
+            finally
+            {
+                if (!options.KeepWorkingDirectory && Directory.Exists(workDir))
+                    Directory.Delete(workDir, recursive: true);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+    }
+
+    private static async Task<VerificationResult> RunScenarioAsync(
+        VisualVerificationScenario scenario,
+        RunnerOptions options,
+        string appExe,
+        string workDir)
+    {
+        var vaultRoot = Path.Combine(workDir, "Vault");
+        var todoPath = Path.Combine(vaultRoot, "wiki", "todo");
+        var uiStatePath = Path.Combine(workDir, "ui-state.json");
+        Directory.CreateDirectory(todoPath);
+
+        MaterializeVault(scenario, vaultRoot, todoPath);
+
+        var instanceKey = "visual-" + Guid.NewGuid().ToString("N");
+        using var process = LaunchApp(appExe, scenario.StartUri, todoPath, uiStatePath, instanceKey);
+
+        try
+        {
+            var hwnd = WaitForWindow(process, TimeSpan.FromSeconds(scenario.LaunchTimeoutSeconds));
+            await Task.Delay(scenario.InitialWaitMilliseconds);
+
+            foreach (var action in scenario.Actions)
+            {
+                PerformAction(hwnd, action);
+            }
+
+            var captures = new List<CaptureResult>();
+            foreach (var capture in scenario.Captures)
+            {
+                if (capture.WaitMilliseconds > 0)
+                    await Task.Delay(capture.WaitMilliseconds);
+
+                var path = Path.Combine(options.OutDir, SanitizeFileName(capture.Name) + ".png");
+                CaptureWindow(hwnd, path);
+                var imageStats = AnalyzeImage(path);
+                if (imageStats.UniqueSampledColors <= 1)
+                    throw new InvalidOperationException($"Capture '{capture.Name}' appears blank or uniform: {path}");
+
+                captures.Add(new CaptureResult(capture.Name, path, imageStats.Width, imageStats.Height, imageStats.UniqueSampledColors));
+            }
+
+            return new VerificationResult(
+                scenario.Name,
+                options.OutDir,
+                todoPath,
+                uiStatePath,
+                instanceKey,
+                captures);
+        }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync();
+            }
+        }
+    }
+
+    private static void MaterializeVault(VisualVerificationScenario scenario, string vaultRoot, string todoPath)
+    {
+        var vault = new VaultService(todoPath);
+        var today = DateTime.Today;
+
+        foreach (var task in scenario.Tasks)
+        {
+            vault.Save(task.ToGlassworkTask(today));
+
+            if (task.Artifacts.Count == 0) continue;
+            var artifactsDir = Path.Combine(vaultRoot, "wiki", "todo", task.Id + ".artifacts");
+            Directory.CreateDirectory(artifactsDir);
+            foreach (var artifact in task.Artifacts)
+            {
+                if (string.IsNullOrWhiteSpace(artifact.Name))
+                    throw new FormatException($"Artifact on task '{task.Id}' requires a non-empty name.");
+
+                var fileName = artifact.Name.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
+                    ? artifact.Name
+                    : artifact.Name + ".md";
+                File.WriteAllText(Path.Combine(artifactsDir, SanitizeFileName(fileName)), artifact.Markdown);
+            }
+        }
+    }
+
+    private static Process LaunchApp(string appExe, string? startUri, string vaultPath, string uiStatePath, string instanceKey)
+    {
+        var psi = new ProcessStartInfo(appExe)
+        {
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(appExe)!,
+        };
+
+        if (!string.IsNullOrWhiteSpace(startUri))
+            psi.ArgumentList.Add(startUri);
+
+        psi.Environment[VerificationLaunchOptions.VaultPathVariable] = vaultPath;
+        psi.Environment[VerificationLaunchOptions.UiStatePathVariable] = uiStatePath;
+        psi.Environment[VerificationLaunchOptions.InstanceKeyVariable] = instanceKey;
+        psi.Environment[VerificationLaunchOptions.SkipProtocolRegistrationVariable] = "1";
+        psi.Environment[VerificationLaunchOptions.SkipUpdateCheckVariable] = "1";
+
+        return Process.Start(psi) ?? throw new InvalidOperationException("Failed to launch Glasswork.");
+    }
+
+    private static IntPtr WaitForWindow(Process process, TimeSpan timeout)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            if (process.HasExited)
+                throw new InvalidOperationException($"Glasswork exited before showing a window. Exit code: {process.ExitCode}");
+
+            process.Refresh();
+            if (process.MainWindowHandle != IntPtr.Zero)
+                return process.MainWindowHandle;
+
+            Thread.Sleep(250);
+        }
+
+        throw new TimeoutException($"Glasswork did not show a window within {timeout.TotalSeconds:0}s.");
+    }
+
+    private static void PerformAction(IntPtr hwnd, VisualVerificationAction action)
+    {
+        switch (action.Type.Trim().ToLowerInvariant())
+        {
+            case "wait-for":
+                _ = WaitForElement(hwnd, action);
+                return;
+            case "invoke":
+                InvokeElement(WaitForElement(hwnd, action));
+                return;
+            case "set-value":
+                SetElementValue(WaitForElement(hwnd, action), action.Value ?? string.Empty);
+                return;
+            case "select":
+                SelectElement(WaitForElement(hwnd, action));
+                return;
+            default:
+                throw new FormatException($"Unsupported visual verification action type '{action.Type}'.");
+        }
+    }
+
+    private static AutomationElement WaitForElement(IntPtr hwnd, VisualVerificationAction action)
+    {
+        var timeout = TimeSpan.FromMilliseconds(action.TimeoutMilliseconds <= 0 ? 5000 : action.TimeoutMilliseconds);
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            var root = AutomationElement.FromHandle(hwnd);
+            var element = FindElement(root, action);
+            if (element is not null)
+                return element;
+
+            Thread.Sleep(200);
+        }
+
+        var selector = action.AutomationId is not null
+            ? $"AutomationId='{action.AutomationId}'"
+            : $"Name='{action.Name}'";
+        throw new TimeoutException($"Timed out waiting for UI element with {selector}.");
+    }
+
+    private static AutomationElement? FindElement(AutomationElement root, VisualVerificationAction action)
+    {
+        if (!string.IsNullOrWhiteSpace(action.AutomationId))
+        {
+            var condition = new PropertyCondition(AutomationElement.AutomationIdProperty, action.AutomationId);
+            var match = root.FindFirst(TreeScope.Descendants, condition);
+            if (match is not null) return match;
+        }
+
+        if (!string.IsNullOrWhiteSpace(action.Name))
+        {
+            var condition = new PropertyCondition(AutomationElement.NameProperty, action.Name);
+            return root.FindFirst(TreeScope.Descendants, condition);
+        }
+
+        throw new FormatException("UI action requires automationId or name.");
+    }
+
+    private static void InvokeElement(AutomationElement element)
+    {
+        if (element.TryGetCurrentPattern(InvokePattern.Pattern, out var pattern) &&
+            pattern is InvokePattern invoke)
+        {
+            invoke.Invoke();
+            return;
+        }
+
+        throw new InvalidOperationException($"Element '{element.Current.Name}' does not support InvokePattern.");
+    }
+
+    private static void SetElementValue(AutomationElement element, string value)
+    {
+        if (element.TryGetCurrentPattern(ValuePattern.Pattern, out var pattern) &&
+            pattern is ValuePattern valuePattern)
+        {
+            valuePattern.SetValue(value);
+            return;
+        }
+
+        throw new InvalidOperationException($"Element '{element.Current.Name}' does not support ValuePattern.");
+    }
+
+    private static void SelectElement(AutomationElement element)
+    {
+        if (element.TryGetCurrentPattern(SelectionItemPattern.Pattern, out var selectionPattern) &&
+            selectionPattern is SelectionItemPattern selectionItem)
+        {
+            selectionItem.Select();
+            return;
+        }
+
+        InvokeElement(element);
+    }
+
+    private static async Task RunProcessAsync(string fileName, string arguments, string workingDirectory)
+    {
+        var psi = new ProcessStartInfo(fileName, arguments)
+        {
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+        };
+        using var process = Process.Start(psi) ?? throw new InvalidOperationException($"Failed to start {fileName}.");
+        var stdout = await process.StandardOutput.ReadToEndAsync();
+        var stderr = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"{fileName} exited with {process.ExitCode}.\n{stdout}\n{stderr}");
+    }
+
+    private static void CaptureWindow(IntPtr hwnd, string path)
+    {
+        if (DwmGetWindowAttribute(hwnd, DwmWindowAttributeExtendedFrameBounds, out var rect, Marshal.SizeOf<Rect>()) != 0)
+        {
+            if (!GetWindowRect(hwnd, out rect))
+                throw new InvalidOperationException("GetWindowRect failed.");
+        }
+
+        var width = rect.Right - rect.Left;
+        var height = rect.Bottom - rect.Top;
+        if (width <= 0 || height <= 0)
+            throw new InvalidOperationException("Window has zero size.");
+
+        using var bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+        using (var graphics = Graphics.FromImage(bitmap))
+        {
+            var hdc = graphics.GetHdc();
+            try
+            {
+                if (!PrintWindow(hwnd, hdc, PrintWindowRenderFullContent))
+                    throw new InvalidOperationException("PrintWindow returned false.");
+            }
+            finally
+            {
+                graphics.ReleaseHdc(hdc);
+            }
+        }
+
+        bitmap.Save(path, ImageFormat.Png);
+    }
+
+    private static ImageStats AnalyzeImage(string path)
+    {
+        using var bitmap = new Bitmap(path);
+        var colors = new HashSet<int>();
+        var stepX = Math.Max(1, bitmap.Width / 80);
+        var stepY = Math.Max(1, bitmap.Height / 80);
+        for (var y = 0; y < bitmap.Height; y += stepY)
+        {
+            for (var x = 0; x < bitmap.Width; x += stepX)
+                colors.Add(bitmap.GetPixel(x, y).ToArgb());
+        }
+
+        return new ImageStats(bitmap.Width, bitmap.Height, colors.Count);
+    }
+
+    private static string SanitizeFileName(string value) =>
+        InvalidFileNameCharsRegex().Replace(value.Trim(), "-");
+
+    [GeneratedRegex(@"[\\/:*?""<>|]+")]
+    private static partial Regex InvalidFileNameCharsRegex();
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool PrintWindow(IntPtr hwnd, IntPtr hdcBlt, uint nFlags);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetWindowRect(IntPtr hWnd, out Rect lpRect);
+
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out Rect pvAttribute, int cbAttribute);
+
+    private const uint PrintWindowRenderFullContent = 2;
+    private const int DwmWindowAttributeExtendedFrameBounds = 9;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Rect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+}
+
+internal sealed record RunnerOptions(
+    string ScenarioPath,
+    string RepoRoot,
+    string OutDir,
+    bool NoBuild,
+    bool KeepWorkingDirectory)
+{
+    public static RunnerOptions Parse(string[] args)
+    {
+        string? scenario = null;
+        string? repoRoot = null;
+        string? outDir = null;
+        var noBuild = false;
+        var keepWorkingDir = false;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--scenario":
+                    scenario = RequireValue(args, ref i, "--scenario");
+                    break;
+                case "--repo-root":
+                    repoRoot = RequireValue(args, ref i, "--repo-root");
+                    break;
+                case "--out-dir":
+                    outDir = RequireValue(args, ref i, "--out-dir");
+                    break;
+                case "--no-build":
+                    noBuild = true;
+                    break;
+                case "--keep-working-directory":
+                    keepWorkingDir = true;
+                    break;
+                default:
+                    throw new FormatException($"Unknown argument '{args[i]}'.");
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(scenario))
+            throw new FormatException("Usage: Glasswork.VisualVerification --scenario <path> [--repo-root <path>] [--out-dir <path>] [--no-build]");
+
+        repoRoot ??= FindRepoRoot(Environment.CurrentDirectory);
+        outDir ??= Path.Combine(
+            Path.GetTempPath(),
+            "Glasswork-visual-results-" + DateTime.Now.ToString("yyyyMMdd-HHmmss") + "-" + Guid.NewGuid().ToString("N"));
+
+        return new RunnerOptions(
+            Path.GetFullPath(scenario),
+            Path.GetFullPath(repoRoot),
+            Path.GetFullPath(outDir),
+            noBuild,
+            keepWorkingDir);
+    }
+
+    private static string RequireValue(string[] args, ref int index, string name)
+    {
+        if (index + 1 >= args.Length)
+            throw new FormatException($"{name} requires a value.");
+        index++;
+        return args[index];
+    }
+
+    private static string FindRepoRoot(string start)
+    {
+        var dir = new DirectoryInfo(start);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Glasswork.slnx")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find Glasswork.slnx. Pass --repo-root.");
+    }
+}
+
+internal sealed record VerificationResult(
+    string Scenario,
+    string OutputDirectory,
+    string VaultPath,
+    string UiStatePath,
+    string InstanceKey,
+    IReadOnlyList<CaptureResult> Captures);
+
+internal sealed record CaptureResult(
+    string Name,
+    string Path,
+    int Width,
+    int Height,
+    int UniqueSampledColors);
+
+internal sealed record ImageStats(int Width, int Height, int UniqueSampledColors);


### PR DESCRIPTION
## Summary
- add isolated verification launch mode for Glasswork App
- add scenario-based visual verification runner and PowerShell wrapper
- add Backlog smoke scenario plus AutomationIds for UI Automation
- harden startup smoke verification to use temp Vault/UI state and parallel-safe outputs
- add tests for verification launch/scenario parsing and stabilize watcher debounce tests

## Validation
- dotnet test tests\Glasswork.Tests\Glasswork.Tests.csproj --nologo -v quiet -p:UseSharedCompilation=false
- dotnet build src\Glasswork.App\Glasswork.csproj -c Debug -p:Platform=x64 --nologo -v quiet -tl:off -p:UseSharedCompilation=false
- dotnet build tools\Glasswork.VisualVerification\Glasswork.VisualVerification.csproj --nologo -v quiet -p:UseSharedCompilation=false
- pwsh -File scripts\invoke-visual-verification.ps1 -Scenario scripts\visual-verification\backlog-smoke.json -NoBuild
- pwsh -File scripts\verify-app.ps1 -NoBuild
- dual review: code-review + security-review, followed by clean re-review