### PR TITLE
feat: add add_link MCP tool

### DIFF
--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -1327,6 +1327,83 @@ public sealed class GlassworkTools
     private sealed record ListBacklinksResult(
         [property: JsonPropertyName("backlinks")] BacklinkEntry[] Backlinks);
 
+    private sealed record LinkResult(
+        [property: JsonPropertyName("type")] string Type,
+        [property: JsonPropertyName("url")] string Url,
+        [property: JsonPropertyName("title")] string? Title);
+
+    private sealed record AddLinkResult(
+        [property: JsonPropertyName("task_id")] string TaskId,
+        [property: JsonPropertyName("link")] LinkResult Link,
+        [property: JsonPropertyName("total_links")] int TotalLinks);
+
+    [McpServerTool(Name = "add_link")]
+    [ToolPrecondition(VaultPathReadablePrecondition.PreconditionName)]
+    [Description("Attach a typed external link (ado/pr/incident/doc/build) to a task. Appends to the links: frontmatter array.")]
+    public string AddLink(
+        [Description("Task ID (required).")] string task_id,
+        [Description("Link type: ado, pr, incident, doc, build (required).")] string link_type,
+        [Description("URL or identifier (required).")] string url,
+        [Description("Optional display label")] string? title = null)
+    {
+        using var scope = _logger?.BeginCall("add_link");
+        try
+        {
+            var safeId = SanitizeId(task_id);
+            if (safeId is null || !_vault.Exists(safeId))
+            {
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("not_found", $"Task '{task_id}' not found."));
+            }
+
+            if (string.IsNullOrWhiteSpace(link_type))
+            {
+                scope?.SetResult("error");
+                return JsonSerializer.Serialize(new ErrorResult("invalid_link_type", "link_type is required."));
+            }
+
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                scope?.SetResult("error");
+                return JsonSerializer.Serialize(new ErrorResult("invalid_url", "url is required."));
+            }
+
+            var normalizedType = TaskLink.Types.Normalize(link_type.Trim().ToLowerInvariant());
+            
+            var task = _vault.Load(safeId);
+            if (task is null)
+            {
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("not_found", $"Task '{task_id}' not found."));
+            }
+
+            var newLink = new TaskLink
+            {
+                Type = normalizedType,
+                Value = url.Trim(),
+                Label = string.IsNullOrWhiteSpace(title) ? null : title.Trim()
+            };
+
+            var writeSw = Stopwatch.StartNew();
+            task.Links.Add(newLink);
+            _vault.Save(task);
+            scope?.RecordPhase("write", writeSw.ElapsedMilliseconds);
+
+            var result = new AddLinkResult(
+                TaskId: safeId,
+                Link: new LinkResult(normalizedType, newLink.Value, newLink.Label),
+                TotalLinks: task.Links.Count);
+
+            scope?.SetResult("success");
+            return JsonSerializer.Serialize(result);
+        }
+        catch
+        {
+            scope?.SetResult("error");
+            throw;
+        }
+    }
+
     [McpServerTool(Name = "get_activity")]
     [ToolPrecondition(VaultPathReadablePrecondition.PreconditionName)]
     [Description("Return structured data about what happened in a time period. Foundation for auto-generated work logs.")]

--- a/tests/Glasswork.Mcp.Tests/AddLinkToolTests.cs
+++ b/tests/Glasswork.Mcp.Tests/AddLinkToolTests.cs
@@ -1,0 +1,141 @@
+using System.Text.Json;
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+using Glasswork.Mcp.Tools;
+
+namespace Glasswork.Mcp.Tests;
+
+[TestClass]
+public class AddLinkToolTests
+{
+    private string _vaultDir = null!;
+    private GlassworkTools _tools = null!;
+    private VaultService _vault = null!;
+
+    private string TasksDir => Path.Combine(_vaultDir, "wiki", "todo");
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _vaultDir = Path.Combine(Path.GetTempPath(), "glasswork-add-link-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_vaultDir);
+        _tools = new GlassworkTools(new VaultContext(_vaultDir));
+        _vault = new VaultService(Path.Combine(_vaultDir, "wiki", "todo"));
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_vaultDir))
+            Directory.Delete(_vaultDir, recursive: true);
+    }
+
+    // ───────────────────────────── add_link ────────────────────────────
+
+    [TestMethod]
+    public void AddLink_AddsLinkToTask()
+    {
+        // Arrange: create a task
+        var addJson = _tools.AddTask("Test task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        // Act: add a PR link
+        var linkJson = _tools.AddLink(taskId, link_type: "pr", url: "https://github.com/owner/repo/pull/123", title: "Fix bug");
+
+        // Assert: response shape
+        var doc = JsonDocument.Parse(linkJson);
+        Assert.AreEqual(taskId, doc.RootElement.GetProperty("task_id").GetString());
+        
+        var link = doc.RootElement.GetProperty("link");
+        Assert.AreEqual("pr", link.GetProperty("type").GetString());
+        Assert.AreEqual("https://github.com/owner/repo/pull/123", link.GetProperty("url").GetString());
+        Assert.AreEqual("Fix bug", link.GetProperty("title").GetString());
+        
+        Assert.AreEqual(1, doc.RootElement.GetProperty("total_links").GetInt32());
+
+        // Assert: vault file has link in frontmatter
+        var task = _vault.Load(taskId);
+        Assert.AreEqual(1, task.Links.Count, "Task must have exactly one link.");
+        Assert.AreEqual("pr", task.Links[0].Type);
+        Assert.AreEqual("https://github.com/owner/repo/pull/123", task.Links[0].Value);
+        Assert.AreEqual("Fix bug", task.Links[0].Label);
+    }
+
+    [TestMethod]
+    public void AddLink_TaskNotFound_ReturnsError()
+    {
+        // Act
+        var json = _tools.AddLink("nonexistent", "pr", "https://github.com/owner/repo/pull/1", null);
+        var result = JsonSerializer.Deserialize<JsonElement>(json);
+
+        // Assert
+        Assert.IsTrue(result.TryGetProperty("error", out _));
+        Assert.AreEqual("not_found", result.GetProperty("error").GetString());
+    }
+
+    [TestMethod]
+    public void AddLink_MultipleLinks_PreservesOrder()
+    {
+        // Arrange
+        var taskId = "multi-link";
+        var task = new GlassworkTask { Id = taskId, Title = "Multi-link task" };
+        _vault.Save(task);
+
+        // Act - add multiple links
+        _tools.AddLink(taskId, "pr", "https://pr1", "PR 1");
+        _tools.AddLink(taskId, "ado", "123456", "Work Item");
+        _tools.AddLink(taskId, "doc", "https://doc1", "Design Doc");
+
+        // Assert - verify order preserved
+        var reloaded = _vault.Load(taskId);
+        Assert.IsNotNull(reloaded);
+        Assert.AreEqual(3, reloaded.Links.Count);
+        Assert.AreEqual("pr", reloaded.Links[0].Type);
+        Assert.AreEqual("https://pr1", reloaded.Links[0].Value);
+        Assert.AreEqual("ado", reloaded.Links[1].Type);
+        Assert.AreEqual("123456", reloaded.Links[1].Value);
+        Assert.AreEqual("doc", reloaded.Links[2].Type);
+        Assert.AreEqual("https://doc1", reloaded.Links[2].Value);
+    }
+
+    [TestMethod]
+    public void AddLink_WithoutTitle_SucceedsWithNullLabel()
+    {
+        // Arrange
+        var taskId = "no-title";
+        var task = new GlassworkTask { Id = taskId, Title = "Task without title" };
+        _vault.Save(task);
+
+        // Act
+        var json = _tools.AddLink(taskId, "incident", "INC-456789", null);
+        var result = JsonSerializer.Deserialize<JsonElement>(json);
+
+        // Assert
+        Assert.AreEqual(taskId, result.GetProperty("task_id").GetString());
+        var linkElement = result.GetProperty("link");
+        Assert.IsFalse(linkElement.TryGetProperty("title", out var titleProp) && 
+                      titleProp.ValueKind != JsonValueKind.Null);
+
+        var reloaded = _vault.Load(taskId);
+        Assert.IsNull(reloaded!.Links[0].Label);
+    }
+
+    [TestMethod]
+    public void AddLink_UnknownType_NormalizesToOther()
+    {
+        // Arrange
+        var taskId = "unknown-type";
+        var task = new GlassworkTask { Id = taskId, Title = "Unknown type task" };
+        _vault.Save(task);
+
+        // Act
+        var json = _tools.AddLink(taskId, "unknown-type", "https://example.com", "Some Link");
+        var result = JsonSerializer.Deserialize<JsonElement>(json);
+
+        // Assert
+        Assert.AreEqual("other", result.GetProperty("link").GetProperty("type").GetString());
+
+        var reloaded = _vault.Load(taskId);
+        Assert.AreEqual("other", reloaded!.Links[0].Type);
+    }
+}


### PR DESCRIPTION
# feat: add add_link MCP tool

Closes #205

## Summary

Implements the `add_link` MCP tool to attach typed external links (ado/pr/incident/doc/build) to tasks per ADR 0009's structured links model. This enables agents to bind tasks to external artifacts immediately (e.g., attach PR URL when opening a PR).

## Changes

**New tool:** `add_link`
- **Input:** `task_id` (string), `link_type` (ado|pr|incident|doc|build), `url` (string), `title` (optional string)
- **Output:** JSON with `task_id`, `link` object (`{ type, url, title }`), `total_links` integer
- **Behavior:** Appends to `links:` YAML array in task frontmatter using existing `VaultService.Save()`
- **Type normalization:** Unknown types → `other` via `TaskLink.Types.Normalize()`

## Implementation

- `src/Glasswork.Mcp/Tools/GlassworkTools.cs` (lines 1331-1414):
  - `AddLink` method with `[McpServerTool(Name = "add_link")]` attribute
  - `LinkResult` and `AddLinkResult` records
  - Pattern: Load → Append → Save, coordinator-safe via `VaultService`

## Tests (5/5 passing)

- `AddLinkToolTests.cs`:
  - ✓ Adds PR link with title, verifies JSON response + persistence
  - ✓ Returns error for nonexistent task
  - ✓ Multiple links preserve insertion order
  - ✓ Link without title succeeds with null label
  - ✓ Unknown type normalizes to "other"

## Validation

- ✓ `dotnet build src\Glasswork.Core\` (clean)
- ✓ `dotnet test tests\Glasswork.Tests\` (815/815 pass, 345 pre-existing warnings)
- ⊗ `dotnet build src\Glasswork.App\` (skipped — Windows-only, not available in cloud)

## ADR 0009 Requirements Met

- [x] Structured links are ordered lists in frontmatter
- [x] Support multiple links of same type
- [x] Unknown types tolerated, normalized to "other"
- [x] Array ordering preserved through YAML serialization
