### PR TITLE
feat: add get_my_day MCP tool

### DIFF
--- a/src/Glasswork.Core/Services/TaskService.cs
+++ b/src/Glasswork.Core/Services/TaskService.cs
@@ -134,4 +134,74 @@ public class TaskService
         parent.Subtasks.RemoveAt(subtaskIndex);
         _vault.Save(parent);
     }
+
+    /// <summary>
+    /// Get tasks in My Day for today, applying the four-condition promotion rule from ADR 0008:
+    /// 1. Direct pin: task.MyDay == today
+    /// 2. Task due: task.Due <= today && Status != Done
+    /// 3. Flagged subtask: any subtask has IsMyDay == true
+    /// 4. Due subtask: any subtask has Due <= today && Status != Done
+    /// </summary>
+    public List<GlassworkTask> GetMyDay(bool includeDone, bool includeSubtasks)
+    {
+        var today = DateTime.Today;
+        var tasks = new List<GlassworkTask>();
+
+        foreach (var task in _index.All)
+        {
+            bool promoted = false;
+
+            // Condition 1: Direct pin
+            if (task.MyDay.HasValue && task.MyDay.Value.Date == today)
+            {
+                promoted = true;
+            }
+
+            // Condition 2: Task due (not done)
+            if (!promoted && task.Due.HasValue && task.Due.Value.Date <= today && task.Status != GlassworkTask.Statuses.Done)
+            {
+                promoted = true;
+            }
+
+            // Conditions 3 & 4: Subtask-based promotion
+            if (!promoted)
+            {
+                foreach (var subtask in task.Subtasks)
+                {
+                    // Condition 3: Flagged subtask
+                    if (subtask.IsMyDay)
+                    {
+                        promoted = true;
+                        break;
+                    }
+
+                    // Condition 4: Due subtask (not done)
+                    if (subtask.Due.HasValue && subtask.Due.Value.Date <= today && !subtask.IsEffectivelyDone)
+                    {
+                        promoted = true;
+                        break;
+                    }
+                }
+            }
+
+            // Apply includeDone filter
+            if (promoted)
+            {
+                if (includeDone || task.Status != GlassworkTask.Statuses.Done)
+                {
+                    var clone = task.Clone();
+                    
+                    // Apply includeSubtasks filter
+                    if (!includeSubtasks)
+                    {
+                        clone.Subtasks.Clear();
+                    }
+                    
+                    tasks.Add(clone);
+                }
+            }
+        }
+
+        return tasks;
+    }
 }

--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -187,6 +187,52 @@ public sealed class GlassworkTools
         }
     }
 
+    [McpServerTool(Name = "get_my_day")]
+    [ToolPrecondition(VaultPathReadablePrecondition.PreconditionName)]
+    [Description("Get ordered list of My Day tasks for daily-planning agent flows. Returns tasks promoted via direct pin, due date, or subtask-based rules (ADR 0008).")]
+    public string GetMyDay(
+        [Description("Include done tasks. Defaults to false.")] bool include_done = false,
+        [Description("Expand subtasks of My Day items. Defaults to false.")] bool include_subtasks = false)
+    {
+        using var scope = _logger?.BeginCall("get_my_day");
+        try
+        {
+            var index = new IndexService(_vault);
+            index.EnsureLoaded();
+            var taskService = new TaskService(_vault, index);
+
+            var myDayTasks = taskService.GetMyDay(include_done, include_subtasks);
+
+            var tasks = myDayTasks
+                .Select(t => new MyDayTask(
+                    Id: t.Id,
+                    Title: t.Title,
+                    Status: MapToExternalStatus(t.Status),
+                    Priority: t.Priority,
+                    DueDate: t.Due?.ToString("yyyy-MM-dd"),
+                    Scheduled: t.MyDay?.ToString("yyyy-MM-dd"),
+                    ParentId: t.Parent,
+                    Links: t.Links.Select(link => new MyDayLink(
+                        Type: link.Type,
+                        Url: link.Value,
+                        Title: link.Title ?? link.Value
+                    )).ToList()))
+                .ToList();
+
+            var result = new GetMyDayResult(
+                Tasks: tasks,
+                Count: tasks.Count,
+                AsOf: DateTime.Today.ToString("yyyy-MM-dd"));
+
+            return JsonSerializer.Serialize(result);
+        }
+        catch
+        {
+            scope?.SetResult("error");
+            throw;
+        }
+    }
+
     [McpServerTool(Name = "search_tasks")]
     [ToolPrecondition(VaultPathReadablePrecondition.PreconditionName)]
     [Description("Search task content by topic across title, description, notes, subtasks, and tags. Returns ranked task summaries with matched fields and a snippet.")]
@@ -1366,4 +1412,24 @@ public sealed class GlassworkTools
         [property: JsonPropertyName("title")] string Title,
         [property: JsonPropertyName("completed")] string[] Completed,
         [property: JsonPropertyName("in_progress")] string[] InProgress);
+
+    private sealed record MyDayTask(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("title")] string Title,
+        [property: JsonPropertyName("status")] string Status,
+        [property: JsonPropertyName("priority")] string Priority,
+        [property: JsonPropertyName("due_date")] string? DueDate,
+        [property: JsonPropertyName("scheduled")] string? Scheduled,
+        [property: JsonPropertyName("parent_id")] string? ParentId,
+        [property: JsonPropertyName("links")] List<MyDayLink> Links);
+
+    private sealed record MyDayLink(
+        [property: JsonPropertyName("type")] string Type,
+        [property: JsonPropertyName("url")] string Url,
+        [property: JsonPropertyName("title")] string Title);
+
+    private sealed record GetMyDayResult(
+        [property: JsonPropertyName("tasks")] List<MyDayTask> Tasks,
+        [property: JsonPropertyName("count")] int Count,
+        [property: JsonPropertyName("as_of")] string AsOf);
 }

--- a/tests/Glasswork.Tests/TaskService_GetMyDayTests.cs
+++ b/tests/Glasswork.Tests/TaskService_GetMyDayTests.cs
@@ -1,0 +1,328 @@
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class TaskService_GetMyDayTests
+{
+    private string _tempDir = null!;
+    private VaultService _vault = null!;
+    private IndexService _index = null!;
+    private TaskService _taskService = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-myday-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _vault = new VaultService(_tempDir);
+        _index = new IndexService(_vault);
+        _index.EnsureLoaded();
+        _taskService = new TaskService(_vault, _index);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public void GetMyDay_DirectPin_ReturnsTask()
+    {
+        // Arrange: create task with my_day set to today
+        var task = new GlassworkTask
+        {
+            Id = "direct-pin",
+            Title = "Task pinned to today",
+            Status = GlassworkTask.Statuses.Todo,
+            MyDay = DateTime.Today
+        };
+        _vault.Save(task);
+        _index.OnFileChangedOnDisk("direct-pin");
+
+        // Act
+        var result = _taskService.GetMyDay(includeDone: false, includeSubtasks: false);
+
+        // Assert
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("direct-pin", result[0].Id);
+        Assert.AreEqual("Task pinned to today", result[0].Title);
+    }
+
+    [TestMethod]
+    public void GetMyDay_DirectPin_ExcludesDone_WhenFlagIsFalse()
+    {
+        // Arrange: create done task with my_day set to today
+        var task = new GlassworkTask
+        {
+            Id = "done-direct",
+            Title = "Done task pinned to today",
+            Status = GlassworkTask.Statuses.Done,
+            MyDay = DateTime.Today
+        };
+        _vault.Save(task);
+        _index.OnFileChangedOnDisk("done-direct");
+
+        // Act
+        var result = _taskService.GetMyDay(includeDone: false, includeSubtasks: false);
+
+        // Assert
+        Assert.AreEqual(0, result.Count, "Done tasks should be excluded when includeDone=false");
+    }
+
+    [TestMethod]
+    public void GetMyDay_DirectPin_IncludesDone_WhenFlagIsTrue()
+    {
+        // Arrange: create done task with my_day set to today
+        var task = new GlassworkTask
+        {
+            Id = "done-direct",
+            Title = "Done task pinned to today",
+            Status = GlassworkTask.Statuses.Done,
+            MyDay = DateTime.Today
+        };
+        _vault.Save(task);
+        _index.OnFileChangedOnDisk("done-direct");
+
+        // Act
+        var result = _taskService.GetMyDay(includeDone: true, includeSubtasks: false);
+
+        // Assert
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("done-direct", result[0].Id);
+    }
+
+    [TestMethod]
+    public void GetMyDay_DueToday_ReturnsTask()
+    {
+        // Arrange: create task due today (not done)
+        var task = new GlassworkTask
+        {
+            Id = "due-today",
+            Title = "Task due today",
+            Status = GlassworkTask.Statuses.Todo,
+            Due = DateTime.Today
+        };
+        _vault.Save(task);
+        _index.OnFileChangedOnDisk("due-today");
+
+        // Act
+        var result = _taskService.GetMyDay(includeDone: false, includeSubtasks: false);
+
+        // Assert
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("due-today", result[0].Id);
+    }
+
+    [TestMethod]
+    public void GetMyDay_Overdue_ReturnsTask()
+    {
+        // Arrange: create overdue task (not done)
+        var task = new GlassworkTask
+        {
+            Id = "overdue",
+            Title = "Overdue task",
+            Status = GlassworkTask.Statuses.Todo,
+            Due = DateTime.Today.AddDays(-1)
+        };
+        _vault.Save(task);
+        _index.OnFileChangedOnDisk("overdue");
+
+        // Act
+        var result = _taskService.GetMyDay(includeDone: false, includeSubtasks: false);
+
+        // Assert
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("overdue", result[0].Id);
+    }
+
+    [TestMethod]
+    public void GetMyDay_DueToday_ExcludesDone()
+    {
+        // Arrange: create done task due today
+        var task = new GlassworkTask
+        {
+            Id = "done-due",
+            Title = "Done task due today",
+            Status = GlassworkTask.Statuses.Done,
+            Due = DateTime.Today
+        };
+        _vault.Save(task);
+        _index.OnFileChangedOnDisk("done-due");
+
+        // Act
+        var result = _taskService.GetMyDay(includeDone: false, includeSubtasks: false);
+
+        // Assert
+        Assert.AreEqual(0, result.Count, "Done tasks should be excluded even if due");
+    }
+
+    [TestMethod]
+    public void GetMyDay_FlaggedSubtask_PromotesParent()
+    {
+        // Arrange: create task with flagged subtask
+        var task = new GlassworkTask
+        {
+            Id = "parent-with-flagged",
+            Title = "Parent with flagged subtask",
+            Status = GlassworkTask.Statuses.Todo,
+            Subtasks =
+            [
+                new SubTask
+                {
+                    Text = "Flagged subtask",
+                    Metadata = new Dictionary<string, string> { { "my_day", "true" } }
+                }
+            ]
+        };
+        _vault.Save(task);
+        _index.OnFileChangedOnDisk("parent-with-flagged");
+
+        // Act
+        var result = _taskService.GetMyDay(includeDone: false, includeSubtasks: false);
+
+        // Assert
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("parent-with-flagged", result[0].Id);
+    }
+
+    [TestMethod]
+    public void GetMyDay_SubtaskDueToday_PromotesParent()
+    {
+        // Arrange: create task with subtask due today
+        var task = new GlassworkTask
+        {
+            Id = "parent-subtask-due",
+            Title = "Parent with subtask due today",
+            Status = GlassworkTask.Statuses.Todo,
+            Subtasks =
+            [
+                new SubTask
+                {
+                    Text = "Subtask due today",
+                    Metadata = new Dictionary<string, string> { { "due", DateTime.Today.ToString("yyyy-MM-dd") } }
+                }
+            ]
+        };
+        _vault.Save(task);
+        _index.OnFileChangedOnDisk("parent-subtask-due");
+
+        // Act
+        var result = _taskService.GetMyDay(includeDone: false, includeSubtasks: false);
+
+        // Assert
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("parent-subtask-due", result[0].Id);
+    }
+
+    [TestMethod]
+    public void GetMyDay_SubtaskDueToday_DoneStatus_DoesNotPromote()
+    {
+        // Arrange: create task with done subtask due today
+        var task = new GlassworkTask
+        {
+            Id = "parent-subtask-done",
+            Title = "Parent with done subtask due today",
+            Status = GlassworkTask.Statuses.Todo,
+            Subtasks =
+            [
+                new SubTask
+                {
+                    Text = "Done subtask due today",
+                    Status = "done",
+                    Metadata = new Dictionary<string, string> { { "due", DateTime.Today.ToString("yyyy-MM-dd") } }
+                }
+            ]
+        };
+        _vault.Save(task);
+        _index.OnFileChangedOnDisk("parent-subtask-done");
+
+        // Act
+        var result = _taskService.GetMyDay(includeDone: false, includeSubtasks: false);
+
+        // Assert
+        Assert.AreEqual(0, result.Count, "Done subtasks should not promote parent");
+    }
+
+    [TestMethod]
+    public void GetMyDay_MultipleSources_ReturnsAllUnique()
+    {
+        // Arrange: create tasks via different promotion paths
+        var directPin = new GlassworkTask { Id = "direct", Title = "Direct", MyDay = DateTime.Today };
+        var dueTask = new GlassworkTask { Id = "due", Title = "Due", Due = DateTime.Today };
+        var flaggedTask = new GlassworkTask
+        {
+            Id = "flagged",
+            Title = "Flagged",
+            Subtasks = [new SubTask { Text = "Flag", Metadata = new Dictionary<string, string> { { "my_day", "true" } } }]
+        };
+
+        _vault.Save(directPin);
+        _vault.Save(dueTask);
+        _vault.Save(flaggedTask);
+        _index.OnFileChangedOnDisk("direct");
+        _index.OnFileChangedOnDisk("due");
+        _index.OnFileChangedOnDisk("flagged");
+
+        // Act
+        var result = _taskService.GetMyDay(includeDone: false, includeSubtasks: false);
+
+        // Assert
+        Assert.AreEqual(3, result.Count);
+    }
+
+    [TestMethod]
+    public void GetMyDay_IncludeSubtasks_ExpandsParentSubtasks()
+    {
+        // Arrange: create task with multiple subtasks
+        var task = new GlassworkTask
+        {
+            Id = "parent-expand",
+            Title = "Parent to expand",
+            MyDay = DateTime.Today,
+            Subtasks =
+            [
+                new SubTask { Text = "Subtask 1" },
+                new SubTask { Text = "Subtask 2" }
+            ]
+        };
+        _vault.Save(task);
+        _index.OnFileChangedOnDisk("parent-expand");
+
+        // Act
+        var result = _taskService.GetMyDay(includeDone: false, includeSubtasks: true);
+
+        // Assert
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual(2, result[0].Subtasks.Count, "Subtasks should be included when flag is true");
+    }
+
+    [TestMethod]
+    public void GetMyDay_ExcludeSubtasks_DoesNotExpandParentSubtasks()
+    {
+        // Arrange: create task with subtasks
+        var task = new GlassworkTask
+        {
+            Id = "parent-no-expand",
+            Title = "Parent no expand",
+            MyDay = DateTime.Today,
+            Subtasks =
+            [
+                new SubTask { Text = "Subtask 1" },
+                new SubTask { Text = "Subtask 2" }
+            ]
+        };
+        _vault.Save(task);
+        _index.OnFileChangedOnDisk("parent-no-expand");
+
+        // Act
+        var result = _taskService.GetMyDay(includeDone: false, includeSubtasks: false);
+
+        // Assert
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual(0, result[0].Subtasks.Count, "Subtasks should be excluded when flag is false");
+    }
+}


### PR DESCRIPTION
# Add get_my_day MCP tool for daily planning agents

Closes #203

## Overview

Implements `get_my_day` MCP tool for agent-driven daily planning workflows. Returns an ordered list of tasks in My Day based on the four-condition promotion rule from ADR 0008.

## Implementation

### TaskService.GetMyDay()
- **Four-condition promotion logic**:
  1. Direct pin: `task.MyDay == today`
  2. Task due: `task.Due <= today && Status != Done`
  3. Flagged subtask: any subtask has `IsMyDay == true`
  4. Due subtask: any subtask has `Due <= today && Status != Done`
- **Filters**: `includeDone` (default false), `includeSubtasks` (default false)
- **Returns**: Defensive clones to prevent mutation

### MCP Tool Wrapper
- Follows existing patterns from ADR 0007 (stateless, JSON serialization, precondition filters)
- Result structure includes: id, title, status, priority, due_date, scheduled, parent_id, links
- Links array includes type, url, and title fields

### Tests
- 12 integration tests covering all four promotion conditions
- Tests verify filtering, subtask expansion, and exclusion logic
- All new tests passing (12/12)

## Decisions

**Result structure**: Included priority, due_date, scheduled, parent_id, and links beyond minimal spec to align with existing `list_tasks` pattern and provide richer context for agents.

**Filter order**: Applied `includeDone` after promotion logic to match carryover pattern.

**Clone behavior**: Clear subtasks on clone when `includeSubtasks=false` for defensive copy semantics.

## Validation

✅ **Core build**: Succeeded  
✅ **Test suite**: All 12 new GetMyDay tests pass  
⚠️ **App build**: Failed with "requires a supported Windows architecture" (expected - App is WinUI 3, Windows-only; cannot build in cloud/Linux environment per instructions)  
⚠️ **Pre-existing flakes**: 2 timing-sensitive tests in FileWatcherServiceTests and DebouncerTests failed (unrelated to this change)

## Review Notes

Awaiting dual-model code review (gpt-5.5 and claude-opus-4.7).
