### PR TITLE
feat: make parent Glasswork task link clickable

### DIFF
--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -27,6 +27,7 @@ public sealed partial class TaskDetailPage : Page
     private bool _suppressNextNotesSave;
     private NotesEditController _notesEdit = new(string.Empty);
     private string _pendingDiskNotes = string.Empty;
+    private ParentLinkResolution? _parentResolution;
 
     public TaskDetailPage()
     {
@@ -214,6 +215,7 @@ public sealed partial class TaskDetailPage : Page
             ParentLinkButton.Visibility = Visibility.Collapsed;
             ParentTextRun.Text = string.Empty;
             EditParentButton.Content = "Set parent";
+            _parentResolution = null;
             return;
         }
 
@@ -221,9 +223,26 @@ public sealed partial class TaskDetailPage : Page
         ParentTextRun.Text = p;
         EditParentButton.Content = "Edit parent";
 
+        // Classify parent to determine link type
         var baseUrl = (App.UiState.Get<string>(App.AdoBaseUrlKey) ?? string.Empty).Trim();
-        var url = AdoLinkResolver.TryResolve(p, baseUrl);
-        ParentLinkButton.Visibility = url is null ? Visibility.Collapsed : Visibility.Visible;
+        var classifier = new ParentLinkClassifier(App.Index);
+        _parentResolution = classifier.Classify(p, baseUrl);
+
+        // Update button visibility and content based on resolution
+        if (_parentResolution.Type == ParentLinkResolution.ResolutionType.InAppTask)
+        {
+            ParentLinkButton.Visibility = Visibility.Visible;
+            ParentLinkButton.Content = "Open task";
+        }
+        else if (_parentResolution.Type == ParentLinkResolution.ResolutionType.AdoUrl)
+        {
+            ParentLinkButton.Visibility = Visibility.Visible;
+            ParentLinkButton.Content = "Open in ADO";
+        }
+        else
+        {
+            ParentLinkButton.Visibility = Visibility.Collapsed;
+        }
     }
 
     private void BindSubtasks(IList<SubTask> subtasks)
@@ -1007,12 +1026,27 @@ public sealed partial class TaskDetailPage : Page
 
     private void OpenParent_Click(object sender, RoutedEventArgs e)
     {
-        var p = Task.Parent?.Trim();
-        if (string.IsNullOrEmpty(p)) return;
-        var baseUrl = (App.UiState.Get<string>(App.AdoBaseUrlKey) ?? string.Empty).Trim();
-        var url = AdoLinkResolver.TryResolve(p, baseUrl);
-        if (url is null) return;
-        Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        if (_parentResolution is null) return;
+
+        switch (_parentResolution.Type)
+        {
+            case ParentLinkResolution.ResolutionType.InAppTask:
+                // Navigate to parent task
+                var parentTask = App.Index.ById(_parentResolution.TaskId ?? string.Empty);
+                if (parentTask is not null)
+                    Frame.Navigate(typeof(TaskDetailPage), parentTask);
+                break;
+
+            case ParentLinkResolution.ResolutionType.AdoUrl:
+                // Open in external browser
+                if (_parentResolution.Url is not null)
+                    Process.Start(new ProcessStartInfo(_parentResolution.Url) { UseShellExecute = true });
+                break;
+
+            case ParentLinkResolution.ResolutionType.None:
+                // No action
+                break;
+        }
     }
 
     private async void EditParent_Click(object sender, RoutedEventArgs e)

--- a/src/Glasswork.Core/Services/ParentLinkClassifier.cs
+++ b/src/Glasswork.Core/Services/ParentLinkClassifier.cs
@@ -1,0 +1,37 @@
+namespace Glasswork.Core.Services;
+
+/// <summary>
+/// Classifies a parent string into one of three resolution types:
+/// 1. InAppTask - matches a known Glasswork task id
+/// 2. AdoUrl - resolves through AdoLinkResolver
+/// 3. None - neither resolves
+/// </summary>
+public class ParentLinkClassifier
+{
+    private readonly IndexService _index;
+
+    public ParentLinkClassifier(IndexService index)
+    {
+        _index = index;
+    }
+
+    public ParentLinkResolution Classify(string? parent, string? adoBaseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(parent))
+            return ParentLinkResolution.None();
+
+        var trimmed = parent.Trim();
+
+        // Check if parent matches a known task id
+        var task = _index.ById(trimmed);
+        if (task is not null)
+            return ParentLinkResolution.InAppTask(trimmed);
+
+        // Try ADO resolution
+        var adoUrl = AdoLinkResolver.TryResolve(trimmed, adoBaseUrl);
+        if (adoUrl is not null)
+            return ParentLinkResolution.AdoUrl(adoUrl);
+
+        return ParentLinkResolution.None();
+    }
+}

--- a/src/Glasswork.Core/Services/ParentLinkResolution.cs
+++ b/src/Glasswork.Core/Services/ParentLinkResolution.cs
@@ -1,0 +1,35 @@
+namespace Glasswork.Core.Services;
+
+/// <summary>
+/// Represents the resolved type of a parent link.
+/// </summary>
+public class ParentLinkResolution
+{
+    public enum ResolutionType
+    {
+        InAppTask,
+        AdoUrl,
+        None
+    }
+
+    public ResolutionType Type { get; init; }
+    public string? TaskId { get; init; }
+    public string? Url { get; init; }
+
+    public static ParentLinkResolution InAppTask(string taskId) => new()
+    {
+        Type = ResolutionType.InAppTask,
+        TaskId = taskId
+    };
+
+    public static ParentLinkResolution AdoUrl(string url) => new()
+    {
+        Type = ResolutionType.AdoUrl,
+        Url = url
+    };
+
+    public static ParentLinkResolution None() => new()
+    {
+        Type = ResolutionType.None
+    };
+}

--- a/tests/Glasswork.Tests/ParentLinkClassifierTests.cs
+++ b/tests/Glasswork.Tests/ParentLinkClassifierTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.IO;
+using Glasswork.Core.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class ParentLinkClassifierTests
+{
+    [TestMethod]
+    public void ResolveAsInAppTask_WhenParentMatchesExistingTaskId()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        
+        // Write task file directly in vault root (VaultService.LoadAll looks there)
+        var taskPath = Path.Combine(tempDir, "task-alpha.md");
+        File.WriteAllText(taskPath, @"---
+id: task-alpha
+title: Alpha task
+status: todo
+created: 2026-01-01
+---
+
+Test task");
+        
+        try
+        {
+            // Configure vault and load index
+            var coordinator = new SelfWriteCoordinator(tempDir);
+            var vault = new VaultService(tempDir, coordinator);
+            var indexService = new IndexService(vault);
+            indexService.EnsureLoaded();
+            
+            var classifier = new ParentLinkClassifier(indexService);
+            
+            // Act
+            var result = classifier.Classify("task-alpha", "https://dev.azure.com/org/proj");
+            
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(ParentLinkResolution.ResolutionType.InAppTask, result.Type);
+            Assert.AreEqual("task-alpha", result.TaskId);
+        }
+        finally
+        {
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [TestMethod]
+    public void ResolveAsAdoUrl_WhenParentIsNumericAdoId()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        
+        try
+        {
+            // Empty vault (no matching task)
+            var coordinator = new SelfWriteCoordinator(tempDir);
+            var vault = new VaultService(tempDir, coordinator);
+            var indexService = new IndexService(vault);
+            indexService.EnsureLoaded();
+            
+            var classifier = new ParentLinkClassifier(indexService);
+            var adoBaseUrl = "https://dev.azure.com/myorg/myproject";
+            
+            // Act
+            var result = classifier.Classify("12345", adoBaseUrl);
+            
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(ParentLinkResolution.ResolutionType.AdoUrl, result.Type);
+            Assert.IsNotNull(result.Url);
+            StringAssert.Contains(result.Url, "12345");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [TestMethod]
+    public void ResolveAsNone_WhenParentIsFreeText()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        
+        try
+        {
+            // Empty vault (no matching task)
+            var coordinator = new SelfWriteCoordinator(tempDir);
+            var vault = new VaultService(tempDir, coordinator);
+            var indexService = new IndexService(vault);
+            indexService.EnsureLoaded();
+            
+            var classifier = new ParentLinkClassifier(indexService);
+            
+            // Act
+            var result = classifier.Classify("Some free text parent", null);
+            
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(ParentLinkResolution.ResolutionType.None, result.Type);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+}


### PR DESCRIPTION
# Make parent Glasswork task link clickable

## Summary

Implements detection-before-display pattern for the parent field in TaskDetailPage. When `parent` matches an existing Glasswork task ID, provides in-app navigation. ADO link behavior is preserved as a fallback.

Closes #172

## Implementation

**Core changes:**
- `ParentLinkClassifier` — classifies parent strings into three resolution types:
  - `InAppTask(id)` — matches known Glasswork task → in-app navigation
  - `AdoUrl(url)` — resolves via AdoLinkResolver → external browser
  - `None` — free text → no link button
- `ParentLinkResolution` — model class with three resolution types

**UI integration:**
- `TaskDetailPage.ApplyParent()` — uses classifier to determine link type and button label
- `TaskDetailPage.OpenParent_Click()` — dispatches to in-app navigation or external browser based on resolution
- Button label changes: "Open task" for InAppTask, "Open in ADO" for AdoUrl

## Tests

- `ParentLinkClassifierTests` — three unit tests covering all resolution paths:
  - InAppTask resolution when parent matches existing task
  - AdoUrl resolution for numeric ADO ID
  - None resolution for free text

All tests pass (800/800). Core and App builds succeed.

## Validation

✅ `dotnet build src/Glasswork.Core/Glasswork.Core.csproj -p:EnableWindowsTargeting=true`  
✅ `dotnet build src/Glasswork.App/Glasswork.csproj -p:EnableWindowsTargeting=true -a x64`  
✅ `dotnet test tests/Glasswork.Tests/ -p:EnableWindowsTargeting=true` — 800/800 passed

## Out of scope

- Typeahead picker in Edit Parent dialog (keeping freeform input)
- Promoting `parent` into typed `links:` list (ADR 0009 keeps it separate)
- Bidirectional child lookup (issue #173)
- Wikilink `[[task-id]]` syntax support (optional v2)
