### PR TITLE
Prepare Glasswork v1.4.1 release

### DIFF
--- a/docs/releases/v1.4.1.md
+++ b/docs/releases/v1.4.1.md
@@ -1,0 +1,25 @@
+# Glasswork v1.4.1
+
+MCP and agent-skill release. Glasswork now exposes a safe My Day write surface
+for agents, making Scout/OpenClaw-style daily planning possible without agents
+rewriting task files directly.
+
+## Changes
+
+- **My Day MCP write support.** Added `set_my_day`, a date-scoped direct-pin
+  tool that updates an existing task's `my_day` frontmatter while preserving the
+  task body and registering the write with `SelfWriteCoordinator`.
+- **Richer task projections for planning agents.** `list_tasks` can now include
+  `due`, `my_day`, and `in_my_day_today` fields so agents can distinguish
+  Backlog candidates, existing My Day carryover, due/overdue hard signals, and
+  virtual My Day promotion.
+- **Plan My Day skill groundwork.** Documented the new MCP surface and bumped
+  the MCP package version to `0.6.0` for the new planning-oriented tool set.
+
+## Validation
+
+- Release workflow gates run: input/version validation, release-script Pester
+  tests, Core unit tests (`Glasswork.Tests`), and a Release x64 build of the
+  Windows app.
+- MCP tests cover `set_my_day` success/error behavior, self-write marker
+  registration, and the new My Day/date projection fields.

--- a/src/Glasswork.App/Glasswork.csproj
+++ b/src/Glasswork.App/Glasswork.csproj
@@ -15,10 +15,10 @@
     <WindowsPackageType>None</WindowsPackageType>
     <Nullable>enable</Nullable>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
-    <Version>1.4.0</Version>
-    <AssemblyVersion>1.4.0.0</AssemblyVersion>
-    <FileVersion>1.4.0.0</FileVersion>
-    <InformationalVersion>1.4.0</InformationalVersion>
+    <Version>1.4.1</Version>
+    <AssemblyVersion>1.4.1.0</AssemblyVersion>
+    <FileVersion>1.4.1.0</FileVersion>
+    <InformationalVersion>1.4.1</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Glasswork.Core/Services/VaultService.cs
+++ b/src/Glasswork.Core/Services/VaultService.cs
@@ -393,6 +393,62 @@ public class VaultService
     }
 
     /// <summary>
+    /// Targeted edit: set the task-level <c>my_day</c> frontmatter key without
+    /// rewriting the task body. Preserves line endings and existing frontmatter
+    /// order when replacing an existing value.
+    /// </summary>
+    public void SetMyDay(string taskId, DateTime myDay)
+    {
+        var path = GetFilePath(taskId);
+        if (!File.Exists(path)) return;
+
+        var content = File.ReadAllText(path);
+        var newline = content.Contains("\r\n") ? "\r\n" : "\n";
+
+        var lines = content.Split('\n').Select(l => l.TrimEnd('\r')).ToList();
+        if (lines.Count == 0 || lines[0] != "---") return;
+
+        int closeIdx = -1;
+        for (int i = 1; i < lines.Count; i++)
+        {
+            if (lines[i] == "---") { closeIdx = i; break; }
+        }
+        if (closeIdx < 0) return;
+
+        var newLine = $"my_day: {myDay:yyyy-MM-dd}";
+        var myDayPattern = new System.Text.RegularExpressions.Regex(@"^my_day:\s.*$");
+        var newFront = new List<string>(closeIdx - 1);
+        int insertPos = -1;
+        for (int i = 1; i < closeIdx; i++)
+        {
+            if (myDayPattern.IsMatch(lines[i]))
+            {
+                if (insertPos < 0) insertPos = newFront.Count;
+                continue;
+            }
+            newFront.Add(lines[i]);
+        }
+        if (insertPos < 0) insertPos = newFront.Count;
+        newFront.Insert(insertPos, newLine);
+
+        var rebuilt = new List<string> { "---" };
+        rebuilt.AddRange(newFront);
+        rebuilt.Add("---");
+        for (int i = closeIdx + 1; i < lines.Count; i++) rebuilt.Add(lines[i]);
+
+        var hadTrailingNewline = content.EndsWith('\n');
+        var output = string.Join(newline, rebuilt);
+        if (hadTrailingNewline && !output.EndsWith(newline))
+            output += newline;
+
+        if (output == content) return;
+
+        _selfWrites?.RegisterWrite(path);
+        File.WriteAllText(path, output);
+        RaiseTaskWritten(taskId);
+    }
+
+    /// <summary>
     /// Targeted edit: append a new <c>### [ ] {title}</c> subtask under the <c>## Subtasks</c>
     /// section. Creates the section at end of file if missing. New subtask is placed at the
     /// bottom of the active group — immediately before the first "completed" subtask

--- a/src/Glasswork.Mcp/Glasswork.Mcp.csproj
+++ b/src/Glasswork.Mcp/Glasswork.Mcp.csproj
@@ -8,7 +8,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>glasswork-mcp</ToolCommandName>
     <PackageId>glasswork-mcp</PackageId>
-    <Version>0.5.0</Version>
+    <Version>0.6.0</Version>
     <Description>Glasswork MCP server — typed agent access to an Obsidian-backed task vault.</Description>
     <Authors>Glasswork</Authors>
     <RollForward>LatestMajor</RollForward>

--- a/src/Glasswork.Mcp/README.md
+++ b/src/Glasswork.Mcp/README.md
@@ -108,6 +108,7 @@ The `command` field must resolve to the `glasswork-mcp` binary on `PATH` (i.e., 
 | `add_artifact` | v0.3.0 | Create a task artifact file |
 | `load_context` | v0.4.0 | One-call full-context fetch: task + artifact bodies + recursive subtasks + backlinks |
 | `search_tasks` | v0.5.0 | Topic-driven task discovery — ranked, scoped, with per-hit snippets |
+| `set_my_day` | v0.6.0 | Direct-pin an existing task into My Day for a date |
 
 ### When to use which tool
 
@@ -116,6 +117,7 @@ The `command` field must resolve to the `glasswork-mcp` binary on `PATH` (i.e., 
 | Know which tasks exist right now | `list_tasks` |
 | Fetch a specific task you already know by ID | `get_task` or `load_context` |
 | Discover tasks related to a concept or keyword | `search_tasks` |
+| Add an existing task to My Day | `set_my_day` |
 | Orient before starting work on a new issue | `search_tasks` (find prior art), then `load_context` (deep-dive) |
 
 ### `search_tasks`
@@ -210,7 +212,7 @@ Results are ranked: tasks with a title match score higher than body-only matches
 }
 ```
 
-- **`fields`** (optional): when provided, each returned summary contains only the requested fields plus `id` (always included). Allowed values: `title`, `status`, `parent_id`, `path`, `created`, `priority`. Field names are case-folded, whitespace-trimmed, and de-duplicated; unknown names are silently dropped. Omitting `fields` (or passing `null` / `[]`) preserves the default shape below.
+- **`fields`** (optional): when provided, each returned summary contains only the requested fields plus `id` (always included). Allowed values: `title`, `status`, `parent_id`, `path`, `created`, `priority`, `due`, `my_day`, `in_my_day_today`. Field names are case-folded, whitespace-trimmed, and de-duplicated; unknown names are silently dropped. Omitting `fields` (or passing `null` / `[]`) preserves the default shape below.
 
 **Output (default — no `fields`)**
 
@@ -234,6 +236,21 @@ Results are ranked: tasks with a title match score higher than body-only matches
 {
   "tasks": [
     { "id": "string", "created": "yyyy-MM-dd", "priority": "medium" }
+  ]
+}
+```
+
+**Output (with `fields: ["due", "my_day", "in_my_day_today"]`)**
+
+```json
+{
+  "tasks": [
+    {
+      "id": "string",
+      "due": "yyyy-MM-dd | null",
+      "my_day": "yyyy-MM-dd | null",
+      "in_my_day_today": true
+    }
   ]
 }
 ```
@@ -321,6 +338,40 @@ Re-reads the vault and artifact folder on every call (no cache). The `artifacts`
 | `conflict` | A file with that name already exists — `add_artifact` is create-only in v1 |
 
 Artifacts are stored under `<vault>/wiki/todo/<task-id>.artifacts/<filename>`. The write is registered with `SelfWriteCoordinator` so the running Glasswork app does not raise a spurious "external change" banner.
+
+---
+
+### `set_my_day`
+
+Direct-pins an existing task into **My Day** by setting task-level `my_day` frontmatter to a date. This follows ADR 0013's date-scoped pin model: the task promotes into My Day only when `my_day` equals the user's current local date. The tool does not change due dates, priority, status, subtasks, Description, Notes, or artifacts.
+
+**Input**
+
+```json
+{
+  "task_id": "string (required) — task ID to pin",
+  "my_day": "yyyy-MM-dd (optional) — defaults to today's local date"
+}
+```
+
+**Output (success)**
+
+```json
+{
+  "task_id": "string",
+  "my_day": "yyyy-MM-dd",
+  "path": "string — todo-relative path to the updated task file, e.g. task-id.md"
+}
+```
+
+**Output (errors)**
+
+| `error` value | When |
+|---|---|
+| `not_found` | The task ID does not exist in the vault |
+| `invalid_my_day` | `my_day` is not in `yyyy-MM-dd` format |
+
+The write is registered with `SelfWriteCoordinator` so the running Glasswork app does not raise a spurious "external change" banner.
 
 ---
 
@@ -483,7 +534,7 @@ Phases instrumented in v1:
 | `yaml_parse` | `list_tasks` | Reading and parsing each file's YAML frontmatter |
 | `filter` | `list_tasks` | Applying status / parent_task_id filters |
 | `sort` | `list_tasks` | Sorting results by created date and ID |
-| `write` | `add_task`, `add_artifact` | Writing the file to disk |
+| `write` | `add_task`, `add_artifact`, `set_my_day` | Writing the file to disk |
 | `load_task` | `get_task`, `load_context` | Loading the root task from disk |
 | `scan_artifacts` | `get_task` | Enumerating the task's artifact folder |
 | `load_artifacts` | `load_context` | Reading every artifact body for the root task |

--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -100,7 +100,7 @@ public sealed class GlassworkTools
     public string ListTasks(
         [Description("Filter by status: todo, doing, or done.")] string? status = null,
         [Description("Filter by parent task ID.")] string? parent_task_id = null,
-        [Description("Optional field projection. When provided, each summary contains only these fields plus `id`. Allowed values: title, status, parent_id, path, created, priority. Unknown names are silently dropped. Case-insensitive; whitespace trimmed.")] string[]? fields = null)
+        [Description("Optional field projection. When provided, each summary contains only these fields plus `id`. Allowed values: title, status, parent_id, path, created, priority, due, my_day, in_my_day_today. Unknown names are silently dropped. Case-insensitive; whitespace trimmed.")] string[]? fields = null)
     {
         using var scope = _logger?.BeginCall("list_tasks");
         try
@@ -385,6 +385,55 @@ public sealed class GlassworkTools
         }
     }
 
+    [McpServerTool(Name = "set_my_day")]
+    [ToolPrecondition(VaultPathReadablePrecondition.PreconditionName)]
+    [Description("Direct-pin an existing task into My Day for a specific date. Defaults to today's local date when my_day is omitted.")]
+    public string SetMyDay(
+        [Description("Task ID to pin into My Day.")] string task_id,
+        [Description("Date to set as yyyy-MM-dd. Defaults to today's local date.")] string? my_day = null)
+    {
+        using var scope = _logger?.BeginCall("set_my_day");
+        try
+        {
+            var safeId = SanitizeId(task_id);
+            if (safeId is null || !_vault.Exists(safeId))
+            {
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("not_found", $"Task '{task_id}' not found."));
+            }
+
+            DateTime myDay;
+            if (string.IsNullOrWhiteSpace(my_day))
+            {
+                myDay = DateTime.Today;
+            }
+            else if (!DateTime.TryParseExact(
+                         my_day.Trim(),
+                         "yyyy-MM-dd",
+                         System.Globalization.CultureInfo.InvariantCulture,
+                         System.Globalization.DateTimeStyles.None,
+                         out myDay))
+            {
+                scope?.SetResult("error");
+                return JsonSerializer.Serialize(new ErrorResult("invalid_my_day", "my_day must be a date in yyyy-MM-dd format."));
+            }
+
+            var writeSw = Stopwatch.StartNew();
+            _vault.SetMyDay(safeId, myDay);
+            scope?.RecordPhase("write", writeSw.ElapsedMilliseconds);
+
+            return JsonSerializer.Serialize(new SetMyDayResult(
+                TaskId: safeId,
+                MyDay: myDay.ToString("yyyy-MM-dd"),
+                Path: TodoRelativeTaskPath(safeId)));
+        }
+        catch
+        {
+            scope?.SetResult("error");
+            throw;
+        }
+    }
+
     [McpServerTool(Name = "load_context")]
     [ToolPrecondition(VaultPathReadablePrecondition.PreconditionName)]
     [Description("Return a task's complete context bundle: task content + artifact bodies + recursive subtasks (to depth) + backlinks. Single-call replacement for chaining get_task + N artifact reads + list_tasks + backlink discovery. Read-only.")]
@@ -622,7 +671,7 @@ public sealed class GlassworkTools
 
     private static readonly HashSet<string> AllowedSummaryFields = new(StringComparer.Ordinal)
     {
-        "title", "status", "parent_id", "path", "created", "priority",
+        "title", "status", "parent_id", "path", "created", "priority", "due", "my_day", "in_my_day_today",
     };
 
     /// <summary>
@@ -663,6 +712,13 @@ public sealed class GlassworkTools
         if (fields.Contains("path")) dict["path"] = TodoRelativeTaskPath(task.Id);
         if (fields.Contains("created")) dict["created"] = task.Created.ToString("yyyy-MM-dd");
         if (fields.Contains("priority")) dict["priority"] = task.Priority;
+        if (fields.Contains("due")) dict["due"] = task.Due?.ToString("yyyy-MM-dd");
+        if (fields.Contains("my_day")) dict["my_day"] = task.MyDay?.ToString("yyyy-MM-dd");
+        if (fields.Contains("in_my_day_today"))
+            dict["in_my_day_today"] = MyDayPromotionPolicy.IsTaskInMyDayToday(
+                task,
+                DateOnly.FromDateTime(DateTime.Today),
+                new HashSet<string>(StringComparer.Ordinal));
         return dict;
     }
 
@@ -734,6 +790,11 @@ public sealed class GlassworkTools
         [property: JsonPropertyName("artifacts")] List<ArtifactInfo> Artifacts);
 
     private sealed record AddArtifactResult(
+        [property: JsonPropertyName("path")] string Path);
+
+    private sealed record SetMyDayResult(
+        [property: JsonPropertyName("task_id")] string TaskId,
+        [property: JsonPropertyName("my_day")] string MyDay,
         [property: JsonPropertyName("path")] string Path);
 
     private sealed record ErrorResult(

--- a/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
@@ -436,6 +436,54 @@ public class GlassworkToolsTests
     }
 
     [TestMethod]
+    public void ListTasks_FieldsDueAndMyDay_ReturnsIsoDates()
+    {
+        var task = new GlassworkTask
+        {
+            Id = "dated-task",
+            Title = "Dated task",
+            Status = GlassworkTask.Statuses.Todo,
+            Created = new DateTime(2026, 6, 1),
+            Due = new DateTime(2026, 6, 8),
+            MyDay = new DateTime(2026, 6, 9),
+        };
+        _vault.Save(task);
+
+        var json = _tools.ListTasks(fields: new[] { "due", "my_day" });
+        var first = JsonDocument.Parse(json).RootElement.GetProperty("tasks")[0];
+
+        Assert.AreEqual("2026-06-08", first.GetProperty("due").GetString());
+        Assert.AreEqual("2026-06-09", first.GetProperty("my_day").GetString());
+    }
+
+    [TestMethod]
+    public void ListTasks_FieldsInMyDayToday_UsesPromotionPolicy()
+    {
+        _vault.Save(new GlassworkTask
+        {
+            Id = "today-pin",
+            Title = "Today pin",
+            Status = GlassworkTask.Statuses.Todo,
+            MyDay = DateTime.Today,
+        });
+        _vault.Save(new GlassworkTask
+        {
+            Id = "not-today",
+            Title = "Not today",
+            Status = GlassworkTask.Statuses.Todo,
+        });
+
+        var json = _tools.ListTasks(fields: new[] { "title", "in_my_day_today" });
+        var tasks = JsonDocument.Parse(json).RootElement.GetProperty("tasks");
+        var byTitle = tasks.EnumerateArray().ToDictionary(
+            t => t.GetProperty("title").GetString()!,
+            t => t.GetProperty("in_my_day_today").GetBoolean());
+
+        Assert.IsTrue(byTitle["Today pin"]);
+        Assert.IsFalse(byTitle["Not today"]);
+    }
+
+    [TestMethod]
     public void ListTasks_ParentIdInOutput_IsNullWhenNoParent()
     {
         _tools.AddTask("Standalone Task");
@@ -894,6 +942,74 @@ public class GlassworkToolsTests
 
         Assert.AreEqual(1, artifacts.GetArrayLength());
         Assert.AreEqual("research.md", artifacts[0].GetProperty("filename").GetString());
+    }
+
+    // ───────────────────────────── set_my_day ────────────────────────────
+
+    [TestMethod]
+    public void SetMyDay_DefaultDate_DirectPinsTaskForToday()
+    {
+        var addJson = _tools.AddTask("Plan Today");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var json = _tools.SetMyDay(taskId);
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual(taskId, doc.RootElement.GetProperty("task_id").GetString());
+        Assert.AreEqual(DateTime.Today.ToString("yyyy-MM-dd"), doc.RootElement.GetProperty("my_day").GetString());
+
+        var task = _vault.Load(taskId)!;
+        Assert.AreEqual(DateTime.Today, task.MyDay);
+    }
+
+    [TestMethod]
+    public void SetMyDay_ExplicitDate_StoresRequestedDate()
+    {
+        var addJson = _tools.AddTask("Plan Later");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var json = _tools.SetMyDay(taskId, "2026-06-10");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("2026-06-10", doc.RootElement.GetProperty("my_day").GetString());
+        Assert.AreEqual(new DateTime(2026, 6, 10), _vault.Load(taskId)!.MyDay);
+    }
+
+    [TestMethod]
+    public void SetMyDay_InvalidDate_ReturnsStructuredError()
+    {
+        var addJson = _tools.AddTask("Invalid Date Pin");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var json = _tools.SetMyDay(taskId, "06/10/2026");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("invalid_my_day", doc.RootElement.GetProperty("error").GetString());
+        Assert.IsFalse(_vault.Load(taskId)!.MyDay.HasValue);
+    }
+
+    [TestMethod]
+    public void SetMyDay_NotFound_ReturnsStructuredError()
+    {
+        var json = _tools.SetMyDay("missing-task");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("not_found", doc.RootElement.GetProperty("error").GetString());
+    }
+
+    [TestMethod]
+    public void SetMyDay_RegistersSelfWrite_MarkerFileContainsTaskPath()
+    {
+        var addJson = _tools.AddTask("SelfWrite My Day Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        _tools.SetMyDay(taskId, "2026-06-10");
+
+        var markerFile = Path.Combine(TasksDir, ".glasswork", "recent-writes.json");
+        Assert.IsTrue(File.Exists(markerFile), "SelfWriteCoordinator must write its marker file when set_my_day updates a task.");
+        var markerContent = File.ReadAllText(markerFile);
+        StringAssert.Contains(markerContent, $"{taskId}.md",
+            "Marker file must reference the written task path.");
     }
 
     // ───────────────────────────── load_context ──────────────────────────


### PR DESCRIPTION
## Summary
- add My Day MCP support for `set_my_day` and planning-oriented list projections
- bump Glasswork.App to 1.4.1 and Glasswork.Mcp to 0.6.0
- add `docs/releases/v1.4.1.md` release notes

## Validation
- `. .\scripts\Validate-ReleasePublication.ps1; Test-ReleasePublicationInputs -RepoRoot (Get-Location) -Version 1.4.1`
- `dotnet test tests\Glasswork.Mcp.Tests\Glasswork.Mcp.Tests.csproj --no-restore`
- `dotnet test tests\Glasswork.Tests\Glasswork.Tests.csproj --configuration Release --nologo --verbosity minimal -- MSTest.Parallelize.Workers=1`
- `Invoke-Pester -Path tests\scripts -Output Detailed -CI`
- `dotnet build src\Glasswork.App\Glasswork.csproj --configuration Release -p:Platform=x64 --nologo --verbosity minimal`