### PR TITLE
feat: work log format parser and model

### DIFF
--- a/src/Glasswork.Core/Models/WorkLog.cs
+++ b/src/Glasswork.Core/Models/WorkLog.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+
+namespace Glasswork.Core.Models;
+
+/// <summary>
+/// Represents a weekly work log journal entry stored at wiki/journal/YYYY-WNN.md.
+/// Work logs are agent-generated summaries of completed work with anti-hallucination rules.
+/// </summary>
+public class WorkLog
+{
+    /// <summary>
+    /// Type identifier, always "work-log".
+    /// </summary>
+    public string Type { get; set; } = "work-log";
+
+    /// <summary>
+    /// Period granularity: "week" for weekly logs.
+    /// </summary>
+    public string Period { get; set; } = "week";
+
+    /// <summary>
+    /// ISO week number in format "YYYY-WNN" (e.g., "2026-W21").
+    /// </summary>
+    public string Week { get; set; } = string.Empty;
+
+    /// <summary>
+    /// First date of the covered period (inclusive).
+    /// </summary>
+    public DateTime DateFrom { get; set; }
+
+    /// <summary>
+    /// Last date of the covered period (inclusive).
+    /// </summary>
+    public DateTime DateTo { get; set; }
+
+    /// <summary>
+    /// UTC timestamp when this log was generated.
+    /// </summary>
+    public DateTime GeneratedAt { get; set; }
+
+    /// <summary>
+    /// The generator that created this log (e.g., "copilot").
+    /// </summary>
+    public string GeneratedBy { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Task IDs referenced in this work log.
+    /// </summary>
+    public List<string> TasksReferenced { get; set; } = [];
+
+    /// <summary>
+    /// Main narrative summary (2-3 paragraphs).
+    /// </summary>
+    public string Summary { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Key insights and breakthrough moments (optional section).
+    /// </summary>
+    public string KeyInsights { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Strategic thinking highlights (optional section).
+    /// </summary>
+    public string StrategicThinking { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Tasks completed during the period.
+    /// </summary>
+    public string TasksCompleted { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Tasks in progress at the end of the period (optional section).
+    /// </summary>
+    public string InProgress { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Frustrations or roadblocks encountered (optional section).
+    /// </summary>
+    public string Frustrations { get; set; } = string.Empty;
+}

--- a/src/Glasswork.Core/Services/WorkLogParser.cs
+++ b/src/Glasswork.Core/Services/WorkLogParser.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Glasswork.Core.Models;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Glasswork.Core.Services;
+
+/// <summary>
+/// Parses WorkLog markdown files with YAML frontmatter from wiki/journal/YYYY-WNN.md.
+/// </summary>
+public partial class WorkLogParser
+{
+    private static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
+        .WithNamingConvention(UnderscoredNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    [GeneratedRegex(@"^---\s*\n(.*?)\n---\s*\n?(.*)", RegexOptions.Singleline)]
+    private static partial Regex FrontmatterRegex();
+
+    [GeneratedRegex(@"(?ms)^## Summary\s*$(.*?)(?=^## |\z)", RegexOptions.Multiline)]
+    private static partial Regex SummarySectionRegex();
+
+    [GeneratedRegex(@"(?ms)^## Key Insights & Breakthrough Moments\s*$(.*?)(?=^## |\z)", RegexOptions.Multiline)]
+    private static partial Regex KeyInsightsSectionRegex();
+
+    [GeneratedRegex(@"(?ms)^## Strategic Thinking Highlights\s*$(.*?)(?=^## |\z)", RegexOptions.Multiline)]
+    private static partial Regex StrategicThinkingSectionRegex();
+
+    [GeneratedRegex(@"(?ms)^## Tasks Completed\s*$(.*?)(?=^## |\z)", RegexOptions.Multiline)]
+    private static partial Regex TasksCompletedSectionRegex();
+
+    [GeneratedRegex(@"(?ms)^## In Progress at Week End\s*$(.*?)(?=^## |\z)", RegexOptions.Multiline)]
+    private static partial Regex InProgressSectionRegex();
+
+    [GeneratedRegex(@"(?ms)^## Frustrations or Roadblocks\s*$(.*?)(?=^## |\z)", RegexOptions.Multiline)]
+    private static partial Regex FrustrationsSectionRegex();
+
+    /// <summary>
+    /// Parse a work log markdown file's content into a WorkLog object.
+    /// </summary>
+    public WorkLog Parse(string content)
+    {
+        var match = FrontmatterRegex().Match(content);
+        if (!match.Success)
+            throw new FormatException("Invalid work log: missing YAML frontmatter delimiters (---).");
+
+        var yamlContent = match.Groups[1].Value;
+        var body = match.Groups[2].Value.Trim();
+
+        var frontmatter = YamlDeserializer.Deserialize<WorkLogFrontmatter>(yamlContent)
+            ?? throw new FormatException("Failed to deserialize work log YAML frontmatter.");
+
+        // Validate required fields
+        if (string.IsNullOrEmpty(frontmatter.Type))
+            throw new FormatException("Work log missing required field: type");
+        if (string.IsNullOrEmpty(frontmatter.Period))
+            throw new FormatException("Work log missing required field: period");
+        if (string.IsNullOrEmpty(frontmatter.Week))
+            throw new FormatException("Work log missing required field: week");
+        if (string.IsNullOrEmpty(frontmatter.DateFrom))
+            throw new FormatException("Work log missing required field: date_from");
+        if (string.IsNullOrEmpty(frontmatter.DateTo))
+            throw new FormatException("Work log missing required field: date_to");
+        if (string.IsNullOrEmpty(frontmatter.GeneratedAt))
+            throw new FormatException("Work log missing required field: generated_at");
+        if (string.IsNullOrEmpty(frontmatter.GeneratedBy))
+            throw new FormatException("Work log missing required field: generated_by");
+
+        var workLog = new WorkLog
+        {
+            Type = frontmatter.Type,
+            Period = frontmatter.Period,
+            Week = frontmatter.Week,
+            DateFrom = ParseDate(frontmatter.DateFrom),
+            DateTo = ParseDate(frontmatter.DateTo),
+            GeneratedAt = ParseDateTimeUtc(frontmatter.GeneratedAt),
+            GeneratedBy = frontmatter.GeneratedBy,
+            TasksReferenced = frontmatter.TasksReferenced ?? [],
+            Summary = ExtractSection(body, SummarySectionRegex()),
+            KeyInsights = ExtractSection(body, KeyInsightsSectionRegex()),
+            StrategicThinking = ExtractSection(body, StrategicThinkingSectionRegex()),
+            TasksCompleted = ExtractSection(body, TasksCompletedSectionRegex()),
+            InProgress = ExtractSection(body, InProgressSectionRegex()),
+            Frustrations = ExtractSection(body, FrustrationsSectionRegex())
+        };
+
+        return workLog;
+    }
+
+    private static DateTime ParseDate(string dateStr)
+    {
+        if (DateTime.TryParse(dateStr, out var date))
+            return date.Date;
+        throw new FormatException($"Invalid date format: {dateStr}");
+    }
+
+    private static DateTime ParseDateTimeUtc(string dateTimeStr)
+    {
+        if (DateTime.TryParse(dateTimeStr, System.Globalization.CultureInfo.InvariantCulture,
+                             System.Globalization.DateTimeStyles.AdjustToUniversal | System.Globalization.DateTimeStyles.AssumeUniversal,
+                             out var dateTime))
+            return DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+        throw new FormatException($"Invalid datetime format: {dateTimeStr}");
+    }
+
+    private static string ExtractSection(string body, Regex sectionRegex)
+    {
+        var match = sectionRegex.Match(body);
+        if (!match.Success)
+            return string.Empty;
+
+        return match.Groups[1].Value.Trim();
+    }
+
+    /// <summary>
+    /// DTO for work log frontmatter deserialization.
+    /// </summary>
+    private class WorkLogFrontmatter
+    {
+        public string? Type { get; set; }
+        public string? Period { get; set; }
+        public string? Week { get; set; }
+        public string? DateFrom { get; set; }
+        public string? DateTo { get; set; }
+        public string? GeneratedAt { get; set; }
+        public string? GeneratedBy { get; set; }
+        public List<string>? TasksReferenced { get; set; }
+    }
+}

--- a/src/Glasswork.Core/Services/WorkLogParser.cs
+++ b/src/Glasswork.Core/Services/WorkLogParser.cs
@@ -99,10 +99,14 @@ public partial class WorkLogParser
 
     private static DateTime ParseDateTimeUtc(string dateTimeStr)
     {
-        if (DateTime.TryParse(dateTimeStr, System.Globalization.CultureInfo.InvariantCulture,
-                             System.Globalization.DateTimeStyles.AdjustToUniversal | System.Globalization.DateTimeStyles.AssumeUniversal,
-                             out var dateTime))
-            return DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+        if (DateTimeOffset.TryParse(dateTimeStr, System.Globalization.CultureInfo.InvariantCulture,
+                                     System.Globalization.DateTimeStyles.None,
+                                     out var offset))
+        {
+            if (offset.Offset == TimeSpan.Zero)
+                return offset.UtcDateTime;
+            throw new FormatException($"Timestamp must be UTC (Z suffix or +00:00 offset): {dateTimeStr}");
+        }
         throw new FormatException($"Invalid datetime format: {dateTimeStr}");
     }
 

--- a/tests/Glasswork.Tests/Services/WorkLogParserTests.cs
+++ b/tests/Glasswork.Tests/Services/WorkLogParserTests.cs
@@ -195,4 +195,29 @@ This is not a valid work log format.
         var ex = Assert.ThrowsExactly<FormatException>(() => parser.Parse(markdown));
         Assert.IsTrue(ex.Message.Contains("frontmatter delimiters"));
     }
+
+    [TestMethod]
+    public void Parse_GeneratedAtWithoutTimezone_ThrowsFormatException()
+    {
+        // Arrange - generated_at without Z suffix
+        var markdown = @"---
+type: work-log
+period: week
+week: 2026-W21
+date_from: 2026-05-18
+date_to: 2026-05-24
+generated_at: 2026-05-26T14:00:00
+generated_by: copilot
+---
+
+## Summary
+Content.
+";
+
+        var parser = new WorkLogParser();
+
+        // Act & Assert
+        var ex = Assert.ThrowsExactly<FormatException>(() => parser.Parse(markdown));
+        Assert.IsTrue(ex.Message.Contains("UTC"));
+    }
 }

--- a/tests/Glasswork.Tests/Services/WorkLogParserTests.cs
+++ b/tests/Glasswork.Tests/Services/WorkLogParserTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Glasswork.Tests.Services;
+
+[TestClass]
+public class WorkLogParserTests
+{
+    [TestMethod]
+    public void Parse_ValidWorkLog_ReturnsWorkLogWithAllSections()
+    {
+        // Arrange
+        var markdown = @"---
+type: work-log
+period: week
+week: 2026-W21
+date_from: 2026-05-18
+date_to: 2026-05-24
+generated_at: 2026-05-26T14:00:00Z
+generated_by: copilot
+tasks_referenced: [auth-fix, my-day-virtual-promotion]
+---
+
+## Summary
+Completed 7 tasks across 3 projects. Fixed authentication flow and promoted My Day feature to production.
+
+## Key Insights & Breakthrough Moments
+- Discovered race condition in token refresh
+- Realized virtual scrolling doubles My Day responsiveness
+
+## Strategic Thinking Highlights
+- Prioritized auth fix over new features
+- Deferred migration to focus on stability
+
+## Tasks Completed
+- [[auth-fix]] — Fix token refresh race condition, ADO #1234
+- [[my-day-virtual-promotion]] — Virtual scrolling for My Day list
+
+## In Progress at Week End
+- [[migration]] — Database schema migration in progress
+
+## Frustrations or Roadblocks
+- Build server downtime on Tuesday blocked PR merge
+";
+
+        var parser = new WorkLogParser();
+
+        // Act
+        var workLog = parser.Parse(markdown);
+
+        // Assert
+        Assert.AreEqual("work-log", workLog.Type);
+        Assert.AreEqual("week", workLog.Period);
+        Assert.AreEqual("2026-W21", workLog.Week);
+        Assert.AreEqual(new DateTime(2026, 5, 18), workLog.DateFrom);
+        Assert.AreEqual(new DateTime(2026, 5, 24), workLog.DateTo);
+        Assert.AreEqual(new DateTime(2026, 5, 26, 14, 0, 0, DateTimeKind.Utc), workLog.GeneratedAt);
+        Assert.AreEqual("copilot", workLog.GeneratedBy);
+        CollectionAssert.AreEqual(new[] { "auth-fix", "my-day-virtual-promotion" }, workLog.TasksReferenced);
+        
+        Assert.IsTrue(workLog.Summary.Contains("Completed 7 tasks"));
+        Assert.IsTrue(workLog.KeyInsights.Contains("race condition"));
+        Assert.IsTrue(workLog.StrategicThinking.Contains("Prioritized auth fix"));
+        Assert.IsTrue(workLog.TasksCompleted.Contains("[[auth-fix]]"));
+        Assert.IsTrue(workLog.InProgress.Contains("[[migration]]"));
+        Assert.IsTrue(workLog.Frustrations.Contains("Build server downtime"));
+    }
+
+    [TestMethod]
+    public void Parse_OptionalSectionsMissing_ReturnsWorkLogWithEmptyStrings()
+    {
+        // Arrange - minimal work log with only required sections
+        var markdown = @"---
+type: work-log
+period: week
+week: 2026-W21
+date_from: 2026-05-18
+date_to: 2026-05-24
+generated_at: 2026-05-26T14:00:00Z
+generated_by: copilot
+---
+
+## Summary
+Minimal work log with only summary section.
+
+## Tasks Completed
+- [[task-1]] — Completed basic task
+";
+
+        var parser = new WorkLogParser();
+
+        // Act
+        var workLog = parser.Parse(markdown);
+
+        // Assert - optional sections should be empty strings
+        Assert.AreEqual(string.Empty, workLog.KeyInsights);
+        Assert.AreEqual(string.Empty, workLog.StrategicThinking);
+        Assert.AreEqual(string.Empty, workLog.InProgress);
+        Assert.AreEqual(string.Empty, workLog.Frustrations);
+        
+        // Required sections should have content
+        Assert.IsTrue(workLog.Summary.Contains("Minimal work log"));
+        Assert.IsTrue(workLog.TasksCompleted.Contains("[[task-1]]"));
+    }
+
+    [TestMethod]
+    public void Parse_MissingRequiredFrontmatter_ThrowsFormatException()
+    {
+        // Arrange - missing required field 'generated_by'
+        var markdown = @"---
+type: work-log
+period: week
+week: 2026-W21
+date_from: 2026-05-18
+date_to: 2026-05-24
+generated_at: 2026-05-26T14:00:00Z
+---
+
+## Summary
+Content here.
+";
+
+        var parser = new WorkLogParser();
+
+        // Act & Assert
+        var ex = Assert.ThrowsExactly<FormatException>(() => parser.Parse(markdown));
+        Assert.IsTrue(ex.Message.Contains("generated_by"));
+    }
+
+    [TestMethod]
+    public void Parse_EmptyTasksReferenced_ReturnsEmptyList()
+    {
+        // Arrange - no tasks_referenced field
+        var markdown = @"---
+type: work-log
+period: week
+week: 2026-W21
+date_from: 2026-05-18
+date_to: 2026-05-24
+generated_at: 2026-05-26T14:00:00Z
+generated_by: copilot
+---
+
+## Summary
+No tasks this week.
+";
+
+        var parser = new WorkLogParser();
+
+        // Act
+        var workLog = parser.Parse(markdown);
+
+        // Assert
+        Assert.AreEqual(0, workLog.TasksReferenced.Count);
+    }
+
+    [TestMethod]
+    public void Parse_InvalidDateFormat_ThrowsFormatException()
+    {
+        // Arrange - invalid date format
+        var markdown = @"---
+type: work-log
+period: week
+week: 2026-W21
+date_from: invalid-date
+date_to: 2026-05-24
+generated_at: 2026-05-26T14:00:00Z
+generated_by: copilot
+---
+
+## Summary
+Content.
+";
+
+        var parser = new WorkLogParser();
+
+        // Act & Assert
+        Assert.ThrowsExactly<FormatException>(() => parser.Parse(markdown));
+    }
+
+    [TestMethod]
+    public void Parse_MissingFrontmatterDelimiters_ThrowsFormatException()
+    {
+        // Arrange - no frontmatter delimiters
+        var markdown = @"## Summary
+This is not a valid work log format.
+";
+
+        var parser = new WorkLogParser();
+
+        // Act & Assert
+        var ex = Assert.ThrowsExactly<FormatException>(() => parser.Parse(markdown));
+        Assert.IsTrue(ex.Message.Contains("frontmatter delimiters"));
+    }
+}


### PR DESCRIPTION
# Work Log Format Specification

Implements the on-disk format for agent-generated work logs as defined in issue #218.

## Changes

- **Model**: Added `WorkLog` model (`src/Glasswork.Core/Models/WorkLog.cs`) with frontmatter properties (type, period, week, date_from, date_to, generated_at, generated_by, tasks_referenced) and structured body sections (Summary, Key Insights, Strategic Thinking, Tasks Completed, In Progress, Frustrations).

- **Parser**: Implemented `WorkLogParser` (`src/Glasswork.Core/Services/WorkLogParser.cs`) with:
  - YAML frontmatter validation (required fields: type, period, week, date_from, date_to, generated_at, generated_by)
  - Regex-based section extraction for optional body sections
  - UTC datetime parsing with `DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal` to preserve timezone
  - Proper error handling with descriptive `FormatException` messages

- **Tests**: Comprehensive test suite (`tests/Glasswork.Tests/Services/WorkLogParserTests.cs`) covering:
  - Complete work log with all sections
  - Optional sections missing
  - Required frontmatter validation
  - Empty tasks_referenced list
  - Invalid date formats
  - Missing frontmatter delimiters

## Validation

- ✅ Core build succeeds
- ✅ All 782 unit tests pass (including 7 new WorkLogParser tests)
- ⚠️ App build skipped (WinUI 3 architecture constraints, no App changes in this slice)

## Code Review Findings

Dual-model code review (GPT-5.5 + Claude Opus 4.7) completed:

- **GPT-5.5**: Flagged medium-severity issue with UTC timestamp validation — parser accepted timezone-less timestamps when spec requires explicit UTC. Fixed by replacing `DateTime.TryParse` with `DateTimeOffset.TryParse` and validating offset is exactly zero.
- **Claude Opus 4.7**: No issues found.

Both findings addressed in commit `c007bb7`.

## Format Spec

Work logs are stored at `{vault}/wiki/journal/YYYY-WNN.md` with YAML frontmatter and structured markdown sections per the anti-hallucination template from `wiggitywhitney/mcp-commit-story`.

## Decisions

- Used existing `FrontmatterParser` patterns for consistency with task parsing
- Optional sections return empty strings when missing (rather than null) for easier consumption
- ISO week format stored as string `"YYYY-WNN"` (e.g., `"2026-W21"`) without validation of week number validity

## Next Steps

This format enables #64 (auto-generate weekly work log on a schedule). The next slice would implement:
- `get_activity('week')` to provide structured data
- Agent rendering logic using this template
- File writing via `add_artifact` or future `write_journal_entry` tool
- Work Log page in WinUI app to render these files

Closes #218

