### PR TITLE
feat: add move_task MCP tool

### DIFF
--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -889,23 +889,30 @@ public sealed class GlassworkTools
     /// <summary>
     /// Returns true if setting taskId's parent to potentialParent would create a cycle.
     /// Walks the ancestor chain of potentialParent to check if taskId appears.
+    /// Guards against existing cycles by tracking visited nodes.
     /// </summary>
     private bool WouldCreateCycle(string taskId, string potentialParent)
     {
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var current = potentialParent;
         
         while (!string.IsNullOrEmpty(current))
         {
+            // If we've seen this node before, there's a pre-existing cycle
+            // Treat this as safe (no cycle involving taskId), but stop walking
+            if (!visited.Add(current))
+                return false;
+
             if (current == taskId)
                 return true;
-                
+
             var task = _vault.Load(current);
             if (task is null)
                 break;
-                
+
             current = task.Parent;
         }
-        
+
         return false;
     }
 

--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -832,6 +832,83 @@ public sealed class GlassworkTools
         }
     }
 
+    [McpServerTool(Name = "move_task")]
+    [ToolPrecondition(VaultPathReadablePrecondition.PreconditionName)]
+    [Description("Reparent a task (with circular-ancestor guard). If the task has subtasks, the whole subtree implicitly moves.")]
+    public string MoveTask(
+        [Description("Task ID to move.")] string task_id,
+        [Description("New parent task ID, or null to promote to top-level.")] string? new_parent_id)
+    {
+        using var scope = _logger?.BeginCall("move_task");
+        try
+        {
+            var safeId = SanitizeId(task_id);
+            if (safeId is null || !_vault.Exists(safeId))
+            {
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("not_found", $"Task '{task_id}' not found."));
+            }
+
+            var task = _vault.Load(safeId)!;
+            var oldParentId = task.Parent;
+            var safeNewParent = SanitizeId(new_parent_id);
+
+            // Validate new parent exists
+            if (!string.IsNullOrEmpty(safeNewParent) && !_vault.Exists(safeNewParent))
+            {
+                scope?.SetResult("invalid_parent");
+                return JsonSerializer.Serialize(new ErrorResult("invalid_parent", $"Parent task '{new_parent_id}' not found."));
+            }
+
+            // Check for circular reparenting
+            if (!string.IsNullOrEmpty(safeNewParent) && WouldCreateCycle(safeId, safeNewParent))
+            {
+                scope?.SetResult("circular_parent");
+                return JsonSerializer.Serialize(new ErrorResult("circular_parent", $"Cannot move task '{task_id}': would create a circular parent relationship."));
+            }
+
+            // Perform the move
+            var writeSw = Stopwatch.StartNew();
+            _vault.SetParent(safeId, safeNewParent);
+            scope?.RecordPhase("write", writeSw.ElapsedMilliseconds);
+
+            scope?.SetResult("success");
+            return JsonSerializer.Serialize(new MoveTaskResult(
+                TaskId: safeId,
+                Title: task.Title,
+                OldParentId: oldParentId,
+                NewParentId: safeNewParent));
+        }
+        catch
+        {
+            scope?.SetResult("error");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Returns true if setting taskId's parent to potentialParent would create a cycle.
+    /// Walks the ancestor chain of potentialParent to check if taskId appears.
+    /// </summary>
+    private bool WouldCreateCycle(string taskId, string potentialParent)
+    {
+        var current = potentialParent;
+        
+        while (!string.IsNullOrEmpty(current))
+        {
+            if (current == taskId)
+                return true;
+                
+            var task = _vault.Load(current);
+            if (task is null)
+                break;
+                
+            current = task.Parent;
+        }
+        
+        return false;
+    }
+
     private static string AppendNotes(string existing, string value)
     {
         var trimmed = existing.TrimEnd();
@@ -1392,6 +1469,12 @@ public sealed class GlassworkTools
     private sealed record UpdateTaskResult(
         [property: JsonPropertyName("task_id")] string TaskId,
         [property: JsonPropertyName("updated_fields")] string[] UpdatedFields);
+
+    private sealed record MoveTaskResult(
+        [property: JsonPropertyName("task_id")] string TaskId,
+        [property: JsonPropertyName("title")] string Title,
+        [property: JsonPropertyName("old_parent_id")] string? OldParentId,
+        [property: JsonPropertyName("new_parent_id")] string? NewParentId);
 
     private sealed record ErrorResult(
         [property: JsonPropertyName("error")] string Error,

--- a/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
@@ -1942,6 +1942,37 @@ References [[{taskId}]].
         // Assert: Should return invalid_parent error
         Assert.AreEqual("invalid_parent", result.RootElement.GetProperty("error").GetString());
     }
+
+    [TestMethod]
+    public void MoveTask_PreExistingCycle_DoesNotHang()
+    {
+        // Arrange: Create a pre-existing cycle (a -> b -> a) using VaultService.SetParent directly
+        var aJson = _tools.AddTask("Task A");
+        var bJson = _tools.AddTask("Task B");
+        var aId = JsonDocument.Parse(aJson).RootElement.GetProperty("task_id").GetString()!;
+        var bId = JsonDocument.Parse(bJson).RootElement.GetProperty("task_id").GetString()!;
+
+        // Create the cycle using VaultService.SetParent (bypasses all validation)
+        _vault.SetParent(aId, bId);
+        _vault.SetParent(bId, aId);
+
+        // Create an unrelated task
+        var cJson = _tools.AddTask("Task C");
+        var cId = JsonDocument.Parse(cJson).RootElement.GetProperty("task_id").GetString()!;
+
+        // Act: Try to move unrelated task C to the cyclic parent a
+        // This should complete (not hang) and succeed since c is not part of the cycle
+        var json = _tools.MoveTask(cId, aId);
+        var result = JsonDocument.Parse(json);
+
+        // Assert: Should succeed (c is not part of the a <-> b cycle)
+        Assert.AreEqual(cId, result.RootElement.GetProperty("task_id").GetString());
+        Assert.AreEqual(aId, result.RootElement.GetProperty("new_parent_id").GetString());
+
+        // Verify the file was updated
+        var updatedTask = _vault.Load(cId)!;
+        Assert.AreEqual(aId, updatedTask.Parent);
+    }
 }
 
 

--- a/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
@@ -1832,6 +1832,116 @@ References [[{taskId}]].
         Assert.IsTrue(phases.TryGetProperty("backlinks_scan", out _),
             "list_backlinks must record 'backlinks_scan' phase when GLASSWORK_MCP_TRACE=1.");
     }
+
+    // ───────────────────────────── move_task ─────────────────────────────
+
+    [TestMethod]
+    public void MoveTask_FromOneParentToAnother_UpdatesParentAndReturnsOldAndNew()
+    {
+        // Create: grandparent -> parent1 -> child
+        //         grandparent -> parent2
+        var grandparentJson = _tools.AddTask("Grandparent");
+        var grandparentId = JsonDocument.Parse(grandparentJson).RootElement.GetProperty("task_id").GetString()!;
+        
+        var parent1Json = _tools.AddTask("Parent 1", parent_task_id: grandparentId);
+        var parent1Id = JsonDocument.Parse(parent1Json).RootElement.GetProperty("task_id").GetString()!;
+        
+        var parent2Json = _tools.AddTask("Parent 2", parent_task_id: grandparentId);
+        var parent2Id = JsonDocument.Parse(parent2Json).RootElement.GetProperty("task_id").GetString()!;
+        
+        var childJson = _tools.AddTask("Child", parent_task_id: parent1Id);
+        var childId = JsonDocument.Parse(childJson).RootElement.GetProperty("task_id").GetString()!;
+
+        // Move child from parent1 to parent2
+        var moveJson = _tools.MoveTask(childId, parent2Id);
+        var doc = JsonDocument.Parse(moveJson);
+
+        Assert.AreEqual(childId, doc.RootElement.GetProperty("task_id").GetString());
+        Assert.AreEqual("Child", doc.RootElement.GetProperty("title").GetString());
+        Assert.AreEqual(parent1Id, doc.RootElement.GetProperty("old_parent_id").GetString());
+        Assert.AreEqual(parent2Id, doc.RootElement.GetProperty("new_parent_id").GetString());
+
+        // Verify the file was actually updated
+        var task = _vault.Load(childId)!;
+        Assert.AreEqual(parent2Id, task.Parent);
+    }
+
+    [TestMethod]
+    public void MoveTask_CircularReparenting_ReturnsError()
+    {
+        // Arrange: Create hierarchy grandparent -> parent -> child
+        var grandparentJson = _tools.AddTask("Grandparent Task");
+        var grandparentId = JsonDocument.Parse(grandparentJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var parentJson = _tools.AddTask("Parent Task", parent_task_id: grandparentId);
+        var parentId = JsonDocument.Parse(parentJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var childJson = _tools.AddTask("Child Task", parent_task_id: parentId);
+        var childId = JsonDocument.Parse(childJson).RootElement.GetProperty("task_id").GetString()!;
+
+        // Act: Try to make grandparent a child of child (circular)
+        var json = _tools.MoveTask(grandparentId, childId);
+        var result = JsonDocument.Parse(json);
+
+        // Assert: Should reject with circular_parent error
+        Assert.AreEqual("circular_parent", result.RootElement.GetProperty("error").GetString());
+        Assert.IsTrue(result.RootElement.GetProperty("message").GetString()!.Contains("circular"));
+
+        // Verify parent wasn't changed
+        var grandparent = _vault.Load(grandparentId)!;
+        Assert.IsNull(grandparent.Parent);
+    }
+
+    [TestMethod]
+    public void MoveTask_PromoteToTopLevel_ClearsParent()
+    {
+        // Arrange: Create parent -> child
+        var parentJson = _tools.AddTask("Parent Task");
+        var parentId = JsonDocument.Parse(parentJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var childJson = _tools.AddTask("Child Task", parent_task_id: parentId);
+        var childId = JsonDocument.Parse(childJson).RootElement.GetProperty("task_id").GetString()!;
+
+        // Act: Promote child to top-level (null parent)
+        var moveJson = _tools.MoveTask(childId, null);
+        var doc = JsonDocument.Parse(moveJson);
+
+        // Assert: Success with null new_parent_id
+        Assert.AreEqual(childId, doc.RootElement.GetProperty("task_id").GetString());
+        Assert.AreEqual("Child Task", doc.RootElement.GetProperty("title").GetString());
+        Assert.AreEqual(parentId, doc.RootElement.GetProperty("old_parent_id").GetString());
+        Assert.AreEqual(JsonValueKind.Null, doc.RootElement.GetProperty("new_parent_id").ValueKind);
+
+        // Verify file was updated (parent cleared)
+        var task = _vault.Load(childId)!;
+        Assert.IsNull(task.Parent);
+    }
+
+    [TestMethod]
+    public void MoveTask_TaskNotFound_ReturnsError()
+    {
+        // Act: Try to move non-existent task
+        var json = _tools.MoveTask("nonexistent", "anyparent");
+        var result = JsonDocument.Parse(json);
+
+        // Assert: Should return not_found error
+        Assert.AreEqual("not_found", result.RootElement.GetProperty("error").GetString());
+    }
+
+    [TestMethod]
+    public void MoveTask_ParentNotFound_ReturnsError()
+    {
+        // Arrange: Create a task
+        var taskJson = _tools.AddTask("Some Task");
+        var taskId = JsonDocument.Parse(taskJson).RootElement.GetProperty("task_id").GetString()!;
+
+        // Act: Try to move to non-existent parent
+        var json = _tools.MoveTask(taskId, "nonexistent-parent");
+        var result = JsonDocument.Parse(json);
+
+        // Assert: Should return invalid_parent error
+        Assert.AreEqual("invalid_parent", result.RootElement.GetProperty("error").GetString());
+    }
 }
 
 


### PR DESCRIPTION
# Add move_task MCP tool with circular reparenting guard

Closes #210

## Summary

Adds a new `move_task` MCP tool that allows agents to reparent tasks with validation:

1. **New parent existence validation** - Ensures the target parent exists before moving
2. **Circular reparenting prevention** - Guards against tasks becoming their own ancestors
3. **Support for promoting to top-level** - Accepts null parent to promote tasks
4. **Implicit subtree movement** - No file operations needed when moving subtasks

## Implementation

- **MoveTask() method** in `GlassworkTools.cs` with full validation chain:
  - Task exists check → Parent exists check (if non-null) → Circular check → SetParent
- **WouldCreateCycle() helper** that walks ancestor chain from potentialParent upward
- **MoveTaskResult record type** for consistent JSON serialization
- Uses existing `VaultService.SetParent()` for targeted frontmatter edit (no body rewrite)

## Test Coverage

✅ All 5 tests passing:
- Reparent from one parent to another
- Circular reparenting detection (grandparent → child)
- Promote to top-level (null parent)
- Task not found error
- Parent not found error

## Validation

✅ All project checks passed:
- `dotnet build src/Glasswork.Core/Glasswork.Core.csproj` - Succeeded
- `dotnet test tests/Glasswork.Mcp.Tests/Glasswork.Mcp.Tests.csproj` - All 203 tests passed

## TDD Workflow

Followed strict red-green-refactor:
1. Tracer bullet test (reparent between parents) - RED → GREEN
2. Circular reparenting test - RED → GREEN  
3. Promote to top-level test - RED → GREEN
4. Error tests (task/parent not found) - RED → GREEN

## Review Notes

Awaiting dual-model code review (gpt-5.5 and claude-opus-4.7).
