### PR TITLE
fix: close #131 as duplicate of #182 (scroll preservation already implemented)

### DIFF
--- a/.ralph-pr-body-131.md
+++ b/.ralph-pr-body-131.md
@@ -1,0 +1,48 @@
+# fix: close #131 as duplicate of #182 (scroll preservation already implemented)
+
+Closes #131
+
+## Summary
+
+Issue #131 is a duplicate of #182. The scroll preservation feature was fully implemented and merged in:
+- PR #183 (May 19, 2026) - Backlog scroll preservation
+- PR #233 (June 1, 2026) - My Day scroll preservation
+
+## Implementation Status
+
+All acceptance criteria from #131 are already met:
+
+✅ **Toggling a task checkbox in Backlog keeps scroll position**
+- Implemented via `BacklogPage.Refreshing`/`Refreshed` event handlers
+- Captures scroll state before `VM.Refresh()`, restores after layout
+
+✅ **External file edit keeps scroll position**
+- Same mechanism handles all `Refresh()` paths (checkbox, file watcher, etc.)
+- `_pendingRestore ??=` pattern preserves original offset across back-to-back refreshes
+
+✅ **My Day has the same behavior**
+- Identical pattern in `MyDayPage` for `TodayList`
+- Merged in PR #233
+
+✅ **No regression to grouping/collapse/filter**
+- Context validation (ViewMode/IsGrouped/FilterStatus/SearchText) drops stale snapshots
+- User-initiated layout changes correctly jump to top
+
+## Verification
+
+All existing tests pass:
+
+```
+dotnet test --filter "FullyQualifiedName~RefreshingEvent"
+Test summary: total: 16, failed: 0, succeeded: 16, skipped: 0
+```
+
+Test coverage includes:
+- `BacklogViewModelRefreshingEventTests` (7 tests) - event contract for Backlog
+- `MyDayViewModelRefreshingEventTests` (9 tests) - event contract for My Day
+
+## Related Issues
+
+- #182 - Original issue (closed via PR #183)
+- PR #183 - Backlog fix
+- PR #233 - My Day fix


### PR DESCRIPTION
# fix: close #131 as duplicate of #182 (scroll preservation already implemented)

Closes #131

## Summary

Issue #131 is a duplicate of #182. The scroll preservation feature was fully implemented and merged in:
- PR #183 (May 19, 2026) - Backlog scroll preservation
- PR #233 (June 1, 2026) - My Day scroll preservation

## Implementation Status

All acceptance criteria from #131 are already met:

✅ **Toggling a task checkbox in Backlog keeps scroll position**
- Implemented via `BacklogPage.Refreshing`/`Refreshed` event handlers
- Captures scroll state before `VM.Refresh()`, restores after layout

✅ **External file edit keeps scroll position**
- Same mechanism handles all `Refresh()` paths (checkbox, file watcher, etc.)
- `_pendingRestore ??=` pattern preserves original offset across back-to-back refreshes

✅ **My Day has the same behavior**
- Identical pattern in `MyDayPage` for `TodayList`
- Merged in PR #233

✅ **No regression to grouping/collapse/filter**
- Context validation (ViewMode/IsGrouped/FilterStatus/SearchText) drops stale snapshots
- User-initiated layout changes correctly jump to top

## Verification

All existing tests pass:

```
dotnet test --filter "FullyQualifiedName~RefreshingEvent"
Test summary: total: 16, failed: 0, succeeded: 16, skipped: 0
```

Test coverage includes:
- `BacklogViewModelRefreshingEventTests` (7 tests) - event contract for Backlog
- `MyDayViewModelRefreshingEventTests` (9 tests) - event contract for My Day

## Related Issues

- #182 - Original issue (closed via PR #183)
- PR #183 - Backlog fix
- PR #233 - My Day fix
