### PR TITLE
feat: add list_overdue MCP tool

### DIFF
--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -1640,6 +1640,51 @@ public sealed class GlassworkTools
         }
     }
 
+    [McpServerTool(Name = "list_overdue")]
+    [ToolPrecondition(VaultPathReadablePrecondition.PreconditionName)]
+    [Description("Find tasks past their due date for morning review. Returns tasks where due_date < today and status != done.")]
+    public string ListOverdue(
+        [Description("Include only tasks in My Day. Default false.")] bool include_my_day_only = false,
+        [Description("Maximum number of tasks to return. Default 50.")] int limit = 50)
+    {
+        using var scope = _logger?.BeginCall("list_overdue");
+        try
+        {
+            var all = _vault.LoadAll();
+            var today = DateTime.Today;
+
+            var overdueTasks = all
+                .Where(t => t.Due.HasValue && t.Due.Value.Date < today && t.Status != GlassworkTask.Statuses.Done)
+                .Where(t => !include_my_day_only || t.IsMyDay)
+                .OrderBy(t => t.Due)
+                .Take(limit)
+                .ToList();
+
+            var tasks = overdueTasks
+                .Select(t => new OverdueTask(
+                    Id: t.Id,
+                    Title: t.Title,
+                    Status: MapToExternalStatus(t.Status),
+                    DueDate: t.Due!.Value.ToString("yyyy-MM-dd"),
+                    DaysOverdue: (today - t.Due!.Value.Date).Days,
+                    Priority: t.Priority,
+                    InMyDay: t.IsMyDay))
+                .ToList();
+
+            var result = new ListOverdueResult(
+                Tasks: tasks,
+                Count: tasks.Count,
+                AsOf: today.ToString("yyyy-MM-dd"));
+
+            return JsonSerializer.Serialize(result);
+        }
+        catch
+        {
+            scope?.SetResult("error");
+            throw;
+        }
+    }
+
     [McpServerTool(Name = "get_activity")]
     [ToolPrecondition(VaultPathReadablePrecondition.PreconditionName)]
     [Description("Return structured data about what happened in a time period. Foundation for auto-generated work logs.")]
@@ -1791,6 +1836,20 @@ public sealed class GlassworkTools
 
     private sealed record GetMyDayResult(
         [property: JsonPropertyName("tasks")] List<MyDayTask> Tasks,
+        [property: JsonPropertyName("count")] int Count,
+        [property: JsonPropertyName("as_of")] string AsOf);
+
+    private sealed record OverdueTask(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("title")] string Title,
+        [property: JsonPropertyName("status")] string Status,
+        [property: JsonPropertyName("due_date")] string DueDate,
+        [property: JsonPropertyName("days_overdue")] int DaysOverdue,
+        [property: JsonPropertyName("priority")] string Priority,
+        [property: JsonPropertyName("in_my_day")] bool InMyDay);
+
+    private sealed record ListOverdueResult(
+        [property: JsonPropertyName("tasks")] List<OverdueTask> Tasks,
         [property: JsonPropertyName("count")] int Count,
         [property: JsonPropertyName("as_of")] string AsOf);
 }

--- a/tests/Glasswork.Mcp.Tests/ListOverdueToolTests.cs
+++ b/tests/Glasswork.Mcp.Tests/ListOverdueToolTests.cs
@@ -1,0 +1,228 @@
+using System.Text.Json;
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+using Glasswork.Mcp.Tools;
+
+namespace Glasswork.Mcp.Tests;
+
+[TestClass]
+public class ListOverdueToolTests
+{
+    private string _vaultDir = null!;
+    private GlassworkTools _tools = null!;
+    private VaultService _vault = null!;
+
+    private string TasksDir => Path.Combine(_vaultDir, "wiki", "todo");
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _vaultDir = Path.Combine(Path.GetTempPath(), "glasswork-mcp-overdue-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_vaultDir);
+        _tools = new GlassworkTools(new VaultContext(_vaultDir));
+        _vault = new VaultService(TasksDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_vaultDir))
+            Directory.Delete(_vaultDir, recursive: true);
+    }
+
+    // ───────────────────────────── list_overdue ─────────────────────────────
+
+    [TestMethod]
+    public void ListOverdue_ReturnsTaskPastDueDate()
+    {
+        // ARRANGE: Create a task with due date yesterday
+        var yesterday = DateTime.Today.AddDays(-1);
+        var task = new GlassworkTask
+        {
+            Id = "overdue-task",
+            Title = "Overdue Task",
+            Status = GlassworkTask.Statuses.Todo,
+            Due = yesterday,
+            Created = DateTime.Today.AddDays(-7)
+        };
+        _vault.Save(task);
+
+        // ACT: Call list_overdue
+        var json = _tools.ListOverdue();
+
+        // ASSERT: The task should appear in the results
+        using var doc = JsonDocument.Parse(json);
+        var tasks = doc.RootElement.GetProperty("tasks");
+        Assert.AreEqual(1, tasks.GetArrayLength(), "Should return 1 overdue task");
+
+        var returnedTask = tasks[0];
+        Assert.AreEqual("overdue-task", returnedTask.GetProperty("id").GetString());
+        Assert.AreEqual("Overdue Task", returnedTask.GetProperty("title").GetString());
+        Assert.AreEqual("todo", returnedTask.GetProperty("status").GetString());
+        Assert.AreEqual(yesterday.ToString("yyyy-MM-dd"), returnedTask.GetProperty("due_date").GetString());
+        Assert.AreEqual(1, returnedTask.GetProperty("days_overdue").GetInt32());
+    }
+
+    [TestMethod]
+    public void ListOverdue_ExcludesDoneTasks()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), "glasswork-mcp-tests", Guid.NewGuid().ToString("N"));
+        var tasksDir = Path.Combine(baseDir, "wiki", "todo");
+        Directory.CreateDirectory(tasksDir);
+        var v = new VaultService(tasksDir);
+
+        v.Save(new GlassworkTask
+        {
+            Id = "t-overdue-done",
+            Title = "Overdue but done",
+            Due = DateTime.Today.AddDays(-2),
+            Status = GlassworkTask.Statuses.Done
+        });
+
+        v.Save(new GlassworkTask
+        {
+            Id = "t-overdue-active",
+            Title = "Overdue and active",
+            Due = DateTime.Today.AddDays(-2),
+            Status = GlassworkTask.Statuses.Todo
+        });
+
+        var tools = new GlassworkTools(new VaultContext(baseDir));
+        var json = tools.ListOverdue();
+        var result = JsonDocument.Parse(json);
+
+        var tasks = result.RootElement.GetProperty("tasks");
+        Assert.AreEqual(1, tasks.GetArrayLength());
+        Assert.AreEqual("t-overdue-active", tasks[0].GetProperty("id").GetString());
+    }
+
+    [TestMethod]
+    public void ListOverdue_RespectsLimitParameter()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), "glasswork-mcp-tests", Guid.NewGuid().ToString("N"));
+        var tasksDir = Path.Combine(baseDir, "wiki", "todo");
+        Directory.CreateDirectory(tasksDir);
+        var v = new VaultService(tasksDir);
+
+        // Create 5 overdue tasks
+        for (int i = 0; i < 5; i++)
+        {
+            v.Save(new GlassworkTask
+            {
+                Id = $"t-overdue-{i}",
+                Title = $"Overdue task {i}",
+                Due = DateTime.Today.AddDays(-i - 1),
+                Status = GlassworkTask.Statuses.Todo
+            });
+        }
+
+        var tools = new GlassworkTools(new VaultContext(baseDir));
+        var json = tools.ListOverdue(limit: 3);
+        var result = JsonDocument.Parse(json);
+
+        var tasks = result.RootElement.GetProperty("tasks");
+        Assert.AreEqual(3, tasks.GetArrayLength());
+        Assert.AreEqual(3, result.RootElement.GetProperty("count").GetInt32());
+    }
+
+    [TestMethod]
+    public void ListOverdue_ExcludesTasksDueToday()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), "glasswork-mcp-tests", Guid.NewGuid().ToString("N"));
+        var tasksDir = Path.Combine(baseDir, "wiki", "todo");
+        Directory.CreateDirectory(tasksDir);
+        var v = new VaultService(tasksDir);
+
+        v.Save(new GlassworkTask
+        {
+            Id = "t-due-today",
+            Title = "Due today",
+            Due = DateTime.Today,
+            Status = GlassworkTask.Statuses.Todo
+        });
+
+        v.Save(new GlassworkTask
+        {
+            Id = "t-overdue",
+            Title = "Overdue",
+            Due = DateTime.Today.AddDays(-1),
+            Status = GlassworkTask.Statuses.Todo
+        });
+
+        var tools = new GlassworkTools(new VaultContext(baseDir));
+        var json = tools.ListOverdue();
+        var result = JsonDocument.Parse(json);
+
+        var tasks = result.RootElement.GetProperty("tasks");
+        Assert.AreEqual(1, tasks.GetArrayLength());
+        Assert.AreEqual("t-overdue", tasks[0].GetProperty("id").GetString());
+    }
+
+    [TestMethod]
+    public void ListOverdue_HandlesNoDueDate()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), "glasswork-mcp-tests", Guid.NewGuid().ToString("N"));
+        var tasksDir = Path.Combine(baseDir, "wiki", "todo");
+        Directory.CreateDirectory(tasksDir);
+        var v = new VaultService(tasksDir);
+
+        v.Save(new GlassworkTask
+        {
+            Id = "t-no-due",
+            Title = "No due date",
+            Due = null,
+            Status = GlassworkTask.Statuses.Todo
+        });
+
+        v.Save(new GlassworkTask
+        {
+            Id = "t-overdue",
+            Title = "Overdue",
+            Due = DateTime.Today.AddDays(-1),
+            Status = GlassworkTask.Statuses.Todo
+        });
+
+        var tools = new GlassworkTools(new VaultContext(baseDir));
+        var json = tools.ListOverdue();
+        var result = JsonDocument.Parse(json);
+
+        var tasks = result.RootElement.GetProperty("tasks");
+        Assert.AreEqual(1, tasks.GetArrayLength());
+        Assert.AreEqual("t-overdue", tasks[0].GetProperty("id").GetString());
+    }
+
+    [TestMethod]
+    public void ListOverdue_FiltersToMyDayOnly()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), "glasswork-mcp-tests", Guid.NewGuid().ToString("N"));
+        var tasksDir = Path.Combine(baseDir, "wiki", "todo");
+        Directory.CreateDirectory(tasksDir);
+        var v = new VaultService(tasksDir);
+
+        v.Save(new GlassworkTask
+        {
+            Id = "t-overdue-myday",
+            Title = "Overdue in My Day",
+            Due = DateTime.Today.AddDays(-2),
+            Status = GlassworkTask.Statuses.Todo,
+            MyDay = DateTime.Today
+        });
+
+        v.Save(new GlassworkTask
+        {
+            Id = "t-overdue-not-myday",
+            Title = "Overdue not in My Day",
+            Due = DateTime.Today.AddDays(-2),
+            Status = GlassworkTask.Statuses.Todo,
+            MyDay = null
+        });
+
+        var tools = new GlassworkTools(new VaultContext(baseDir));
+        var json = tools.ListOverdue(include_my_day_only: true);
+        var result = JsonDocument.Parse(json);
+
+        var tasks = result.RootElement.GetProperty("tasks");
+        Assert.AreEqual(1, tasks.GetArrayLength());
+        Assert.AreEqual("t-overdue-myday", tasks[0].GetProperty("id").GetString());
+    }
+}


### PR DESCRIPTION
# MCP: list_overdue — find tasks past their due date

Closes #209

## Summary

Implements the `list_overdue` MCP tool to support morning review workflows. Returns tasks where `due_date < today` and status is not done.

## Changes

- **New tool**: `list_overdue` in `GlassworkTools.cs`
  - Filters to tasks with `Due < today` and `Status != Done`
  - Optional `include_my_day_only` parameter
  - Configurable `limit` (default 50)
  - Returns `days_overdue` calculation for each task
  - Orders by due date (oldest first)
- **New types**: `OverdueTask` and `ListOverdueResult` records with JSON serialization
- **Tests**: 6 integration tests covering core functionality and filtering

## Validation

- ✅ All 6 new tests pass
- ✅ All 815 existing tests pass
- ✅ `dotnet build src/Glasswork.Core/` succeeds
- ✅ TDD workflow followed (red-green-refactor per vertical slice)

## Review Notes

Ready for dual-model code review.
