### PR TITLE
feat: add mode parameter to add_artifact for iterative agent work

### DIFF
--- a/src/Glasswork.Mcp/CHANGELOG.md
+++ b/src/Glasswork.Mcp/CHANGELOG.md
@@ -5,6 +5,14 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`add_artifact` overwrite mode** (issue #134): optional `mode` parameter (`"create"` | `"overwrite"`). When `mode: "overwrite"`, the tool replaces the content of an existing artifact file instead of returning `{error: "conflict"}`. Defaults to `"create"` (create-only) for backward compatibility. Use `"overwrite"` for iterative agent workflows that refine artifacts (e.g., `plan.md`) across multiple turns without inventing `plan-v2.md` filenames. Path-traversal guards, `SelfWriteCoordinator` registration, and write-phase trace instrumentation still apply.
+
+---
+
 ## [0.7.0] — 2026-06-03
 
 ### Added

--- a/src/Glasswork.Mcp/README.md
+++ b/src/Glasswork.Mcp/README.md
@@ -319,7 +319,8 @@ Re-reads the vault and artifact folder on every call (no cache). The `artifacts`
 {
   "task_id": "string (required) — owning task ID",
   "filename": "string (required) — must end in .md, no path separators",
-  "content": "string (required) — full markdown content"
+  "content": "string (required) — full markdown content",
+  "mode": "string (optional) — \"create\" (default) | \"overwrite\""
 }
 ```
 
@@ -339,7 +340,11 @@ Re-reads the vault and artifact folder on every call (no cache). The `artifacts`
 | `invalid_filename` | `filename` is null, empty, whitespace, or does not end in `.md` |
 | `invalid_content` | `content` is null |
 | `path_traversal` | `filename` contains a path separator (`/` or `\`), `..`, is absolute, or resolves outside the artifact folder |
-| `conflict` | A file with that name already exists — `add_artifact` is create-only in v1 |
+| `conflict` | A file with that name already exists and `mode` is `"create"` (or omitted). Pass `mode: "overwrite"` to replace existing files |
+
+**Mode behavior:**
+- `mode: "create"` (or omitted) — create-only semantics. Returns `{error: "conflict"}` if the file already exists.
+- `mode: "overwrite"` — create-or-replace semantics. If the file exists, replaces its content. If it doesn't exist, creates it. Use this for iterative agent workflows that refine artifacts across multiple turns.
 
 Artifacts are stored under `<vault>/wiki/todo/<task-id>.artifacts/<filename>`. The write is registered with `SelfWriteCoordinator` so the running Glasswork app does not raise a spurious "external change" banner.
 

--- a/src/Glasswork.Mcp/README.md
+++ b/src/Glasswork.Mcp/README.md
@@ -339,6 +339,7 @@ Re-reads the vault and artifact folder on every call (no cache). The `artifacts`
 | `not_found` | The task ID does not exist in the vault |
 | `invalid_filename` | `filename` is null, empty, whitespace, or does not end in `.md` |
 | `invalid_content` | `content` is null |
+| `invalid_mode` | `mode` is not null, `"create"`, or `"overwrite"` (case-insensitive, whitespace-trimmed) |
 | `path_traversal` | `filename` contains a path separator (`/` or `\`), `..`, is absolute, or resolves outside the artifact folder |
 | `conflict` | A file with that name already exists and `mode` is `"create"` (or omitted). Pass `mode: "overwrite"` to replace existing files |
 

--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -305,7 +305,8 @@ public sealed class GlassworkTools
     public string AddArtifact(
         [Description("Task ID that owns the artifact.")] string task_id,
         [Description("Filename for the artifact, must end in .md (e.g. 'plan.md'). Simple filenames only — no path separators.")] string filename,
-        [Description("Markdown content to write into the artifact file.")] string? content)
+        [Description("Markdown content to write into the artifact file.")] string? content,
+        [Description("Write mode: \"create\" (default, fails if file exists) or \"overwrite\" (create-or-replace).")] string? mode = null)
     {
         using var scope = _logger?.BeginCall("add_artifact");
         try
@@ -362,7 +363,8 @@ public sealed class GlassworkTools
                     $"Filename '{filename}' is not allowed. Use a simple filename without path separators or '..'."));
             }
 
-            if (File.Exists(resolvedPath))
+            var effectiveMode = mode?.ToLowerInvariant() ?? "create";
+            if (effectiveMode == "create" && File.Exists(resolvedPath))
             {
                 scope?.SetResult("conflict");
                 return JsonSerializer.Serialize(new ErrorResult("conflict",

--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -363,7 +363,14 @@ public sealed class GlassworkTools
                     $"Filename '{filename}' is not allowed. Use a simple filename without path separators or '..'."));
             }
 
-            var effectiveMode = mode?.ToLowerInvariant() ?? "create";
+            var effectiveMode = mode?.Trim().ToLowerInvariant() ?? "create";
+            if (effectiveMode != "create" && effectiveMode != "overwrite")
+            {
+                scope?.SetResult("error");
+                return JsonSerializer.Serialize(new ErrorResult("invalid_mode",
+                    $"Invalid mode '{mode}'. Valid values: create, overwrite."));
+            }
+
             if (effectiveMode == "create" && File.Exists(resolvedPath))
             {
                 scope?.SetResult("conflict");

--- a/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
@@ -1032,6 +1032,31 @@ public class GlassworkToolsTests
     }
 
     [TestMethod]
+    public void AddArtifact_InvalidMode_ReturnsInvalidModeError()
+    {
+        var addJson = _tools.AddTask("Invalid Mode Test");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        _tools.AddArtifact(taskId, "original.md", "ORIGINAL_CONTENT");
+
+        // Act: try to overwrite with an invalid mode value (typo)
+        var resultJson = _tools.AddArtifact(taskId, "original.md", "TYPO_REPLACED", mode: "creat");
+
+        // Assert: must return invalid_mode error
+        var doc = JsonDocument.Parse(resultJson);
+        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var errorProp),
+            "AddArtifact with invalid mode must return an error envelope.");
+        Assert.AreEqual("invalid_mode", errorProp.GetString(),
+            "Error code must be 'invalid_mode' for unrecognized mode values.");
+
+        // Assert: existing artifact must not be overwritten
+        var artifactPath = ResolveTodoPath(Path.Combine(taskId + ".artifacts", "original.md"));
+        var actualContent = File.ReadAllText(artifactPath);
+        Assert.AreEqual("ORIGINAL_CONTENT", actualContent,
+            "Existing artifact must not be overwritten when an invalid mode is passed.");
+    }
+
+    [TestMethod]
     public void AddArtifact_VisibleViaGetTask()
     {
         var addJson = _tools.AddTask("End To End Task");

--- a/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
@@ -906,6 +906,92 @@ public class GlassworkToolsTests
     }
 
     [TestMethod]
+    public void AddArtifact_OverwriteMode_ReplacesExistingFile()
+    {
+        var addJson = _tools.AddTask("Overwrite Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        _tools.AddArtifact(taskId, "plan.md", "v1");
+        var json = _tools.AddArtifact(taskId, "plan.md", "v2", mode: "overwrite");
+        var doc = JsonDocument.Parse(json);
+
+        var path = doc.RootElement.GetProperty("path").GetString()!;
+        Assert.IsFalse(string.IsNullOrEmpty(path), "Overwrite must succeed and return path.");
+
+        var artifactFolder = Path.Combine(TasksDir, taskId + ".artifacts");
+        var content = File.ReadAllText(Path.Combine(artifactFolder, "plan.md"));
+        Assert.AreEqual("v2", content, "Overwrite mode must replace file content.");
+    }
+
+    [TestMethod]
+    public void AddArtifact_OverwriteMode_CreatesNewFile()
+    {
+        var addJson = _tools.AddTask("Overwrite Create Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var json = _tools.AddArtifact(taskId, "new.md", "content", mode: "overwrite");
+        var doc = JsonDocument.Parse(json);
+
+        var path = doc.RootElement.GetProperty("path").GetString()!;
+        Assert.IsFalse(string.IsNullOrEmpty(path), "Overwrite must succeed for new file.");
+
+        var artifactFolder = Path.Combine(TasksDir, taskId + ".artifacts");
+        var content = File.ReadAllText(Path.Combine(artifactFolder, "new.md"));
+        Assert.AreEqual("content", content, "Overwrite mode creates new file when it doesn't exist.");
+    }
+
+    [TestMethod]
+    public void AddArtifact_CreateModeDefault_StillReturnsConflict()
+    {
+        var addJson = _tools.AddTask("Default Mode Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        _tools.AddArtifact(taskId, "plan.md", "first");
+        var json = _tools.AddArtifact(taskId, "plan.md", "second");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("conflict", doc.RootElement.GetProperty("error").GetString(),
+            "Default mode (omitted) must still return conflict for existing files.");
+    }
+
+    [TestMethod]
+    public void AddArtifact_CreateModeExplicit_ReturnsConflict()
+    {
+        var addJson = _tools.AddTask("Explicit Create Mode Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        _tools.AddArtifact(taskId, "plan.md", "first");
+        var json = _tools.AddArtifact(taskId, "plan.md", "second", mode: "create");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("conflict", doc.RootElement.GetProperty("error").GetString(),
+            "Explicit mode=\"create\" must return conflict for existing files.");
+    }
+
+    [TestMethod]
+    public void AddArtifact_OverwriteMode_PathTraversal_StillBlocked()
+    {
+        var addJson = _tools.AddTask("Overwrite Path Traversal Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var json = _tools.AddArtifact(taskId, "../escape.md", "bad", mode: "overwrite");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("path_traversal", doc.RootElement.GetProperty("error").GetString(),
+            "Overwrite mode must still block path traversal.");
+    }
+
+    [TestMethod]
+    public void AddArtifact_OverwriteMode_MissingTask_ReturnsNotFound()
+    {
+        var json = _tools.AddArtifact("does-not-exist", "plan.md", "content", mode: "overwrite");
+        var doc = JsonDocument.Parse(json);
+
+        Assert.AreEqual("not_found", doc.RootElement.GetProperty("error").GetString(),
+            "Overwrite mode must return not_found for missing task.");
+    }
+
+    [TestMethod]
     public void AddArtifact_NotFoundTask_ReturnsNotFoundError()
     {
         var json = _tools.AddArtifact("does-not-exist", "plan.md", "content");
@@ -927,6 +1013,22 @@ public class GlassworkToolsTests
         var markerContent = File.ReadAllText(markerFile);
         StringAssert.Contains(markerContent, "artifact.md",
             "Marker file must reference the written artifact path.");
+    }
+
+    [TestMethod]
+    public void AddArtifact_OverwriteMode_RegistersSelfWrite_MarkerFileContainsArtifactPath()
+    {
+        var addJson = _tools.AddTask("SelfWrite Overwrite Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        _tools.AddArtifact(taskId, "overwrite.md", "v1");
+        _tools.AddArtifact(taskId, "overwrite.md", "v2", mode: "overwrite");
+
+        var markerFile = Path.Combine(TasksDir, ".glasswork", "recent-writes.json");
+        Assert.IsTrue(File.Exists(markerFile), "SelfWriteCoordinator must write its marker file when add_artifact overwrites an artifact.");
+        var markerContent = File.ReadAllText(markerFile);
+        StringAssert.Contains(markerContent, "overwrite.md",
+            "Marker file must reference the overwritten artifact path.");
     }
 
     [TestMethod]


### PR DESCRIPTION
# Add mode parameter to add_artifact for iterative agent work

Closes #134

## Summary

Adds an optional `mode` parameter to the `add_artifact` MCP tool to enable iterative agent workflows (Ralph-style) that refine artifacts across multiple turns without inventing versioned filenames (`plan-v2.md`, `plan-v3.md`).

**API change (backward compatible):**
- `mode: "create"` (default) — create-only semantics. Returns `{error: "conflict"}` if the file exists.
- `mode: "overwrite"` — create-or-replace semantics. If the file exists, replaces its content. If not, creates it.

## Implementation Approach

**Option B** (from issue body) — added `mode` parameter to existing `add_artifact` tool rather than creating separate `update_artifact` tool, keeping tool surface small per ADR 0007.

**Safety properties preserved:**
- Path-traversal guards (`VaultPathGuard.EnsurePathInVault`) still run before mode branching
- Task existence check still runs first
- `SelfWriteCoordinator` registration happens before write in both modes
- Write phase trace instrumentation applies to both modes
- Default behavior unchanged — backward compatible

**Logic:**
```csharp
var effectiveMode = mode?.ToLowerInvariant() ?? "create";
if (effectiveMode == "create" && File.Exists(resolvedPath))
{
    return JsonSerializer.Serialize(new { error = "conflict", message = ... });
}
// ... proceed with write
```

## Tests (7 new tests, all passing)

- `AddArtifact_OverwriteMode_ReplacesExistingFile` — overwrite replaces existing artifact content
- `AddArtifact_OverwriteMode_CreatesNewFile` — overwrite creates new file when it doesn't exist (create-or-replace semantic)
- `AddArtifact_CreateModeDefault_StillReturnsConflict` — default mode (omitted) preserves conflict behavior
- `AddArtifact_CreateModeExplicit_ReturnsConflict` — explicit `mode: "create"` returns conflict on existing file
- `AddArtifact_OverwriteMode_PathTraversal_StillBlocked` — path traversal rejected in overwrite mode
- `AddArtifact_OverwriteMode_MissingTask_ReturnsNotFound` — missing task returns not_found in overwrite mode
- `AddArtifact_OverwriteMode_RegistersSelfWrite_MarkerFileContainsArtifactPath` — SelfWriteCoordinator registration verified

## Validation

- ✅ All 797 tests pass (no regressions)
- ✅ `dotnet build src/Glasswork.Core` succeeds
- ✅ `dotnet build src/Glasswork.App -r win-x64` succeeds
- ✅ `dotnet test tests/Glasswork.Tests` succeeds

## Documentation

- Updated `src/Glasswork.Mcp/README.md`:
  - Input schema now includes optional `mode` parameter
  - Conflict error description clarified (create-mode only)
  - Mode behavior documented (create-only vs create-or-replace)
- Added CHANGELOG entry under `[Unreleased]` section

## Decisions

- **Mode parameter is optional with null default** — preserves backward compatibility. Agents that don't pass `mode` get the existing create-only behavior.
- **Mode values are case-insensitive** — normalized via `ToLowerInvariant()` for robustness.
- **"overwrite" implements create-or-replace** — does not error if file doesn't exist. This is what iterative agents actually want (no need to check if file exists before deciding which mode to use).

## Out of Scope

Per triage and ADR 0007 §5:
- **Optimistic-concurrency mtime conflict semantics** — reserved for future multi-writer scenarios. Iterative agents are intentionally last-writer-wins.
- **Destructive-tool warning/opt-in** — separate concern tracked in #142.
- **`update_task` tool** — separate slice tracked in #136.

## Relevant ADRs

- **ADR 0007** §3 (tool surface), §5 (future update_* semantics), §9 (path traversal)
- **ADR 0002** (three-tier task prose model — artifacts are agent-produced)
- **Hard rule 5** from copilot-instructions.md (SelfWriteCoordinator registration)
