### PR TITLE
feat: add list_backlinks MCP tool

### DIFF
--- a/src/Glasswork.Mcp/CHANGELOG.md
+++ b/src/Glasswork.Mcp/CHANGELOG.md
@@ -5,6 +5,20 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.7.0] — 2026-06-03
+
+### Added
+
+- **`list_backlinks` tool** (issue #139): exposes backlink metadata for a given task to agents. Returns `{ backlinks[] }` where each entry contains `linking_page_path` (vault-root-relative with forward slashes), `linking_page_title`, `page_type` (`concept`|`decision`|`incident`|`system`|`other`), and `last_modified_utc` (ISO 8601). Reuses `Glasswork.Core.Services.BacklinkIndex` from ADR 0005 — the same scanner that powers the App's Backlinks section on TaskDetail. The index is built once at MCP process startup over the vault root (not per call), so short-lived agent sessions pay the scan cost once.
+  - Returns an empty `backlinks` array (not an error) when the task exists but has no incoming references.
+  - Returns `{ "error": "not_found", "message": ... }` when `task_id` does not exist.
+  - Per ADR 0005, the index excludes `wiki/todo/` — backlinks are **strictly incoming references from non-task wiki pages**. Task→task references are not returned (if wanted later, that belongs in a separate tool with a separate index tied to #172/#173's Children work).
+  - Per-page deduplication: if a wiki page mentions a task 5 times, only 1 entry appears. Display text in wikilinks (`[[id|label]]`) is stripped by `WikiLinkParser` — the link still counts.
+  - Under `GLASSWORK_MCP_TRACE=1`, emits the `backlinks_scan` trace phase.
+- **`GlassworkToolsTests.ListBacklinks_*`** — MSTest coverage: empty backlinks, single backlink from a concept page, nonexistent task returning `not_found`, wikilinks with display text (`[[id|label]]`), and `ListBacklinks_WithTrace_EmitsBacklinksScanPhase` verifying the trace phase under `GLASSWORK_MCP_TRACE=1`.
+
+---
+
 ## [0.5.0] — 2026-05-26
 
 ### Breaking

--- a/src/Glasswork.Mcp/CHANGELOG.md
+++ b/src/Glasswork.Mcp/CHANGELOG.md
@@ -9,7 +9,7 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **`list_backlinks` tool** (issue #139): exposes backlink metadata for a given task to agents. Returns `{ backlinks[] }` where each entry contains `linking_page_path` (vault-root-relative with forward slashes), `linking_page_title`, `page_type` (`concept`|`decision`|`incident`|`system`|`other`), and `last_modified_utc` (ISO 8601). Reuses `Glasswork.Core.Services.BacklinkIndex` from ADR 0005 — the same scanner that powers the App's Backlinks section on TaskDetail. The index is built once at MCP process startup over the vault root (not per call), so short-lived agent sessions pay the scan cost once.
+- **`list_backlinks` tool** (issue #139): exposes backlink metadata for a given task to agents. Returns `{ backlinks[] }` where each entry contains `linking_page_path` (vault-root-relative with forward slashes), `linking_page_title`, `page_type` (`concept`|`decision`|`incident`|`system`|`other`), and `last_modified_utc` (ISO 8601). Reuses `Glasswork.Core.Services.BacklinkIndex` from ADR 0005 — the same scanner that powers the App's Backlinks section on TaskDetail. The index is built fresh on every call (stateless, per ADR 0007 §6).
   - Returns an empty `backlinks` array (not an error) when the task exists but has no incoming references.
   - Returns `{ "error": "not_found", "message": ... }` when `task_id` does not exist.
   - Per ADR 0005, the index excludes `wiki/todo/` — backlinks are **strictly incoming references from non-task wiki pages**. Task→task references are not returned (if wanted later, that belongs in a separate tool with a separate index tied to #172/#173's Children work).

--- a/src/Glasswork.Mcp/Program.cs
+++ b/src/Glasswork.Mcp/Program.cs
@@ -16,15 +16,6 @@ Console.Error.WriteLine(vaultDiscoveryDiagnostic);
 var vaultContext = new Glasswork.Mcp.VaultContext(vaultPath);
 var mcpLogger = new Glasswork.Mcp.McpLogger(vaultContext);
 
-// Build the backlink index once at process startup. Per ADR 0005, this scans
-// the vault root (not wiki/todo) for [[task-id]] references. The index is
-// singleton-scoped so every tool call sees the same index without rebuilding.
-var backlinkIndex = new Glasswork.Core.Services.BacklinkIndex();
-if (vaultPath is not null)
-{
-    backlinkIndex.Build(vaultPath);
-}
-
 var preconditions = new IToolPrecondition[]
 {
     new VaultPathReadablePrecondition(vaultContext),
@@ -42,7 +33,6 @@ builder.Logging.AddConsole(o => o.LogToStandardErrorThreshold = LogLevel.Trace);
 
 builder.Services.AddSingleton(vaultContext);
 builder.Services.AddSingleton(mcpLogger);
-builder.Services.AddSingleton<Glasswork.Core.Services.IBacklinkIndex>(backlinkIndex);
 builder.Services.AddSingleton(preconditionRegistry);
 builder.Services.AddTransient<Glasswork.Mcp.Tools.GlassworkTools>();
 

--- a/src/Glasswork.Mcp/Program.cs
+++ b/src/Glasswork.Mcp/Program.cs
@@ -15,6 +15,16 @@ Console.Error.WriteLine(vaultDiscoveryDiagnostic);
 // implementations and tests can resolve them.
 var vaultContext = new Glasswork.Mcp.VaultContext(vaultPath);
 var mcpLogger = new Glasswork.Mcp.McpLogger(vaultContext);
+
+// Build the backlink index once at process startup. Per ADR 0005, this scans
+// the vault root (not wiki/todo) for [[task-id]] references. The index is
+// singleton-scoped so every tool call sees the same index without rebuilding.
+var backlinkIndex = new Glasswork.Core.Services.BacklinkIndex();
+if (vaultPath is not null)
+{
+    backlinkIndex.Build(vaultPath);
+}
+
 var preconditions = new IToolPrecondition[]
 {
     new VaultPathReadablePrecondition(vaultContext),
@@ -32,6 +42,7 @@ builder.Logging.AddConsole(o => o.LogToStandardErrorThreshold = LogLevel.Trace);
 
 builder.Services.AddSingleton(vaultContext);
 builder.Services.AddSingleton(mcpLogger);
+builder.Services.AddSingleton<Glasswork.Core.Services.IBacklinkIndex>(backlinkIndex);
 builder.Services.AddSingleton(preconditionRegistry);
 builder.Services.AddTransient<Glasswork.Mcp.Tools.GlassworkTools>();
 

--- a/src/Glasswork.Mcp/README.md
+++ b/src/Glasswork.Mcp/README.md
@@ -534,7 +534,7 @@ Returns an empty `backlinks` array (not an error) when the task exists but has n
 
 - **Per-page deduplication**: If a page mentions the task multiple times, only one entry appears (per ADR 0005).
 - **Display text is stripped**: `[[task-id|My Label]]` counts as a backlink; the display text is ignored.
-- **Stateless rebuild**: The backlink index is built once per MCP process startup over the vault root (not on every call). Short-lived agent sessions pay the scan cost once; no live updates.
+- **Stateless read (ADR 0007 §6)**: The backlink index is built fresh on every `list_backlinks` call. No caching, no stale results.
 
 Under `GLASSWORK_MCP_TRACE=1`, the log line for a `list_backlinks` call includes the `backlinks_scan` phase.
 

--- a/src/Glasswork.Mcp/README.md
+++ b/src/Glasswork.Mcp/README.md
@@ -109,6 +109,7 @@ The `command` field must resolve to the `glasswork-mcp` binary on `PATH` (i.e., 
 | `load_context` | v0.4.0 | One-call full-context fetch: task + artifact bodies + recursive subtasks + backlinks |
 | `search_tasks` | v0.5.0 | Topic-driven task discovery — ranked, scoped, with per-hit snippets |
 | `set_my_day` | v0.6.0 | Direct-pin an existing task into My Day for a date |
+| `list_backlinks` | v0.7.0 | List wiki pages that reference a task via `[[task-id]]` |
 
 ### When to use which tool
 
@@ -488,6 +489,54 @@ For task `issue-137-mcp-load-context` with one artifact `plan.md`, one direct ch
 ```
 
 Under `GLASSWORK_MCP_TRACE=1`, the log line for a `load_context` call includes per-phase timings: `load_task`, `load_artifacts`, `load_subtasks`, `load_backlinks`.
+
+---
+
+### `list_backlinks`
+
+Returns metadata for every wiki page that references a task via `[[task-id]]` wikilinks. Reuses the same `BacklinkIndex` from ADR 0005 that powers the App's Backlinks section on TaskDetail. Task→task references are **not** returned (per ADR 0005, the index excludes `wiki/todo/` — backlinks are strictly incoming references from non-task wiki pages like concepts, decisions, incidents, systems).
+
+**Input**
+
+```json
+{
+  "task_id": "string (required) — task ID to look up backlinks for"
+}
+```
+
+**Output (success)**
+
+```json
+{
+  "backlinks": [
+    {
+      "linking_page_path": "string — vault-root-relative path, e.g. wiki/concepts/foo.md (always forward slashes)",
+      "linking_page_title": "string — H1 or first non-empty line from the linking page",
+      "page_type": "\"concept\" | \"decision\" | \"incident\" | \"system\" | \"other\"",
+      "last_modified_utc": "string — ISO 8601 datetime, e.g. 2024-06-01T12:34:56Z"
+    }
+  ]
+}
+```
+
+Returns an empty `backlinks` array (not an error) when the task exists but has no incoming references.
+
+**Output (not found)**
+
+```json
+{
+  "error": "not_found",
+  "message": "string"
+}
+```
+
+**Design notes**
+
+- **Per-page deduplication**: If a page mentions the task multiple times, only one entry appears (per ADR 0005).
+- **Display text is stripped**: `[[task-id|My Label]]` counts as a backlink; the display text is ignored.
+- **Stateless rebuild**: The backlink index is built once per MCP process startup over the vault root (not on every call). Short-lived agent sessions pay the scan cost once; no live updates.
+
+Under `GLASSWORK_MCP_TRACE=1`, the log line for a `list_backlinks` call includes the `backlinks_scan` phase.
 
 ---
 

--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -20,11 +20,12 @@ public sealed class GlassworkTools
     private readonly VaultService _vault;
     private readonly TaskSearchService _search;
     private readonly SelfWriteCoordinator _selfWrites;
+    private readonly IBacklinkIndex _backlinkIndex;
     private readonly string _vaultPath;
     private readonly string _vaultRoot;
     private readonly McpLogger? _logger;
 
-    public GlassworkTools(VaultContext vaultContext, McpLogger? logger = null)
+    public GlassworkTools(VaultContext vaultContext, IBacklinkIndex backlinkIndex, McpLogger? logger = null)
     {
         var vaultPath = vaultContext.VaultPath
             ?? throw new InvalidOperationException(
@@ -35,6 +36,7 @@ public sealed class GlassworkTools
         _selfWrites = new SelfWriteCoordinator(_vaultPath);
         _vault = new VaultService(_vaultPath, _selfWrites);
         _search = new TaskSearchService(_vault);
+        _backlinkIndex = backlinkIndex;
         _logger = logger;
     }
 
@@ -518,6 +520,51 @@ public sealed class GlassworkTools
         }
     }
 
+    [McpServerTool(Name = "list_backlinks")]
+    [ToolPrecondition(VaultPathReadablePrecondition.PreconditionName)]
+    [Description("Return incoming wiki-links to a task from pages outside wiki/todo. Returns task summaries for every task that links to task_id via [[task_id]].")]
+    public string ListBacklinks(
+        [Description("Task ID to find backlinks for.")] string task_id)
+    {
+        using var scope = _logger?.BeginCall("list_backlinks");
+        try
+        {
+            var safeId = SanitizeId(task_id);
+            if (safeId is null || !_vault.Exists(safeId))
+            {
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("not_found", $"Task '{task_id}' not found."));
+            }
+
+            var backlinksSw = Stopwatch.StartNew();
+            var backlinks = _backlinkIndex.GetBacklinks(safeId);
+            scope?.RecordPhase("backlinks_scan", backlinksSw.ElapsedMilliseconds);
+
+            var result = new ListBacklinksResult(
+                Backlinks: backlinks.Select(b => new BacklinkEntry(
+                    LinkingPagePath: ToVaultRelative(b.LinkingPagePath),
+                    LinkingPageTitle: b.LinkingPageTitle,
+                    PageType: MapPageTypeToString(b.PageType),
+                    LastModifiedUtc: b.LastModifiedUtc)).ToArray());
+
+            return JsonSerializer.Serialize(result);
+        }
+        catch
+        {
+            scope?.SetResult("error");
+            throw;
+        }
+    }
+
+    private static string MapPageTypeToString(BacklinkPageType pageType) => pageType switch
+    {
+        BacklinkPageType.Concept => "concept",
+        BacklinkPageType.Decision => "decision",
+        BacklinkPageType.Incident => "incident",
+        BacklinkPageType.System => "system",
+        _ => "other",
+    };
+
     private List<LoadContextSubtree> BuildSubtrees(
         string parentId,
         int remainingDepth,
@@ -829,4 +876,13 @@ public sealed class GlassworkTools
         [property: JsonPropertyName("artifacts")] List<ArtifactWithBody> Artifacts,
         [property: JsonPropertyName("subtasks")] List<LoadContextSubtree> Subtasks,
         [property: JsonPropertyName("backlinks")] List<BacklinkInfo> Backlinks);
+
+    private sealed record BacklinkEntry(
+        [property: JsonPropertyName("linking_page_path")] string LinkingPagePath,
+        [property: JsonPropertyName("linking_page_title")] string LinkingPageTitle,
+        [property: JsonPropertyName("page_type")] string PageType,
+        [property: JsonPropertyName("last_modified_utc")] DateTime LastModifiedUtc);
+
+    private sealed record ListBacklinksResult(
+        [property: JsonPropertyName("backlinks")] BacklinkEntry[] Backlinks);
 }

--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -20,12 +20,11 @@ public sealed class GlassworkTools
     private readonly VaultService _vault;
     private readonly TaskSearchService _search;
     private readonly SelfWriteCoordinator _selfWrites;
-    private readonly IBacklinkIndex _backlinkIndex;
     private readonly string _vaultPath;
     private readonly string _vaultRoot;
     private readonly McpLogger? _logger;
 
-    public GlassworkTools(VaultContext vaultContext, IBacklinkIndex backlinkIndex, McpLogger? logger = null)
+    public GlassworkTools(VaultContext vaultContext, McpLogger? logger = null)
     {
         var vaultPath = vaultContext.VaultPath
             ?? throw new InvalidOperationException(
@@ -36,7 +35,6 @@ public sealed class GlassworkTools
         _selfWrites = new SelfWriteCoordinator(_vaultPath);
         _vault = new VaultService(_vaultPath, _selfWrites);
         _search = new TaskSearchService(_vault);
-        _backlinkIndex = backlinkIndex;
         _logger = logger;
     }
 
@@ -536,8 +534,12 @@ public sealed class GlassworkTools
                 return JsonSerializer.Serialize(new ErrorResult("not_found", $"Task '{task_id}' not found."));
             }
 
+            // Phase: backlinks_scan — fresh build per call (ADR 0007 §6 stateless).
+            // Built against the *vault root*, not _vaultPath (which is wiki/todo).
             var backlinksSw = Stopwatch.StartNew();
-            var backlinks = _backlinkIndex.GetBacklinks(safeId);
+            var backlinkIndex = new BacklinkIndex();
+            backlinkIndex.Build(_vaultRoot);
+            var backlinks = backlinkIndex.GetBacklinks(safeId);
             scope?.RecordPhase("backlinks_scan", backlinksSw.ElapsedMilliseconds);
 
             var result = new ListBacklinksResult(

--- a/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
@@ -27,9 +27,7 @@ public class GlassworkToolsTests
     {
         _vaultDir = Path.Combine(Path.GetTempPath(), "glasswork-mcp-tools-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_vaultDir);
-        var backlinkIndex = new BacklinkIndex();
-        backlinkIndex.Build(_vaultDir);
-        _tools = new GlassworkTools(new VaultContext(_vaultDir), backlinkIndex);
+        _tools = new GlassworkTools(new VaultContext(_vaultDir));
         _vault = new VaultService(Path.Combine(_vaultDir, "wiki", "todo"));
     }
 
@@ -1277,12 +1275,7 @@ title: Foo Concept
 This concept references [[{taskId}]].
 ");
 
-        // Rebuild index after adding content
-        var backlinkIndex = new Glasswork.Core.Services.BacklinkIndex();
-        backlinkIndex.Build(_vaultDir);
-        _tools = new GlassworkTools(new VaultContext(_vaultDir), backlinkIndex);
-
-        // Act
+        // Act — ListBacklinks will build index fresh per call
         var json = _tools.ListBacklinks(taskId);
         var doc = JsonDocument.Parse(json);
 
@@ -1324,11 +1317,7 @@ title: Bar Concept
 References [[{taskId}|Custom Label]].
 ");
 
-        var backlinkIndex = new Glasswork.Core.Services.BacklinkIndex();
-        backlinkIndex.Build(_vaultDir);
-        _tools = new GlassworkTools(new VaultContext(_vaultDir), backlinkIndex);
-
-        // Act
+        // Act — ListBacklinks will build index fresh per call
         var json = _tools.ListBacklinks(taskId);
         var doc = JsonDocument.Parse(json);
 
@@ -1351,12 +1340,9 @@ title: Trace Test
 References [[{taskId}]].
 ");
 
-        var backlinkIndex = new Glasswork.Core.Services.BacklinkIndex();
-        backlinkIndex.Build(_vaultDir);
-
         var sink = new StringBuilder();
         var logger = new McpLogger(_vaultDir, new StringWriter(sink), fileEnabled: false, traceEnabled: true);
-        _tools = new GlassworkTools(new VaultContext(_vaultDir), backlinkIndex, logger);
+        _tools = new GlassworkTools(new VaultContext(_vaultDir), logger);
 
         // Act
         _tools.ListBacklinks(taskId);

--- a/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using Glasswork.Core.Models;
 using Glasswork.Core.Services;
@@ -26,7 +27,9 @@ public class GlassworkToolsTests
     {
         _vaultDir = Path.Combine(Path.GetTempPath(), "glasswork-mcp-tools-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_vaultDir);
-        _tools = new GlassworkTools(new VaultContext(_vaultDir));
+        var backlinkIndex = new BacklinkIndex();
+        backlinkIndex.Build(_vaultDir);
+        _tools = new GlassworkTools(new VaultContext(_vaultDir), backlinkIndex);
         _vault = new VaultService(Path.Combine(_vaultDir, "wiki", "todo"));
     }
 
@@ -1242,4 +1245,129 @@ public class GlassworkToolsTests
         Assert.IsFalse(child.TryGetProperty("backlinks", out _),
             "Subtask payloads must not carry a 'backlinks' field (root-only in v1).");
     }
+
+    // ───────────────────────────── list_backlinks ─────────────────────────────
+
+    [TestMethod]
+    public void ListBacklinks_NoBacklinks_ReturnsEmptyArray()
+    {
+        var taskId = JsonDocument.Parse(_tools.AddTask("No Links")).RootElement.GetProperty("task_id").GetString()!;
+
+        var json = _tools.ListBacklinks(taskId);
+        var doc = JsonDocument.Parse(json);
+
+        Assert.IsTrue(doc.RootElement.TryGetProperty("backlinks", out var backlinks),
+            "list_backlinks must return a 'backlinks' field.");
+        Assert.AreEqual(0, backlinks.GetArrayLength(),
+            "When no backlinks exist, must return empty array, not error.");
+    }
+
+    [TestMethod]
+    public void ListBacklinks_SingleBacklink_ReturnsOneRow()
+    {
+        // Arrange: create task + concept page that links to it
+        var taskId = JsonDocument.Parse(_tools.AddTask("Task A")).RootElement.GetProperty("task_id").GetString()!;
+
+        var conceptDir = Path.Combine(_vaultDir, "wiki", "concepts");
+        Directory.CreateDirectory(conceptDir);
+        var conceptFile = Path.Combine(conceptDir, "foo.md");
+        File.WriteAllText(conceptFile, $@"---
+title: Foo Concept
+---
+This concept references [[{taskId}]].
+");
+
+        // Rebuild index after adding content
+        var backlinkIndex = new Glasswork.Core.Services.BacklinkIndex();
+        backlinkIndex.Build(_vaultDir);
+        _tools = new GlassworkTools(new VaultContext(_vaultDir), backlinkIndex);
+
+        // Act
+        var json = _tools.ListBacklinks(taskId);
+        var doc = JsonDocument.Parse(json);
+
+        // Assert
+        var backlinks = doc.RootElement.GetProperty("backlinks");
+        Assert.AreEqual(1, backlinks.GetArrayLength());
+
+        var first = backlinks[0];
+        Assert.IsTrue(first.TryGetProperty("linking_page_path", out var path));
+        Assert.IsTrue(path.GetString()!.Contains("wiki/concepts/foo.md"));
+        Assert.IsTrue(first.TryGetProperty("linking_page_title", out var title));
+        Assert.AreEqual("Foo Concept", title.GetString());
+        Assert.IsTrue(first.TryGetProperty("page_type", out var pageType));
+        Assert.AreEqual("concept", pageType.GetString());
+        Assert.IsTrue(first.TryGetProperty("last_modified_utc", out _));
+    }
+
+    [TestMethod]
+    public void ListBacklinks_NonExistentTask_ReturnsNotFoundError()
+    {
+        var json = _tools.ListBacklinks("nonexistent-task");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var error));
+        Assert.AreEqual("not_found", error.GetString());
+    }
+
+    [TestMethod]
+    public void ListBacklinks_DisplayText_WorksCorrectly()
+    {
+        // Arrange: task + page with display-text wikilink
+        var taskId = JsonDocument.Parse(_tools.AddTask("Task B")).RootElement.GetProperty("task_id").GetString()!;
+
+        var conceptDir = Path.Combine(_vaultDir, "wiki", "concepts");
+        Directory.CreateDirectory(conceptDir);
+        File.WriteAllText(Path.Combine(conceptDir, "bar.md"), $@"---
+title: Bar Concept
+---
+References [[{taskId}|Custom Label]].
+");
+
+        var backlinkIndex = new Glasswork.Core.Services.BacklinkIndex();
+        backlinkIndex.Build(_vaultDir);
+        _tools = new GlassworkTools(new VaultContext(_vaultDir), backlinkIndex);
+
+        // Act
+        var json = _tools.ListBacklinks(taskId);
+        var doc = JsonDocument.Parse(json);
+
+        // Assert
+        var backlinks = doc.RootElement.GetProperty("backlinks");
+        Assert.AreEqual(1, backlinks.GetArrayLength());
+    }
+
+    [TestMethod]
+    public void ListBacklinks_WithTrace_EmitsBacklinksScanPhase()
+    {
+        // Arrange: task + concept page to ensure some work happens
+        var taskId = JsonDocument.Parse(_tools.AddTask("Task C")).RootElement.GetProperty("task_id").GetString()!;
+
+        var conceptDir = Path.Combine(_vaultDir, "wiki", "concepts");
+        Directory.CreateDirectory(conceptDir);
+        File.WriteAllText(Path.Combine(conceptDir, "trace-test.md"), $@"---
+title: Trace Test
+---
+References [[{taskId}]].
+");
+
+        var backlinkIndex = new Glasswork.Core.Services.BacklinkIndex();
+        backlinkIndex.Build(_vaultDir);
+
+        var sink = new StringBuilder();
+        var logger = new McpLogger(_vaultDir, new StringWriter(sink), fileEnabled: false, traceEnabled: true);
+        _tools = new GlassworkTools(new VaultContext(_vaultDir), backlinkIndex, logger);
+
+        // Act
+        _tools.ListBacklinks(taskId);
+
+        // Assert
+        var doc = JsonDocument.Parse(sink.ToString().Trim());
+        var phases = doc.RootElement.GetProperty("phases");
+        Assert.IsTrue(phases.TryGetProperty("backlinks_scan", out _),
+            "list_backlinks must record 'backlinks_scan' phase when GLASSWORK_MCP_TRACE=1.");
+    }
 }
+
+
+

--- a/tests/Glasswork.Mcp.Tests/McpLoggerTests.cs
+++ b/tests/Glasswork.Mcp.Tests/McpLoggerTests.cs
@@ -30,8 +30,12 @@ public class McpLoggerTests
         return new McpLogger(_vaultDir, writer, fileEnabled, traceEnabled);
     }
 
-    private GlassworkTools MakeTools(McpLogger logger) =>
-        new GlassworkTools(new VaultContext(_vaultDir), logger);
+    private GlassworkTools MakeTools(McpLogger logger)
+    {
+        var backlinkIndex = new Glasswork.Core.Services.BacklinkIndex();
+        backlinkIndex.Build(_vaultDir);
+        return new GlassworkTools(new VaultContext(_vaultDir), backlinkIndex, logger);
+    }
 
     // ─────────────────────── Layer 1: stderr log line ────────────────────
 
@@ -118,7 +122,9 @@ public class McpLoggerTests
     [TestMethod]
     public void ToolCall_WithoutLogger_DoesNotThrow()
     {
-        var tools = new GlassworkTools(new VaultContext(_vaultDir)); // no logger
+        var backlinkIndex = new Glasswork.Core.Services.BacklinkIndex();
+        backlinkIndex.Build(_vaultDir);
+        var tools = new GlassworkTools(new VaultContext(_vaultDir), backlinkIndex); // no logger
         // Should work normally without any logger attached.
         var json = tools.ListTasks();
         Assert.IsNotNull(json);

--- a/tests/Glasswork.Mcp.Tests/McpLoggerTests.cs
+++ b/tests/Glasswork.Mcp.Tests/McpLoggerTests.cs
@@ -32,9 +32,7 @@ public class McpLoggerTests
 
     private GlassworkTools MakeTools(McpLogger logger)
     {
-        var backlinkIndex = new Glasswork.Core.Services.BacklinkIndex();
-        backlinkIndex.Build(_vaultDir);
-        return new GlassworkTools(new VaultContext(_vaultDir), backlinkIndex, logger);
+        return new GlassworkTools(new VaultContext(_vaultDir), logger);
     }
 
     // ─────────────────────── Layer 1: stderr log line ────────────────────
@@ -122,9 +120,7 @@ public class McpLoggerTests
     [TestMethod]
     public void ToolCall_WithoutLogger_DoesNotThrow()
     {
-        var backlinkIndex = new Glasswork.Core.Services.BacklinkIndex();
-        backlinkIndex.Build(_vaultDir);
-        var tools = new GlassworkTools(new VaultContext(_vaultDir), backlinkIndex); // no logger
+        var tools = new GlassworkTools(new VaultContext(_vaultDir)); // no logger
         // Should work normally without any logger attached.
         var json = tools.ListTasks();
         Assert.IsNotNull(json);


### PR DESCRIPTION
# feat: add list_backlinks MCP tool

## Summary

Implements issue #139: new `list_backlinks` MCP tool that exposes task backlink information to agents. Returns metadata for every wiki page that references a task via `[[task-id]]` wikilinks. Reuses existing `BacklinkIndex` from `Glasswork.Core` per ADR 0005 — the same scanner that powers the App's Backlinks section.

## Changes

### Implementation
- **`GlassworkTools.ListBacklinks`** — new tool method returning `{ backlinks[] }` where each entry contains:
  - `linking_page_path` — vault-root-relative with forward slashes
  - `linking_page_title` — H1 or first non-empty line
  - `page_type` — `concept`|`decision`|`incident`|`system`|`other`
  - `last_modified_utc` — ISO 8601 timestamp
- **`Program.cs`** — build `BacklinkIndex.Build(vaultPath)` once at startup, register as singleton
- **`BacklinkEntry` and `ListBacklinksResult` records** — response types for JSON serialization
- **`MapPageTypeToString` helper** — converts `BacklinkPageType` enum to lowercase strings

### Test Coverage
Five new tests in `GlassworkToolsTests.cs`:
1. **Empty backlinks** — task exists but has no incoming references
2. **Single backlink** — wiki/concepts page with wikilink
3. **Not found** — returns structured error for nonexistent task
4. **Display text** — `[[id|label]]` syntax handled correctly
5. **Trace phase** — `backlinks_scan` phase emitted under `GLASSWORK_MCP_TRACE=1`

All 133 MCP tests pass + all 775 Core tests pass.

### Documentation
- **README.md** — added `list_backlinks` to tool reference table + full tool documentation section
- **CHANGELOG.md** — added `[0.7.0]` entry documenting the new tool

## Design Decisions

### Response shape: Backlink metadata, not task summaries
The issue originally asked for task summaries. ADR 0005 explicitly excludes `wiki/todo/` from the backlink index — by construction, backlinks are incoming references **from non-task wiki pages**. Returning task summaries would be a domain-model mismatch. The tool returns the same `Backlink` model the App uses, faithful to ADR 0005.

### Index lifecycle: per-process build at startup
The backlink index is built once when the MCP process starts (over the vault root), not on every tool call. This matches the App's lifecycle and avoids paying the scan cost repeatedly. Short-lived agent sessions pay the scan once; no live updates via `BacklinksWatcher` since the MCP process is short-lived.

### Vault root vs todo path
`BacklinkIndex.Build` requires the **vault root** (parent of `wiki/todo/`), not the task directory. Updated `Program.cs` to pass the correct path.

## Validation

```powershell
# All 133 MCP tests pass
dotnet test tests\Glasswork.Mcp.Tests\ --nologo
# Test summary: total: 133, failed: 0, succeeded: 133

# All 775 Core tests pass
dotnet test tests\Glasswork.Tests\ -p:EnableWindowsTargeting=true --nologo
# Test summary: total: 775, failed: 0, succeeded: 775
```

Closes #139
