### PR TITLE
feat: add children section to task detail page

### DIFF
--- a/.commit-message-173.txt
+++ b/.commit-message-173.txt
@@ -1,0 +1,20 @@
+feat: add children section to task detail page
+
+Implements Issue #173 - display child tasks in TaskDetailPage.
+
+Backend changes:
+- Added IndexService.GetChildren(taskId) to query tasks whose parent field matches taskId
+- Added ChildRow model for UI projection (mirrors BacklinkRow pattern)
+
+UI changes:
+- Added ChildrenSection to TaskDetailPage.xaml after LinksSection
+- Added BindChildren() method and Child_Click() handler
+- Wired OnAnyTaskFileChangedExternally to refresh children on vault changes
+- Section shows "Children (n)" header with count, hidden when n == 0
+- Each child row shows task title and navigates in-app on click
+
+Tests:
+- Added IndexServiceGetChildrenTests with 3 test cases
+- All existing tests still pass (803 total)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml
@@ -570,6 +570,32 @@
                     </ItemsControl>
                 </StackPanel>
 
+                <!-- Children (issue #173 — tasks whose parent field matches this task's id) -->
+                <StackPanel x:Name="ChildrenSection" Spacing="8" Margin="0,16,0,0" Visibility="Collapsed">
+                    <TextBlock x:Name="ChildrenHeader" Text="Children" Style="{StaticResource SubtitleTextBlockStyle}" />
+                    <ItemsControl x:Name="ChildrenList">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Button HorizontalAlignment="Stretch"
+                                        HorizontalContentAlignment="Stretch"
+                                        Margin="0,2,0,2"
+                                        Padding="12,8"
+                                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                        BorderThickness="1"
+                                        Click="Child_Click">
+                                    <Grid>
+                                        <TextBlock Text="{Binding Title}"
+                                                   FontWeight="SemiBold"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   VerticalAlignment="Center" />
+                                    </Grid>
+                                </Button>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
                 <!-- Backlinks (slice 6 — incoming wikilinks from outside wiki/todo/) -->
                 <StackPanel x:Name="BacklinksSection" Spacing="8" Margin="0,16,0,0" Visibility="Collapsed">
                     <TextBlock x:Name="BacklinksHeader" Text="Backlinks" Style="{StaticResource SubtitleTextBlockStyle}" />

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -47,7 +47,10 @@ public sealed partial class TaskDetailPage : Page
             // (FocusSubtaskTitle is currently informational; UI affordance for scrolling could
             // be added later).
             if (App.Watcher is not null)
+            {
                 App.Watcher.TaskFileChanged += OnTaskFileChangedExternally;
+                App.Watcher.TaskFileChanged += OnAnyTaskFileChangedExternally;
+            }
             App.ArtifactChangedExternally += OnArtifactChangedExternally;
             App.BacklinksChangedExternally += OnBacklinksChangedExternally;
             ApplyTask(nav.Task);
@@ -56,7 +59,10 @@ public sealed partial class TaskDetailPage : Page
         if (e.Parameter is GlassworkTask task)
         {
             if (App.Watcher is not null)
+            {
                 App.Watcher.TaskFileChanged += OnTaskFileChangedExternally;
+                App.Watcher.TaskFileChanged += OnAnyTaskFileChangedExternally;
+            }
             App.ArtifactChangedExternally += OnArtifactChangedExternally;
             App.BacklinksChangedExternally += OnBacklinksChangedExternally;
             ApplyTask(task);
@@ -85,6 +91,7 @@ public sealed partial class TaskDetailPage : Page
         BindRelated(task.RelatedLinks);
         BindArtifacts(task.Id);
         BindLinks(task.Links);
+        BindChildren(task.Id);
         BindBacklinks(task.Id);
 
         CreatedText.Text = $"Created: {task.Created:yyyy-MM-dd}";
@@ -288,6 +295,39 @@ public sealed partial class TaskDetailPage : Page
         ArtifactsList.ItemsSource = ArtifactRow.Project(artifacts, DateTime.UtcNow);
     }
 
+
+    private void BindChildren(string taskId)
+    {
+        IReadOnlyList<GlassworkTask> children;
+        try
+        {
+            children = App.Index?.GetChildren(taskId) ?? Array.Empty<GlassworkTask>();
+        }
+        catch
+        {
+            // Children lookup is best-effort — never block the task view.
+            children = Array.Empty<GlassworkTask>();
+        }
+
+        if (children.Count == 0)
+        {
+            ChildrenSection.Visibility = Visibility.Collapsed;
+            ChildrenList.ItemsSource = null;
+            return;
+        }
+
+        ChildrenSection.Visibility = Visibility.Visible;
+        ChildrenHeader.Text = $"Children ({children.Count})";
+        ChildrenList.ItemsSource = ChildRow.Project(children);
+    }
+
+    private void Child_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement fe || fe.DataContext is not ChildRow row) return;
+        var child = App.Index?.ById(row.Id);
+        if (child is null) return;
+        Frame.Navigate(typeof(TaskDetailPage), child);
+    }
 
     private void BindBacklinks(string taskId)
     {
@@ -547,7 +587,10 @@ public sealed partial class TaskDetailPage : Page
     {
         base.OnNavigatedFrom(e);
         if (App.Watcher is not null)
+        {
             App.Watcher.TaskFileChanged -= OnTaskFileChangedExternally;
+            App.Watcher.TaskFileChanged -= OnAnyTaskFileChangedExternally;
+        }
         App.ArtifactChangedExternally -= OnArtifactChangedExternally;
         App.BacklinksChangedExternally -= OnBacklinksChangedExternally;
         App.ObsidianLauncher.NotInstalled -= OnObsidianNotInstalled;
@@ -566,6 +609,18 @@ public sealed partial class TaskDetailPage : Page
         // touching the model or any banners. The watcher is filtered through
         // SelfWriteCoordinator, so this only fires for external edits (Obsidian, agents).
         DispatcherQueue.TryEnqueue(HandleExternalFileChange);
+    }
+
+    private void OnAnyTaskFileChangedExternally(object? sender, string fileName)
+    {
+        // Refresh children list on any task file change. This catches:
+        // - New tasks created with parent = current task id
+        // - Existing tasks changing their parent field to/from current task id
+        // - Child tasks being deleted
+        // Slightly inefficient (refreshes on all changes) but simple and safe.
+        var id = Task?.Id;
+        if (string.IsNullOrEmpty(id)) return;
+        DispatcherQueue.TryEnqueue(() => BindChildren(id));
     }
 
     private void HandleExternalFileChange()

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -49,7 +49,7 @@ public sealed partial class TaskDetailPage : Page
             if (App.Watcher is not null)
             {
                 App.Watcher.TaskFileChanged += OnTaskFileChangedExternally;
-                App.Watcher.TaskFileChanged += OnAnyTaskFileChangedExternally;
+                App.Watcher.TaskFileChange += OnAnyTaskFileChange;
             }
             App.ArtifactChangedExternally += OnArtifactChangedExternally;
             App.BacklinksChangedExternally += OnBacklinksChangedExternally;
@@ -61,7 +61,7 @@ public sealed partial class TaskDetailPage : Page
             if (App.Watcher is not null)
             {
                 App.Watcher.TaskFileChanged += OnTaskFileChangedExternally;
-                App.Watcher.TaskFileChanged += OnAnyTaskFileChangedExternally;
+                App.Watcher.TaskFileChange += OnAnyTaskFileChange;
             }
             App.ArtifactChangedExternally += OnArtifactChangedExternally;
             App.BacklinksChangedExternally += OnBacklinksChangedExternally;
@@ -589,7 +589,7 @@ public sealed partial class TaskDetailPage : Page
         if (App.Watcher is not null)
         {
             App.Watcher.TaskFileChanged -= OnTaskFileChangedExternally;
-            App.Watcher.TaskFileChanged -= OnAnyTaskFileChangedExternally;
+            App.Watcher.TaskFileChange -= OnAnyTaskFileChange;
         }
         App.ArtifactChangedExternally -= OnArtifactChangedExternally;
         App.BacklinksChangedExternally -= OnBacklinksChangedExternally;
@@ -611,12 +611,13 @@ public sealed partial class TaskDetailPage : Page
         DispatcherQueue.TryEnqueue(HandleExternalFileChange);
     }
 
-    private void OnAnyTaskFileChangedExternally(object? sender, string fileName)
+    private void OnAnyTaskFileChange(object? sender, TaskFileChange change)
     {
         // Refresh children list on any task file change. This catches:
-        // - New tasks created with parent = current task id
+        // - New tasks created with parent = current task id (including MCP/agent writes)
         // - Existing tasks changing their parent field to/from current task id
         // - Child tasks being deleted
+        // Uses TaskFileChange (not TaskFileChanged) so agent/MCP writes trigger refresh.
         // Slightly inefficient (refreshes on all changes) but simple and safe.
         var id = Task?.Id;
         if (string.IsNullOrEmpty(id)) return;

--- a/src/Glasswork.Core/Models/ChildRow.cs
+++ b/src/Glasswork.Core/Models/ChildRow.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Core.Models;
+
+/// <summary>
+/// UI projection of a child task for the TaskDetail Children section.
+/// A child is a task whose `parent` field matches the current task's id.
+/// Lives in Core (UI-free) to keep the projection unit-testable.
+/// </summary>
+public sealed record ChildRow(
+    string Id,
+    string Title)
+{
+    /// <summary>
+    /// Project a sequence of child tasks (already sorted by title from
+    /// IndexService.GetChildren) into UI rows. Order is preserved.
+    /// </summary>
+    public static IReadOnlyList<ChildRow> Project(IReadOnlyList<GlassworkTask> children)
+    {
+        return children
+            .Select(c => new ChildRow(c.Id, c.Title))
+            .ToList();
+    }
+}

--- a/src/Glasswork.Core/Services/IndexService.cs
+++ b/src/Glasswork.Core/Services/IndexService.cs
@@ -122,6 +122,31 @@ public class IndexService
     }
 
     /// <summary>
+    /// Returns all tasks whose <c>parent</c> field matches the given task id,
+    /// sorted by title. Returns defensive clones; mutating elements does not
+    /// affect the canonical store. Returns an empty list when no children exist.
+    /// </summary>
+    public IReadOnlyList<GlassworkTask> GetChildren(string taskId)
+    {
+        if (string.IsNullOrWhiteSpace(taskId))
+            return Array.Empty<GlassworkTask>();
+
+        var trimmedId = taskId.Trim();
+        
+        lock (_gate)
+        {
+            var children = _store.Values
+                .Where(t => !string.IsNullOrWhiteSpace(t.Parent) && 
+                           t.Parent.Trim().Equals(trimmedId, StringComparison.Ordinal))
+                .OrderBy(t => t.Title, StringComparer.Ordinal)
+                .Select(t => t.Clone())
+                .ToList();
+            
+            return children;
+        }
+    }
+
+    /// <summary>
     /// Hydrate the in-memory store from <see cref="VaultService.LoadAll"/>.
     /// Idempotent. Intentionally does <b>not</b> raise <see cref="TasksChanged"/> —
     /// this is a snapshot, not a delta. Call once during app startup

--- a/tests/Glasswork.Tests/IndexServiceGetChildrenTests.cs
+++ b/tests/Glasswork.Tests/IndexServiceGetChildrenTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.IO;
+using System.Linq;
+using Glasswork.Core.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class IndexServiceGetChildrenTests
+{
+    [TestMethod]
+    public void GetChildren_ReturnsTasksWhoseParentMatchesId()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            // Write parent task
+            var parentPath = Path.Combine(tempDir, "parent-task.md");
+            File.WriteAllText(parentPath, @"---
+id: parent-task
+title: Parent Task
+status: todo
+created: 2026-01-01
+---
+
+Parent task");
+
+            // Write child tasks
+            var child1Path = Path.Combine(tempDir, "child-1.md");
+            File.WriteAllText(child1Path, @"---
+id: child-1
+title: Child 1
+status: todo
+created: 2026-01-02
+parent: parent-task
+---
+
+Child task 1");
+
+            var child2Path = Path.Combine(tempDir, "child-2.md");
+            File.WriteAllText(child2Path, @"---
+id: child-2
+title: Child 2
+status: todo
+created: 2026-01-03
+parent: parent-task
+---
+
+Child task 2");
+
+            // Write unrelated task
+            var unrelatedPath = Path.Combine(tempDir, "other-task.md");
+            File.WriteAllText(unrelatedPath, @"---
+id: other-task
+title: Other Task
+status: todo
+created: 2026-01-04
+---
+
+Other task");
+
+            // Load index
+            var coordinator = new SelfWriteCoordinator(tempDir);
+            var vault = new VaultService(tempDir, coordinator);
+            var index = new IndexService(vault);
+            index.EnsureLoaded();
+
+            // Act
+            var children = index.GetChildren("parent-task");
+
+            // Assert
+            Assert.AreEqual(2, children.Count, "Should return two children");
+            Assert.IsTrue(children.Any(c => c.Id == "child-1"), "Should include child-1");
+            Assert.IsTrue(children.Any(c => c.Id == "child-2"), "Should include child-2");
+            Assert.IsFalse(children.Any(c => c.Id == "other-task"), "Should not include unrelated task");
+            
+            // Verify sorted by title
+            var titles = children.Select(c => c.Title).ToList();
+            CollectionAssert.AreEqual(new[] { "Child 1", "Child 2" }, titles, "Should be sorted by title");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [TestMethod]
+    public void GetChildren_ReturnsEmptyListWhenNoChildren()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            // Write task with no children
+            var parentPath = Path.Combine(tempDir, "parent-task.md");
+            File.WriteAllText(parentPath, @"---
+id: parent-task
+title: Parent Task
+status: todo
+created: 2026-01-01
+---
+
+Parent task");
+
+            // Load index
+            var coordinator = new SelfWriteCoordinator(tempDir);
+            var vault = new VaultService(tempDir, coordinator);
+            var index = new IndexService(vault);
+            index.EnsureLoaded();
+
+            // Act
+            var children = index.GetChildren("parent-task");
+
+            // Assert
+            Assert.AreEqual(0, children.Count, "Should return empty list when no children exist");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [TestMethod]
+    public void GetChildren_UsesTrimmedParentMatching()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            // Write parent task
+            var parentPath = Path.Combine(tempDir, "parent-task.md");
+            File.WriteAllText(parentPath, @"---
+id: parent-task
+title: Parent Task
+status: todo
+created: 2026-01-01
+---
+
+Parent task");
+
+            // Write child with whitespace in parent field
+            var childPath = Path.Combine(tempDir, "child-with-space.md");
+            File.WriteAllText(childPath, @"---
+id: child-with-space
+title: Child With Space
+status: todo
+created: 2026-01-02
+parent: ' parent-task '
+---
+
+Child task with whitespace in parent");
+
+            // Load index
+            var coordinator = new SelfWriteCoordinator(tempDir);
+            var vault = new VaultService(tempDir, coordinator);
+            var index = new IndexService(vault);
+            index.EnsureLoaded();
+
+            // Act
+            var children = index.GetChildren("parent-task");
+
+            // Assert
+            Assert.AreEqual(1, children.Count, "Should match parent even with whitespace");
+            Assert.AreEqual("child-with-space", children[0].Id);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+}


### PR DESCRIPTION
# Add children section to task detail page

Closes #173

## Changes

This PR implements a "Children" section in `TaskDetailPage` that displays tasks whose `parent` field points to the current task's id.

### Backend
- Added `IndexService.GetChildren(taskId)` — O(n) scan returning tasks where `parent.Trim() == taskId`, sorted by title
- Added `ChildRow` model for UI projection (parallels `BacklinkRow`)
- Reuses the trimmed-string-match semantics from #172's `ParentLinkClassifier`

### UI
- Added `ChildrenSection` to `TaskDetailPage.xaml` (placed before `BacklinksSection`)
- Shows "Children (n)" header with count, collapsed when n == 0
- Each row displays task title; clicking navigates in-app to child's `TaskDetailPage`
- Wired `OnAnyTaskFileChangedExternally` to refresh children when vault changes (any task file edit, since we can't efficiently track parent field changes)

### Tests
- Added `IndexServiceGetChildrenTests.cs` with 3 test cases
  - Basic matching (2 children found, sorted by title)
  - Empty list when no children
  - Trimmed parent matching
- All 803 existing tests still pass

## Visual Verification

**TODO**: Need to run visual verification per hard rule 7 before merge. Will run:
```powershell
pwsh -File scripts\invoke-visual-verification.ps1 -Scenario <appropriate-scenario>
```

Or create a new scenario if needed for children view.

## Decisions

- Children refresh on any task file change (slightly inefficient but simple) — a more targeted approach would require tracking parent field changes in the index
- Placed ChildrenSection before BacklinksSection per triage note "beneath existing structural sections"
- Navigation uses existing `Frame.Navigate(typeof(TaskDetailPage), child)` pattern

## Review Notes

Awaiting dual-model code review (gpt-5.5 and claude-opus-4.7).

## Validation

- ✅ Core build passes
- ✅ App build passes  
- ✅ All 803 tests pass (3 new tests added)
- ⏳ Visual verification pending
- ⏳ Code review pending
- ⏳ CI pending
