### PR TITLE
feat(visual-verification): computer-use inspection authoring aid

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -177,6 +177,13 @@ inside Ubuntu.
    Linux agents cannot run this** — they must flag UI-touching work for local
    re-verification before merge.
 
+   > **Skill:** the step-by-step playbook for this rule — verifying changes,
+   > writing scenarios, and discovering/scaffolding `AutomationId` selectors by
+   > inspecting the live UI Automation tree (`scripts\inspect-app.ps1`) — lives
+   > in [`.github/skills/visual-verification.md`](skills/visual-verification.md).
+   > It also feeds rule 6: a real render is what surfaces the silent
+   > `STOWED_EXCEPTION` crash that init-time cross-references cause.
+
 ## Investigation guidance (for issue triage & root-cause analysis)
 
 When assigned a user-reported issue (label `user-report`):

--- a/.github/skills/visual-verification.md
+++ b/.github/skills/visual-verification.md
@@ -1,0 +1,188 @@
+---
+name: visual-verification
+description: Verify Glasswork app (WinUI 3) changes by rendering the real UI, and author/scaffold verification scenarios by inspecting the live UI Automation tree. Use when changing anything under src/Glasswork.App (XAML, code-behind, ViewModels, App.xaml.cs, draw-affecting services), when a screenshot/visual check is needed, or when writing/discovering AutomationId selectors for a verification scenario.
+---
+
+# Visual verification & scenario authoring
+
+The MSTest suite (`Glasswork.Core`) cannot catch XAML parse errors, layout
+regressions, blank screens, or the silent `STOWED_EXCEPTION 0xc000027b` crashes
+that hard rule 6 describes. Only rendering the real WinUI app can. This skill
+covers (1) verifying a change visually and (2) authoring the deterministic
+scenarios that make verification repeatable — including a "computer use"
+authoring aid that introspects the live UI Automation tree.
+
+> Relationship to the hard rules: this skill is the *how* behind
+> copilot-instructions.md hard rules 6 & 7. Those rules still stand; this skill
+> is the playbook for satisfying them.
+
+**Windows + local only.** Everything here builds the Debug WinUI app and drives
+a real window. Cloud/Linux agents cannot run it — they must flag UI-touching
+work in the PR description for local re-verification before merge.
+
+---
+
+## 1. Verify a change
+
+All scripts launch the Debug build with a verification-only AppInstance key and
+an isolated temp Vault + UI-state file, skipping protocol registration and
+update checks. They never touch the user's installed Glasswork, real Vault,
+normal UI state, or the `glasswork://` handler. Only the spawned dev-build PID
+is screenshotted and killed.
+
+- **Generic startup smoke test** (no scenario needed):
+
+  ```powershell
+  pwsh -File scripts\verify-app.ps1
+  ```
+
+  Builds, launches, waits for the window, screenshots, kills the PID, prints the
+  PNG path. **View the PNG** before declaring the task done. If the process
+  exits before showing a window, that's a startup crash — check Event Viewer >
+  Application for `STOWED_EXCEPTION` / `XamlParseException` (hard rule 6).
+
+- **Behavior-specific verification** (preferred): run a JSON scenario that seeds
+  a deterministic Vault, navigates, and captures named PNGs. The runner rejects
+  blank/uniform screenshots automatically.
+
+  ```powershell
+  pwsh -File scripts\invoke-visual-verification.ps1 -Scenario scripts\visual-verification\backlog-smoke.json
+  ```
+
+  **Add or update a scenario that covers the behavior you changed**, then view
+  the captured PNG(s) under the printed output directory.
+
+---
+
+## 2. Scenario schema (cheat-sheet)
+
+Scenarios live in `scripts\visual-verification\*.json` and deserialize via
+`VisualVerificationScenario` (`Glasswork.Core`). camelCase, comments + trailing
+commas allowed.
+
+```jsonc
+{
+  "name": "Backlog smoke",            // required, non-empty
+  "startUri": "glasswork://backlog",  // optional deep link passed as argv[0]
+  "launchTimeoutSeconds": 20,
+  "initialWaitMilliseconds": 800,
+  "tasks": [                          // seeded into the isolated Vault
+    { "id": "safe-slug", "title": "...", "status": "todo", "priority": "high",
+      "subtasks": [ { "text": "...", "status": "in_progress" } ],
+      "artifacts": [ { "name": "plan.md", "markdown": "# ..." } ] }
+  ],
+  "actions": [                        // UI Automation driven, in order
+    { "type": "select",     "automationId": "NavBacklog", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for",   "automationId": "BacklogHeader" },
+    { "type": "set-value",  "automationId": "BacklogSearchBox", "value": "design" },
+    { "type": "invoke",     "name": "Some button" }
+  ],
+  "captures": [ { "name": "backlog", "waitMilliseconds": 0 } ]  // >= 1 required
+}
+```
+
+Action types: `wait-for` (asserts an element appears), `select`
+(SelectionItem/Invoke), `invoke` (InvokePattern), `set-value` (ValuePattern).
+Target by `automationId` (preferred — stable) or `name`.
+
+---
+
+## 3. Discover selectors
+
+Actions need real `AutomationId`s. Two ways to find them:
+
+- **Grep the XAML** for what's already tagged:
+
+  ```
+  AutomationProperties.AutomationId
+  ```
+
+  Convention: PascalCase ids; landmark headers end with `Header` (e.g.
+  `NavBacklog`, `BacklogHeader`, `BacklogTaskList`, `MyDayTodayHeader`).
+
+- **Inspect the live tree** (the authoring aid — see §4) when you don't know the
+  ids, the screen is new, or you want the full actionable menu.
+
+If the control you need has no `AutomationId`, add one in the XAML (it's also an
+accessibility win) rather than targeting by a brittle `name`.
+
+---
+
+## 4. Author scenarios with the inspection aid ("computer use")
+
+`scripts\inspect-app.ps1` is the authoring aid: it gives an agent the two things
+a computer-use loop needs — **eyes** (a screenshot) and the **accessibility
+tree** (selectors) — then scaffolds a starter scenario. It keeps CI
+deterministic because the committed scenario is hand-finalized, not model-driven.
+
+**Workflow: seed → inspect → refine.**
+
+1. Write a tiny *seed* scenario — just enough to reach the screen you care about
+   (a `startUri`, optional nav `select`/`wait-for` actions, and one throwaway
+   `capture` since the schema requires one).
+2. Run the aid:
+
+   ```powershell
+   pwsh -File scripts\inspect-app.ps1 -Scenario scripts\visual-verification\my-seed.json -OutDir out\inspect
+   ```
+
+3. Read the three artifacts it writes into the output dir:
+   - **`inspection.png`** — screenshot captured at the same moment as the tree
+     walk, so the catalog lines up with the pixels.
+   - **`inspection.json`** — the selector catalog (see shape below).
+   - **`scenario.suggested.json`** — a minimal, valid starter scenario
+     (waits for up to two stable landmark anchors + one capture). Use it as a
+     base; it deliberately omits state-mutating actions.
+4. Pick the actions you need from the catalog's `candidates` and flesh out a
+   real scenario, then commit it under `scripts\visual-verification\` and run it
+   through `invoke-visual-verification.ps1`.
+
+### `inspection.json` shape
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "screenName": "...", "startUri": "...", "windowTitle": "Glasswork",
+  "screenshotFile": "inspection.png",      // the paired PNG
+  "windowBounds": { "x": .., "y": .., "width": .., "height": .. },  // screen px
+  "dpiScale": 1,
+  "warnings": [ "N UI element(s) were skipped due to UI Automation errors." ],
+  "elements": [                            // bounds are SCREENSHOT-relative px
+    { "automationId": "BacklogHeader", "name": "Backlog", "controlType": "Text",
+      "depth": 4, "isOffscreen": false, "isEnabled": true,
+      "patterns": ["..."], "bounds": { "x": .., "y": .., "width": .., "height": .. } }
+  ],
+  "candidates": {                          // ready-to-use, grouped by action
+    "invokable":   [ /* -> "invoke"    actions (buttons) */ ],
+    "selectable":  [ /* -> "select"    actions (nav items, list items) */ ],
+    "valueFields": [ /* -> "set-value" actions (text boxes) */ ],
+    "toggles":     [ /* toggle controls */ ]
+  }
+}
+```
+
+`candidates.selectable` → `select` actions, `valueFields` → `set-value`,
+`invokable` → `invoke`. Element `bounds` are relative to the window's top-left
+(matching `inspection.png`), so a vision model can map a catalog entry to pixels.
+
+### Limitations of the aid
+
+- Walks the **ControlView** tree of the main window. WinUI flyouts/menus that
+  live in a separate popup HWND may not appear; drive the app to the state you
+  want (e.g. open the dialog via an action) before inspecting, and if it's a
+  separate window, target it with its own seed.
+- Per-element UIA reads are defensive (failures are skipped and counted in
+  `warnings`), so a noisy/transient tree degrades gracefully rather than failing.
+- The scaffolded scenario is a *starting point*, not a finished test.
+
+---
+
+## Checklist
+
+```
+[ ] Change touches src\Glasswork.App\ -> visual verification is required
+[ ] Ran verify-app.ps1 or a scenario; VIEWED the PNG (not just exit code)
+[ ] New/changed behavior has a committed scenario under scripts\visual-verification\
+[ ] New selectors discovered via grep or inspect-app.ps1; added AutomationIds where missing
+[ ] Cloud/Linux: flagged UI work for local re-verification in the PR description
+```

--- a/scripts/inspect-app.ps1
+++ b/scripts/inspect-app.ps1
@@ -1,0 +1,72 @@
+<#
+.SYNOPSIS
+  Inspect a Glasswork screen: launch in an isolated sandbox, walk the live UI
+  Automation tree, and emit a selector catalog + paired screenshot + a scaffolded
+  verification scenario.
+
+.DESCRIPTION
+  This is the "computer use" authoring aid. It runs a seed scenario (just enough
+  to navigate to the screen you care about), then dumps:
+    - inspection.json        the accessibility tree (AutomationIds, names, control
+                             types, supported patterns, screenshot-relative bounds,
+                             and candidate groupings by action) paired with...
+    - inspection.png         ...a screenshot captured at the same moment, so the
+                             catalog lines up with the pixels.
+    - scenario.suggested.json a minimal, valid starter scenario you can refine.
+
+  Workflow: write a tiny seed scenario (startUri + optional nav action + a
+  throwaway capture) -> run this -> read the catalog + view the PNG -> flesh out
+  a committed deterministic scenario under scripts\visual-verification\.
+
+  Like the other verification scripts, this launches the Debug build with a
+  verification-only AppInstance key and an isolated temp Vault + UI state, so it
+  never touches the user's installed Glasswork, real Vault, or glasswork://
+  handler. Windows-only; cloud/Linux agents cannot run it.
+
+.PARAMETER Scenario
+  Path to the seed scenario JSON used to launch + navigate before inspecting.
+
+.PARAMETER OutDir
+  Directory for inspection.json / inspection.png / scenario.suggested.json.
+  Defaults to a timestamped temp folder (printed on completion).
+
+.PARAMETER NoBuild
+  Skip dotnet build (use when you've just built).
+
+.EXAMPLE
+  pwsh -File scripts\inspect-app.ps1 -Scenario scripts\visual-verification\backlog-smoke.json
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Scenario,
+
+    [string]$OutDir,
+
+    [switch]$NoBuild
+)
+
+$ErrorActionPreference = 'Stop'
+$repo = Split-Path -Parent $PSScriptRoot
+$project = Join-Path $repo 'tools\Glasswork.VisualVerification\Glasswork.VisualVerification.csproj'
+
+$runnerArgs = @(
+    'run',
+    '--project', $project,
+    '--',
+    '--scenario', (Resolve-Path -LiteralPath $Scenario).Path,
+    '--repo-root', $repo,
+    '--inspect'
+)
+
+if ($OutDir) {
+    $runnerArgs += @('--out-dir', $OutDir)
+}
+if ($NoBuild) {
+    $runnerArgs += '--no-build'
+}
+
+& dotnet @runnerArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "Inspection failed with exit code $LASTEXITCODE."
+}

--- a/src/Glasswork.Core/VisualVerification/ScenarioScaffolder.cs
+++ b/src/Glasswork.Core/VisualVerification/ScenarioScaffolder.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Glasswork.Core.VisualVerification;
+
+/// <summary>
+/// Scaffolds a starter <see cref="VisualVerificationScenario"/> from an inspection
+/// snapshot. Deliberately conservative: it waits for stable landmark elements and
+/// captures one screenshot, but never auto-emits state-mutating actions
+/// (invoke/select/set-value) — those require author intent, and the inspection
+/// catalog's candidate groupings exist for the author to choose from.
+/// </summary>
+public static class ScenarioScaffolder
+{
+    private const string HeaderSuffix = "Header";
+    private const int MaxAnchors = 2;
+    private const int AnchorWaitMilliseconds = 10000;
+
+    private static readonly JsonSerializerOptions WriteOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true,
+    };
+
+    public static VisualVerificationScenario FromInspection(UiInspectionSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var anchors = SelectAnchors(snapshot.Elements);
+        var actions = anchors
+            .Select(a => new VisualVerificationAction
+            {
+                Type = "wait-for",
+                AutomationId = a.AutomationId,
+                TimeoutMilliseconds = AnchorWaitMilliseconds,
+            })
+            .ToList();
+
+        var scenario = new VisualVerificationScenario
+        {
+            Name = string.IsNullOrWhiteSpace(snapshot.ScreenName) ? "Inspected screen" : snapshot.ScreenName,
+            StartUri = snapshot.StartUri,
+            Actions = actions,
+            Captures = [new VisualVerificationCapture { Name = Slug(snapshot.ScreenName) }],
+        };
+
+        scenario.Validate();
+        return scenario;
+    }
+
+    public static string ToScenarioJson(VisualVerificationScenario scenario)
+    {
+        ArgumentNullException.ThrowIfNull(scenario);
+        scenario.Validate();
+        return JsonSerializer.Serialize(scenario, WriteOptions);
+    }
+
+    private static List<InspectedElement> SelectAnchors(IReadOnlyList<InspectedElement> elements) =>
+        elements
+            .Where(e => !string.IsNullOrWhiteSpace(e.AutomationId) && !e.IsOffscreen && e.IsEnabled)
+            .OrderBy(e => e.AutomationId!.EndsWith(HeaderSuffix, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+            .ThenBy(e => e.Depth)
+            .DistinctBy(e => e.AutomationId, StringComparer.OrdinalIgnoreCase)
+            .Take(MaxAnchors)
+            .ToList();
+
+    private static string Slug(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return "screen";
+
+        var builder = new StringBuilder(value.Length);
+        var lastWasDash = false;
+        foreach (var ch in value.Trim().ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                builder.Append(ch);
+                lastWasDash = false;
+            }
+            else if (!lastWasDash)
+            {
+                builder.Append('-');
+                lastWasDash = true;
+            }
+        }
+
+        var slug = builder.ToString().Trim('-');
+        return slug.Length == 0 ? "screen" : slug;
+    }
+}

--- a/src/Glasswork.Core/VisualVerification/UiInspectionBuilder.cs
+++ b/src/Glasswork.Core/VisualVerification/UiInspectionBuilder.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Glasswork.Core.VisualVerification;
+
+/// <summary>
+/// Turns the raw UI Automation facts gathered by the Windows tool into a
+/// catalog-ready <see cref="UiInspectionSnapshot"/>: normalizes pattern names,
+/// filters to elements worth cataloging, converts bounds to be
+/// screenshot-relative, truncates, and groups actionable candidates.
+///
+/// All logic here is pure so it can be unit-tested on Linux/cloud; the tool only
+/// supplies facts.
+/// </summary>
+public static class UiInspectionBuilder
+{
+    public const string InvokePattern = "Invoke";
+    public const string SelectionItemPattern = "SelectionItem";
+    public const string ValuePattern = "Value";
+    public const string TogglePattern = "Toggle";
+    public const string ExpandCollapsePattern = "ExpandCollapse";
+
+    private static readonly HashSet<string> ActionablePatterns = new(StringComparer.Ordinal)
+    {
+        InvokePattern,
+        SelectionItemPattern,
+        ValuePattern,
+        TogglePattern,
+        ExpandCollapsePattern,
+    };
+
+    public static UiInspectionSnapshot Build(UiInspectionInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        var warnings = new List<string>(input.Warnings);
+        var elements = new List<InspectedElement>();
+
+        foreach (var raw in input.RawElements)
+        {
+            var patterns = NormalizePatterns(raw.PatternNames);
+            if (!IsEligible(raw, patterns))
+                continue;
+
+            if (elements.Count >= input.MaxElements)
+            {
+                warnings.Add($"Catalog truncated at MaxElements={input.MaxElements}; some elements were omitted.");
+                break;
+            }
+
+            elements.Add(new InspectedElement
+            {
+                AutomationId = NullIfBlank(raw.AutomationId),
+                Name = NullIfBlank(raw.Name),
+                ControlType = raw.ControlType ?? string.Empty,
+                Depth = raw.Depth,
+                IsOffscreen = raw.IsOffscreen,
+                IsEnabled = raw.IsEnabled,
+                Patterns = patterns,
+                Bounds = ToWindowRelative(raw.ScreenBounds, input.WindowBounds),
+            });
+        }
+
+        return new UiInspectionSnapshot
+        {
+            ScreenName = input.ScreenName,
+            StartUri = input.StartUri,
+            WindowTitle = input.WindowTitle,
+            ScreenshotFile = input.ScreenshotFile,
+            WindowBounds = input.WindowBounds,
+            DpiScale = input.DpiScale <= 0 ? 1.0 : input.DpiScale,
+            Warnings = warnings,
+            Elements = elements,
+            Candidates = BuildCandidates(elements),
+        };
+    }
+
+    /// <summary>
+    /// Maps a raw UIA programmatic name to a friendly one, e.g.
+    /// "InvokePatternIdentifiers.Pattern" → "Invoke". Duplicates and blanks drop out.
+    /// </summary>
+    public static IReadOnlyList<string> NormalizePatterns(IReadOnlyList<string> rawPatternNames)
+    {
+        if (rawPatternNames is null || rawPatternNames.Count == 0)
+            return [];
+
+        var seen = new List<string>();
+        foreach (var raw in rawPatternNames)
+        {
+            var friendly = NormalizePatternName(raw);
+            if (!string.IsNullOrEmpty(friendly) && !seen.Contains(friendly))
+                seen.Add(friendly);
+        }
+
+        return seen;
+    }
+
+    private static string NormalizePatternName(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return string.Empty;
+
+        var trimmed = raw.Trim();
+        var marker = trimmed.IndexOf("PatternIdentifiers", StringComparison.Ordinal);
+        if (marker > 0)
+            return trimmed[..marker];
+
+        // Already friendly (e.g. supplied as "Invoke") — keep as-is.
+        return trimmed;
+    }
+
+    private static bool IsEligible(RawInspectedElement raw, IReadOnlyList<string> patterns)
+    {
+        if (!string.IsNullOrWhiteSpace(raw.AutomationId))
+            return true;
+        if (patterns.Any(ActionablePatterns.Contains))
+            return true;
+
+        // Keep on-screen named elements for context (headers, labels, list text).
+        return !string.IsNullOrWhiteSpace(raw.Name) && !raw.IsOffscreen;
+    }
+
+    private static ElementBounds? ToWindowRelative(ElementBounds? screen, ElementBounds? window)
+    {
+        if (screen is null)
+            return null;
+        if (window is null)
+            return screen;
+
+        return screen with { X = screen.X - window.X, Y = screen.Y - window.Y };
+    }
+
+    private static InspectionCandidates BuildCandidates(IReadOnlyList<InspectedElement> elements)
+    {
+        List<ElementRef> Group(string pattern) => elements
+            .Where(e => e.Patterns.Contains(pattern) &&
+                        (!string.IsNullOrWhiteSpace(e.AutomationId) || !string.IsNullOrWhiteSpace(e.Name)))
+            .Select(e => new ElementRef(e.AutomationId, e.Name, e.ControlType))
+            .ToList();
+
+        return new InspectionCandidates
+        {
+            Invokable = Group(InvokePattern),
+            Selectable = Group(SelectionItemPattern),
+            ValueFields = Group(ValuePattern),
+            Toggles = Group(TogglePattern),
+        };
+    }
+
+    private static string? NullIfBlank(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+}

--- a/src/Glasswork.Core/VisualVerification/UiInspectionSnapshot.cs
+++ b/src/Glasswork.Core/VisualVerification/UiInspectionSnapshot.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+
+namespace Glasswork.Core.VisualVerification;
+
+/// <summary>
+/// A rectangle. For <see cref="InspectedElement.Bounds"/> the origin is the
+/// top-left of the captured window (screenshot-relative pixels) so the catalog
+/// lines up with the paired PNG. For <see cref="UiInspectionSnapshot.WindowBounds"/>
+/// the values are in screen pixels.
+/// </summary>
+public sealed record ElementBounds(double X, double Y, double Width, double Height);
+
+/// <summary>
+/// Raw facts the Windows tool gathers from a single UI Automation element. No
+/// UIA types leak into Core — the tool maps everything to these primitives so
+/// the interesting selection/normalization logic stays unit-testable on Linux.
+/// </summary>
+public sealed class RawInspectedElement
+{
+    public string? AutomationId { get; init; }
+    public string? Name { get; init; }
+    public string? ControlType { get; init; }
+    public int Depth { get; init; }
+    public bool IsOffscreen { get; init; }
+    public bool IsEnabled { get; init; } = true;
+
+    /// <summary>Raw UIA programmatic pattern names, e.g. "InvokePatternIdentifiers.Pattern".</summary>
+    public IReadOnlyList<string> PatternNames { get; init; } = [];
+
+    /// <summary>Element bounds in screen pixels, as reported by UIA.</summary>
+    public ElementBounds? ScreenBounds { get; init; }
+}
+
+/// <summary>A processed, catalog-ready element. Bounds are screenshot-relative.</summary>
+public sealed class InspectedElement
+{
+    public string? AutomationId { get; init; }
+    public string? Name { get; init; }
+    public string ControlType { get; init; } = string.Empty;
+    public int Depth { get; init; }
+    public bool IsOffscreen { get; init; }
+    public bool IsEnabled { get; init; } = true;
+
+    /// <summary>Normalized, friendly pattern names, e.g. "Invoke", "Value", "SelectionItem".</summary>
+    public IReadOnlyList<string> Patterns { get; init; } = [];
+    public ElementBounds? Bounds { get; init; }
+}
+
+/// <summary>A compact selector reference, used in the candidate groupings.</summary>
+public sealed record ElementRef(string? AutomationId, string? Name, string ControlType);
+
+/// <summary>
+/// Non-executable authoring suggestions grouped by the action they would enable.
+/// The scaffolder deliberately does not auto-place these in scenario actions —
+/// an agent picks from them based on intent.
+/// </summary>
+public sealed class InspectionCandidates
+{
+    public IReadOnlyList<ElementRef> Invokable { get; init; } = [];
+    public IReadOnlyList<ElementRef> Selectable { get; init; } = [];
+    public IReadOnlyList<ElementRef> ValueFields { get; init; } = [];
+    public IReadOnlyList<ElementRef> Toggles { get; init; } = [];
+}
+
+/// <summary>
+/// The accessibility-tree catalog the tool emits as <c>inspection.json</c>. Paired
+/// with a screenshot (<see cref="ScreenshotFile"/>) captured at the same moment so
+/// a computer-use agent can map catalog entries to pixels.
+/// </summary>
+public sealed class UiInspectionSnapshot
+{
+    public int SchemaVersion { get; init; } = 1;
+    public string ScreenName { get; init; } = string.Empty;
+    public string? StartUri { get; init; }
+    public string? WindowTitle { get; init; }
+    public string? ScreenshotFile { get; init; }
+    public ElementBounds? WindowBounds { get; init; }
+    public double DpiScale { get; init; } = 1.0;
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+    public IReadOnlyList<InspectedElement> Elements { get; init; } = [];
+    public InspectionCandidates Candidates { get; init; } = new();
+}
+
+/// <summary>Inputs to <see cref="UiInspectionBuilder.Build"/>.</summary>
+public sealed class UiInspectionInput
+{
+    public string ScreenName { get; init; } = string.Empty;
+    public string? StartUri { get; init; }
+    public string? WindowTitle { get; init; }
+    public string? ScreenshotFile { get; init; }
+    public ElementBounds? WindowBounds { get; init; }
+    public double DpiScale { get; init; } = 1.0;
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+    public IReadOnlyList<RawInspectedElement> RawElements { get; init; } = [];
+
+    /// <summary>Cap on catalog size to keep <c>inspection.json</c> manageable.</summary>
+    public int MaxElements { get; init; } = 2000;
+}

--- a/tests/Glasswork.Tests/ScenarioScaffolderTests.cs
+++ b/tests/Glasswork.Tests/ScenarioScaffolderTests.cs
@@ -1,0 +1,110 @@
+using System.Linq;
+using Glasswork.Core.VisualVerification;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class ScenarioScaffolderTests
+{
+    private static UiInspectionSnapshot Snapshot(params InspectedElement[] elements) =>
+        new()
+        {
+            ScreenName = "Backlog smoke",
+            StartUri = "glasswork://backlog",
+            Elements = elements,
+        };
+
+    private static InspectedElement Element(
+        string? automationId = null,
+        string controlType = "Button",
+        bool isOffscreen = false,
+        int depth = 0) =>
+        new()
+        {
+            AutomationId = automationId,
+            ControlType = controlType,
+            IsOffscreen = isOffscreen,
+            Depth = depth,
+        };
+
+    [TestMethod]
+    public void FromInspection_PrefersHeaderAnchors_AndCapsAtTwo()
+    {
+        var scenario = ScenarioScaffolder.FromInspection(Snapshot(
+            Element(automationId: "BacklogTaskList", depth: 3),
+            Element(automationId: "BacklogHeader", depth: 1),
+            Element(automationId: "BacklogSearchBox", depth: 2)));
+
+        Assert.AreEqual(2, scenario.Actions.Count);
+        Assert.AreEqual("wait-for", scenario.Actions[0].Type);
+        Assert.AreEqual("BacklogHeader", scenario.Actions[0].AutomationId);
+    }
+
+    [TestMethod]
+    public void FromInspection_CarriesStartUri_AndSlugsCaptureName()
+    {
+        var scenario = ScenarioScaffolder.FromInspection(Snapshot(
+            Element(automationId: "BacklogHeader")));
+
+        Assert.AreEqual("glasswork://backlog", scenario.StartUri);
+        Assert.AreEqual(1, scenario.Captures.Count);
+        Assert.AreEqual("backlog-smoke", scenario.Captures[0].Name);
+    }
+
+    [TestMethod]
+    public void FromInspection_SkipsOffscreenAnchors()
+    {
+        var scenario = ScenarioScaffolder.FromInspection(Snapshot(
+            Element(automationId: "OffscreenHeader", isOffscreen: true),
+            Element(automationId: "BacklogTaskList")));
+
+        Assert.AreEqual(1, scenario.Actions.Count);
+        Assert.AreEqual("BacklogTaskList", scenario.Actions[0].AutomationId);
+    }
+
+    [TestMethod]
+    public void FromInspection_DeduplicatesAnchorsBySharedAutomationId()
+    {
+        var scenario = ScenarioScaffolder.FromInspection(Snapshot(
+            Element(automationId: "BacklogHeader", depth: 1),
+            Element(automationId: "BacklogHeader", depth: 2),
+            Element(automationId: "BacklogTaskList", depth: 3)));
+
+        Assert.AreEqual(2, scenario.Actions.Count);
+        CollectionAssert.AreEqual(
+            new[] { "BacklogHeader", "BacklogTaskList" },
+            scenario.Actions.Select(a => a.AutomationId).ToArray());
+    }
+
+    [TestMethod]
+    public void FromInspection_WithNoEligibleAnchors_StillProducesValidScenario()
+    {
+        var scenario = ScenarioScaffolder.FromInspection(new UiInspectionSnapshot
+        {
+            ScreenName = "Empty screen",
+            Elements = [Element(controlType: "Text")],
+        });
+
+        Assert.AreEqual(0, scenario.Actions.Count);
+        Assert.AreEqual(1, scenario.Captures.Count);
+        scenario.Validate();
+    }
+
+    [TestMethod]
+    public void ToScenarioJson_RoundTripsThroughFromJson_WithCamelCase()
+    {
+        var scenario = ScenarioScaffolder.FromInspection(Snapshot(
+            Element(automationId: "BacklogHeader")));
+
+        var json = ScenarioScaffolder.ToScenarioJson(scenario);
+
+        StringAssert.Contains(json, "\"startUri\"");
+        Assert.IsFalse(json.Contains("\"StartUri\""));
+
+        var reparsed = VisualVerificationScenario.FromJson(json);
+        Assert.AreEqual("Backlog smoke", reparsed.Name);
+        Assert.AreEqual("glasswork://backlog", reparsed.StartUri);
+        Assert.AreEqual("BacklogHeader", reparsed.Actions[0].AutomationId);
+        Assert.AreEqual("backlog-smoke", reparsed.Captures[0].Name);
+    }
+}

--- a/tests/Glasswork.Tests/UiInspectionBuilderTests.cs
+++ b/tests/Glasswork.Tests/UiInspectionBuilderTests.cs
@@ -1,0 +1,157 @@
+using System.Collections.Generic;
+using System.Linq;
+using Glasswork.Core.VisualVerification;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class UiInspectionBuilderTests
+{
+    private static RawInspectedElement Raw(
+        string? automationId = null,
+        string? name = null,
+        string controlType = "Button",
+        bool isOffscreen = false,
+        IReadOnlyList<string>? patterns = null,
+        ElementBounds? bounds = null,
+        int depth = 0) =>
+        new()
+        {
+            AutomationId = automationId,
+            Name = name,
+            ControlType = controlType,
+            IsOffscreen = isOffscreen,
+            PatternNames = patterns ?? [],
+            ScreenBounds = bounds,
+            Depth = depth,
+        };
+
+    [TestMethod]
+    public void NormalizePatterns_MapsProgrammaticNames_AndDeduplicates()
+    {
+        var result = UiInspectionBuilder.NormalizePatterns(
+        [
+            "InvokePatternIdentifiers.Pattern",
+            "ValuePatternIdentifiers.Pattern",
+            "InvokePatternIdentifiers.Pattern",
+            "   ",
+        ]);
+
+        CollectionAssert.AreEqual(new[] { "Invoke", "Value" }, result.ToArray());
+    }
+
+    [TestMethod]
+    public void Build_KeepsElementWithAutomationId_EvenWithoutPatternsOrName()
+    {
+        var snapshot = UiInspectionBuilder.Build(new UiInspectionInput
+        {
+            RawElements = [Raw(automationId: "NavBacklog")],
+        });
+
+        Assert.AreEqual(1, snapshot.Elements.Count);
+        Assert.AreEqual("NavBacklog", snapshot.Elements[0].AutomationId);
+        Assert.AreEqual(1, snapshot.SchemaVersion);
+    }
+
+    [TestMethod]
+    public void Build_KeepsActionableElement_WithoutAutomationId()
+    {
+        var snapshot = UiInspectionBuilder.Build(new UiInspectionInput
+        {
+            RawElements = [Raw(patterns: ["InvokePatternIdentifiers.Pattern"])],
+        });
+
+        Assert.AreEqual(1, snapshot.Elements.Count);
+        CollectionAssert.Contains(snapshot.Elements[0].Patterns.ToArray(), "Invoke");
+    }
+
+    [TestMethod]
+    public void Build_DropsElement_WithNoId_NoPattern_AndNoName()
+    {
+        var snapshot = UiInspectionBuilder.Build(new UiInspectionInput
+        {
+            RawElements = [Raw(controlType: "Border")],
+        });
+
+        Assert.AreEqual(0, snapshot.Elements.Count);
+    }
+
+    [TestMethod]
+    public void Build_KeepsOnScreenNamedElement_ButDropsOffscreenNamedOnly()
+    {
+        var snapshot = UiInspectionBuilder.Build(new UiInspectionInput
+        {
+            RawElements =
+            [
+                Raw(name: "Visible label", controlType: "Text"),
+                Raw(name: "Hidden label", controlType: "Text", isOffscreen: true),
+            ],
+        });
+
+        Assert.AreEqual(1, snapshot.Elements.Count);
+        Assert.AreEqual("Visible label", snapshot.Elements[0].Name);
+    }
+
+    [TestMethod]
+    public void Build_ConvertsScreenBounds_ToWindowRelative()
+    {
+        var snapshot = UiInspectionBuilder.Build(new UiInspectionInput
+        {
+            WindowBounds = new ElementBounds(30, 20, 800, 600),
+            RawElements = [Raw(automationId: "BacklogHeader", bounds: new ElementBounds(130, 70, 200, 40))],
+        });
+
+        var bounds = snapshot.Elements[0].Bounds!;
+        Assert.AreEqual(100, bounds.X);
+        Assert.AreEqual(50, bounds.Y);
+        Assert.AreEqual(200, bounds.Width);
+        Assert.AreEqual(40, bounds.Height);
+    }
+
+    [TestMethod]
+    public void Build_TruncatesAtMaxElements_AndWarns()
+    {
+        var raws = Enumerable.Range(0, 5).Select(i => Raw(automationId: $"Id{i}")).ToList();
+
+        var snapshot = UiInspectionBuilder.Build(new UiInspectionInput
+        {
+            MaxElements = 3,
+            RawElements = raws,
+        });
+
+        Assert.AreEqual(3, snapshot.Elements.Count);
+        Assert.IsTrue(snapshot.Warnings.Any(w => w.Contains("truncated", System.StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [TestMethod]
+    public void Build_GroupsCandidates_ByPattern()
+    {
+        var snapshot = UiInspectionBuilder.Build(new UiInspectionInput
+        {
+            RawElements =
+            [
+                Raw(automationId: "NavBacklog", patterns: ["SelectionItemPatternIdentifiers.Pattern"]),
+                Raw(automationId: "BacklogSearchBox", patterns: ["ValuePatternIdentifiers.Pattern"]),
+            ],
+        });
+
+        Assert.AreEqual(1, snapshot.Candidates.Selectable.Count);
+        Assert.AreEqual("NavBacklog", snapshot.Candidates.Selectable[0].AutomationId);
+        Assert.AreEqual(1, snapshot.Candidates.ValueFields.Count);
+        Assert.AreEqual("BacklogSearchBox", snapshot.Candidates.ValueFields[0].AutomationId);
+    }
+
+    [TestMethod]
+    public void Build_PassesThroughWarningsAndScreenshotFile()
+    {
+        var snapshot = UiInspectionBuilder.Build(new UiInspectionInput
+        {
+            ScreenshotFile = "inspection.png",
+            Warnings = ["2 elements skipped due to UIA errors"],
+            RawElements = [Raw(automationId: "NavBacklog")],
+        });
+
+        Assert.AreEqual("inspection.png", snapshot.ScreenshotFile);
+        CollectionAssert.Contains(snapshot.Warnings.ToArray(), "2 elements skipped due to UIA errors");
+    }
+}

--- a/tools/Glasswork.VisualVerification/Program.cs
+++ b/tools/Glasswork.VisualVerification/Program.cs
@@ -6,6 +6,7 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,6 +24,13 @@ internal static partial class VisualVerificationRunner
 
     public static async Task<int> RunAsync(string[] args)
     {
+        // Declare Per-Monitor-V2 DPI awareness before any window/UIA/DWM call so
+        // GetWindowRect/DwmGetWindowAttribute report physical pixels that match
+        // UIA's BoundingRectangle and the PrintWindow capture. Without this, a
+        // DPI-unaware process gets virtualized window rects on >100% displays and
+        // the inspection catalog's bounds would not line up with the screenshot.
+        EnsureDpiAware();
+
         try
         {
             var options = RunnerOptions.Parse(args);
@@ -86,6 +94,10 @@ internal static partial class VisualVerificationRunner
                 PerformAction(hwnd, action);
             }
 
+            var inspection = options.Inspect
+                ? EmitInspection(hwnd, scenario, options.OutDir)
+                : null;
+
             var captures = new List<CaptureResult>();
             foreach (var capture in scenario.Captures)
             {
@@ -107,7 +119,9 @@ internal static partial class VisualVerificationRunner
                 todoPath,
                 uiStatePath,
                 instanceKey,
-                captures);
+                captures,
+                inspection?.InspectionPath,
+                inspection?.SuggestedScenarioPath);
         }
         finally
         {
@@ -202,6 +216,149 @@ internal static partial class VisualVerificationRunner
                 throw new FormatException($"Unsupported visual verification action type '{action.Type}'.");
         }
     }
+
+    private static InspectionPaths EmitInspection(IntPtr hwnd, VisualVerificationScenario scenario, string outDir)
+    {
+        // Capture the paired screenshot and walk the tree back-to-back so the
+        // catalog and the PNG describe the same UI state.
+        const string screenshotFile = "inspection.png";
+        CaptureWindow(hwnd, Path.Combine(outDir, screenshotFile));
+
+        var (rawElements, warnings) = WalkUiaTree(hwnd);
+
+        var snapshot = UiInspectionBuilder.Build(new UiInspectionInput
+        {
+            ScreenName = scenario.Name,
+            StartUri = scenario.StartUri,
+            WindowTitle = TryGet(() => AutomationElement.FromHandle(hwnd).Current.Name),
+            ScreenshotFile = screenshotFile,
+            WindowBounds = GetWindowBounds(hwnd),
+            DpiScale = GetDpiScale(hwnd),
+            Warnings = warnings,
+            RawElements = rawElements,
+        });
+
+        var inspectionPath = Path.Combine(outDir, "inspection.json");
+        File.WriteAllText(inspectionPath, JsonSerializer.Serialize(snapshot, InspectionJsonOptions));
+
+        var suggestedPath = Path.Combine(outDir, "scenario.suggested.json");
+        File.WriteAllText(suggestedPath, ScenarioScaffolder.ToScenarioJson(ScenarioScaffolder.FromInspection(snapshot)));
+
+        return new InspectionPaths(inspectionPath, suggestedPath);
+    }
+
+    private static (List<RawInspectedElement> Elements, List<string> Warnings) WalkUiaTree(IntPtr hwnd)
+    {
+        const int maxDepth = 40;
+        const int maxNodes = 4000;
+        var walker = TreeWalker.ControlViewWalker;
+        var elements = new List<RawInspectedElement>();
+        var skipped = 0;
+        var hitMaxDepth = false;
+        var hitMaxNodes = false;
+
+        void Visit(AutomationElement element, int depth)
+        {
+            if (elements.Count >= maxNodes)
+            {
+                hitMaxNodes = true;
+                return;
+            }
+            if (depth > maxDepth)
+            {
+                hitMaxDepth = true;
+                return;
+            }
+
+            try { elements.Add(ToRawElement(element, depth)); }
+            catch { skipped++; }
+
+            AutomationElement? child;
+            try { child = walker.GetFirstChild(element); }
+            catch { skipped++; return; }
+
+            while (child is not null && elements.Count < maxNodes)
+            {
+                Visit(child, depth + 1);
+                try { child = walker.GetNextSibling(child); }
+                catch { skipped++; break; }
+            }
+        }
+
+        try { Visit(AutomationElement.FromHandle(hwnd), 0); }
+        catch { skipped++; }
+
+        var warnings = new List<string>();
+        if (skipped > 0)
+            warnings.Add($"{skipped} UI element(s) were skipped due to UI Automation errors.");
+        if (hitMaxNodes)
+            warnings.Add($"UI Automation traversal stopped at maxNodes={maxNodes}; some elements were omitted.");
+        if (hitMaxDepth)
+            warnings.Add($"UI Automation traversal reached maxDepth={maxDepth}; deeper descendants were omitted.");
+
+        return (elements, warnings);
+    }
+
+    private static RawInspectedElement ToRawElement(AutomationElement element, int depth)
+    {
+        var patterns = new List<string>();
+        try
+        {
+            foreach (var pattern in element.GetSupportedPatterns())
+                patterns.Add(pattern.ProgrammaticName);
+        }
+        catch { /* enumeration can fail on transient elements; keep what we have. */ }
+
+        return new RawInspectedElement
+        {
+            AutomationId = TryGet(() => element.Current.AutomationId),
+            Name = TryGet(() => element.Current.Name),
+            ControlType = TryGet(() => element.Current.ControlType?.ProgrammaticName?.Replace("ControlType.", string.Empty)),
+            Depth = depth,
+            IsOffscreen = TryGet(() => (bool?)element.Current.IsOffscreen) ?? false,
+            IsEnabled = TryGet(() => (bool?)element.Current.IsEnabled) ?? true,
+            PatternNames = patterns,
+            ScreenBounds = TryGet<ElementBounds?>(() =>
+            {
+                var rect = element.Current.BoundingRectangle;
+                return rect.IsEmpty ? null : new ElementBounds(rect.X, rect.Y, rect.Width, rect.Height);
+            }),
+        };
+    }
+
+    private static ElementBounds GetWindowBounds(IntPtr hwnd)
+    {
+        if (DwmGetWindowAttribute(hwnd, DwmWindowAttributeExtendedFrameBounds, out var rect, Marshal.SizeOf<Rect>()) != 0)
+        {
+            if (!GetWindowRect(hwnd, out rect))
+                throw new InvalidOperationException("GetWindowRect failed.");
+        }
+
+        return new ElementBounds(rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top);
+    }
+
+    private static double GetDpiScale(IntPtr hwnd)
+    {
+        try
+        {
+            var dpi = GetDpiForWindow(hwnd);
+            return dpi > 0 ? dpi / 96.0 : 1.0;
+        }
+        catch { return 1.0; }
+    }
+
+    private static T? TryGet<T>(Func<T?> getter)
+    {
+        try { return getter(); }
+        catch { return default; }
+    }
+
+    private static readonly JsonSerializerOptions InspectionJsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
 
     private static AutomationElement WaitForElement(IntPtr hwnd, VisualVerificationAction action)
     {
@@ -346,6 +503,13 @@ internal static partial class VisualVerificationRunner
     [GeneratedRegex(@"[\\/:*?""<>|]+")]
     private static partial Regex InvalidFileNameCharsRegex();
 
+    private static void EnsureDpiAware()
+    {
+        // Best-effort: fails harmlessly if awareness was already set by a host/manifest.
+        try { SetProcessDpiAwarenessContext(DpiAwarenessContextPerMonitorAwareV2); }
+        catch { /* older OS without the API — fall back to process default. */ }
+    }
+
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool PrintWindow(IntPtr hwnd, IntPtr hdcBlt, uint nFlags);
@@ -356,6 +520,16 @@ internal static partial class VisualVerificationRunner
 
     [DllImport("dwmapi.dll")]
     private static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out Rect pvAttribute, int cbAttribute);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetDpiForWindow(IntPtr hwnd);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetProcessDpiAwarenessContext(IntPtr value);
+
+    // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 == (HANDLE)-4.
+    private static readonly IntPtr DpiAwarenessContextPerMonitorAwareV2 = new(-4);
 
     private const uint PrintWindowRenderFullContent = 2;
     private const int DwmWindowAttributeExtendedFrameBounds = 9;
@@ -375,7 +549,8 @@ internal sealed record RunnerOptions(
     string RepoRoot,
     string OutDir,
     bool NoBuild,
-    bool KeepWorkingDirectory)
+    bool KeepWorkingDirectory,
+    bool Inspect)
 {
     public static RunnerOptions Parse(string[] args)
     {
@@ -384,6 +559,7 @@ internal sealed record RunnerOptions(
         string? outDir = null;
         var noBuild = false;
         var keepWorkingDir = false;
+        var inspect = false;
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -404,13 +580,16 @@ internal sealed record RunnerOptions(
                 case "--keep-working-directory":
                     keepWorkingDir = true;
                     break;
+                case "--inspect":
+                    inspect = true;
+                    break;
                 default:
                     throw new FormatException($"Unknown argument '{args[i]}'.");
             }
         }
 
         if (string.IsNullOrWhiteSpace(scenario))
-            throw new FormatException("Usage: Glasswork.VisualVerification --scenario <path> [--repo-root <path>] [--out-dir <path>] [--no-build]");
+            throw new FormatException("Usage: Glasswork.VisualVerification --scenario <path> [--repo-root <path>] [--out-dir <path>] [--no-build] [--inspect]");
 
         repoRoot ??= FindRepoRoot(Environment.CurrentDirectory);
         outDir ??= Path.Combine(
@@ -422,7 +601,8 @@ internal sealed record RunnerOptions(
             Path.GetFullPath(repoRoot),
             Path.GetFullPath(outDir),
             noBuild,
-            keepWorkingDir);
+            keepWorkingDir,
+            inspect);
     }
 
     private static string RequireValue(string[] args, ref int index, string name)
@@ -453,7 +633,11 @@ internal sealed record VerificationResult(
     string VaultPath,
     string UiStatePath,
     string InstanceKey,
-    IReadOnlyList<CaptureResult> Captures);
+    IReadOnlyList<CaptureResult> Captures,
+    string? InspectionPath = null,
+    string? SuggestedScenarioPath = null);
+
+internal sealed record InspectionPaths(string InspectionPath, string SuggestedScenarioPath);
 
 internal sealed record CaptureResult(
     string Name,


### PR DESCRIPTION
## Summary

Adds a "computer-use" authoring aid on top of Glasswork's existing visual-verification system. It launches the WinUI app in the existing isolated sandbox, walks the live UI Automation tree, and emits a **selector catalog (`inspection.json`) paired with a screenshot (`inspection.png`)** plus a **scaffolded starter scenario (`scenario.suggested.json`)**. This gives an agent the two things a computer-use loop needs — eyes (the PNG) and the accessibility tree (selectors) — while keeping CI scenarios deterministic (the committed scenario is hand-finalized, not model-driven).

## What''s included

- **`Glasswork.Core/VisualVerification/`** (pure, cross-platform, unit-tested):
  - `UiInspectionSnapshot.cs` — models (`UiInspectionSnapshot`, `RawInspectedElement`, `InspectedElement`, `ElementBounds`, `InspectionCandidates`, `UiInspectionInput`).
  - `UiInspectionBuilder.cs` — pattern-name normalization, eligibility filtering, screen->window-relative bounds, truncation with warnings, candidate grouping by action.
  - `ScenarioScaffolder.cs` — minimal valid scenario (wait-for stable anchors + one capture, carries `startUri`); camelCase JSON that round-trips through `VisualVerificationScenario.FromJson`.
- **`tools/Glasswork.VisualVerification/Program.cs`** (Windows-only) — `--inspect` mode: defensive UIA ControlView walk (per-property try/catch, depth/node caps + warnings), paired screenshot, Per-Monitor-V2 DPI awareness so catalog bounds align with the PNG.
- **`scripts/inspect-app.ps1`** — thin wrapper to `--inspect`.
- **`.github/skills/visual-verification.md`** — new skill (verify changes + author/scaffold scenarios); cross-linked from copilot-instructions hard rules 6 & 7.
- Tests: `UiInspectionBuilderTests.cs`, `ScenarioScaffolderTests.cs` (MSTest).

## Validation

- `dotnet test tests/Glasswork.Tests/` — 790 passing.
- Real end-to-end `--inspect` run against `backlog-smoke.json` produces an aligned catalog (nav items -> `selectable`, `BacklogSearchBox` -> `valueField`, toggles detected), window-relative bounds, and a valid scaffold. Render verified visually.

## Review notes

Reviewed by dual `code-review` agents (`gpt-5.5` + `claude-opus-4.7`). Adopted: silent UIA-cap truncation warnings, runner Per-Monitor-V2 DPI awareness (UIA `BoundingRectangle` is physical px while `GetWindowRect`/DWM are virtualized in an unaware process), anchor de-duplication, and a `Bounds.Height` test assertion. Set aside one finding (a "truncation false-positive" that doesn''t occur because ineligible elements `continue` before the cap check).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
