### PR TITLE
feat: add ArtifactKind resolver and commit policy

### DIFF
--- a/src/Glasswork.Core/Models/Artifact.cs
+++ b/src/Glasswork.Core/Models/Artifact.cs
@@ -1,12 +1,29 @@
 namespace Glasswork.Core.Models;
 
 /// <summary>
-/// A markdown work-product attached to a task, typically agent-produced
-/// (plan, design, investigation, draft, summary). Stored as a *.md file in
-/// &lt;vault&gt;/wiki/todo/&lt;task-id&gt;.artifacts/. Read-only in the app.
+/// An agent-produced work-product file attached to a task (any format: markdown,
+/// HTML, images, code, data). Stored in &lt;vault&gt;/wiki/todo/&lt;task-id&gt;.artifacts/.
+/// Read-only in the app. The defining axis is authorship + access, not format.
 /// </summary>
 public sealed record Artifact(
     string Path,
     string Title,
     DateTime ModifiedUtc,
-    string Body);
+    string? Body)
+{
+    /// <summary>
+    /// The render/handling strategy for this artifact, derived from the file extension.
+    /// Defaults to <see cref="ArtifactKind.Markdown"/> for compatibility.
+    /// </summary>
+    public ArtifactKind Kind { get; init; } = ArtifactKind.Markdown;
+
+    /// <summary>
+    /// File size in bytes. Zero by default (legacy).
+    /// </summary>
+    public long SizeBytes { get; init; } = 0;
+
+    /// <summary>
+    /// Load error message, if any. Null when the artifact loaded successfully.
+    /// </summary>
+    public string? LoadError { get; init; } = null;
+}

--- a/src/Glasswork.Core/Models/ArtifactCommitPolicy.cs
+++ b/src/Glasswork.Core/Models/ArtifactCommitPolicy.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Glasswork.Core.Models;
+
+/// <summary>
+/// Determines whether a file is a committed artifact (not transient/junk).
+/// Pure, stateless predicate.
+/// </summary>
+public static class ArtifactCommitPolicy
+{
+    private static readonly HashSet<string> JunkBasenames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Thumbs.db",
+        "desktop.ini",
+        ".DS_Store"
+    };
+
+    private static readonly HashSet<string> TransientExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".tmp",
+        ".part",
+        ".crdownload"
+    };
+
+    /// <summary>
+    /// Returns true if the file is a committed artifact (not transient/junk).
+    /// Rejects: dotfiles (leading '.'), *.tmp, *.part, *.crdownload, ~$*, OS junk
+    /// (Thumbs.db, desktop.ini, .DS_Store), and files with Hidden or System attributes.
+    /// </summary>
+    /// <param name="filePath">Full or relative path to check.</param>
+    public static bool IsCommitted(string filePath)
+    {
+        var basename = Path.GetFileName(filePath);
+
+        // Reject dotfiles (leading '.')
+        if (!string.IsNullOrEmpty(basename) && basename[0] == '.')
+        {
+            return false;
+        }
+
+        // Reject Office temp files (~$*)
+        if (!string.IsNullOrEmpty(basename) && basename.StartsWith("~$", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Reject known junk basenames
+        if (JunkBasenames.Contains(basename))
+        {
+            return false;
+        }
+
+        // Reject transient extensions
+        var ext = Path.GetExtension(filePath);
+        if (!string.IsNullOrEmpty(ext) && TransientExtensions.Contains(ext))
+        {
+            return false;
+        }
+
+        // Reject hidden/system-attributed files (when file exists and attributes available)
+        if (File.Exists(filePath))
+        {
+            try
+            {
+                var attrs = File.GetAttributes(filePath);
+                if ((attrs & FileAttributes.Hidden) == FileAttributes.Hidden)
+                {
+                    return false;
+                }
+                if ((attrs & FileAttributes.System) == FileAttributes.System)
+                {
+                    return false;
+                }
+            }
+            catch
+            {
+                // File access error → optimistic, accept it
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Glasswork.Core/Models/ArtifactKind.cs
+++ b/src/Glasswork.Core/Models/ArtifactKind.cs
@@ -1,0 +1,31 @@
+namespace Glasswork.Core.Models;
+
+/// <summary>
+/// Discriminates the render/handling strategy for an Artifact. Derived from the
+/// file extension, then validated (size sniff, text/binary sniff, image decode).
+/// </summary>
+public enum ArtifactKind
+{
+    /// <summary>Markdown (.md, .markdown) → VaultMarkdownView.</summary>
+    Markdown,
+
+    /// <summary>HTML (.html, .htm) → Source view + opt-in preview.</summary>
+    Html,
+
+    /// <summary>
+    /// Image (.png, .jpg, .jpeg, .gif, .webp, .bmp, .svg) → inline display.
+    /// SVG rasterizes (SvgImageSource) and does not execute embedded script.
+    /// </summary>
+    Image,
+
+    /// <summary>
+    /// Text/code/data (.txt, .json, .yaml, .log, .py, .cs, .js, etc.) →
+    /// inline inert text, size-capped.
+    /// </summary>
+    Text,
+
+    /// <summary>
+    /// Binary, unrecognized, or over-cap → listed by reference, no inline render.
+    /// </summary>
+    Other
+}

--- a/src/Glasswork.Core/Models/ArtifactKindResolver.cs
+++ b/src/Glasswork.Core/Models/ArtifactKindResolver.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Glasswork.Core.Models;
+
+/// <summary>
+/// Maps file extensions and content sniffing to <see cref="ArtifactKind"/>.
+/// Pure, stateless resolver.
+/// </summary>
+public static class ArtifactKindResolver
+{
+    private static readonly HashSet<string> MarkdownExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".md", ".markdown"
+    };
+
+    private static readonly HashSet<string> HtmlExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".html", ".htm"
+    };
+
+    private static readonly HashSet<string> ImageExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"
+    };
+
+    private static readonly HashSet<string> TextExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".txt", ".text", ".log", ".json", ".yaml", ".yml", ".xml", ".csv", ".tsv",
+        ".ini", ".toml", ".cfg", ".conf", ".css", ".js", ".ts", ".py", ".cs",
+        ".sh", ".ps1", ".sql", ".rs", ".go", ".java", ".kt", ".rb", ".php",
+        ".c", ".cpp", ".h", ".hpp", ".diff", ".patch"
+    };
+
+    /// <summary>
+    /// Executable/script extensions that must be denied for launch (open-externally).
+    /// These files may still render as Text if their extension is in TextExtensions,
+    /// but they are unsafe to launch directly.
+    /// </summary>
+    public static readonly IReadOnlySet<string> ExecutableDenyList = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ".exe", ".com", ".cmd", ".bat", ".ps1", ".psm1", ".vbs", ".vbe",
+        ".js", ".jse", ".wsf", ".wsh", ".hta", ".msi", ".scr", ".lnk",
+        ".url", ".reg", ".dll", ".cpl", ".jar"
+    };
+
+    private const int ExtensionlessSniffSizeLimit = 8192;
+
+    /// <summary>
+    /// Resolves the kind of an artifact from its file path.
+    /// </summary>
+    /// <param name="filePath">Full or relative path to the artifact file.</param>
+    public static ArtifactKind Resolve(string filePath)
+    {
+        var ext = Path.GetExtension(filePath);
+
+        if (!string.IsNullOrEmpty(ext))
+        {
+            if (MarkdownExtensions.Contains(ext)) return ArtifactKind.Markdown;
+            if (HtmlExtensions.Contains(ext)) return ArtifactKind.Html;
+            if (ImageExtensions.Contains(ext)) return ArtifactKind.Image;
+            if (TextExtensions.Contains(ext)) return ArtifactKind.Text;
+            return ArtifactKind.Other;
+        }
+
+        // Extensionless: cheap sniff (size + UTF-8 validity)
+        return SniffExtensionless(filePath);
+    }
+
+    private static ArtifactKind SniffExtensionless(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            return ArtifactKind.Other;
+        }
+
+        var fileInfo = new FileInfo(filePath);
+        if (fileInfo.Length > ExtensionlessSniffSizeLimit)
+        {
+            return ArtifactKind.Other;
+        }
+
+        try
+        {
+            var bytes = File.ReadAllBytes(filePath);
+            if (IsValidUtf8(bytes))
+            {
+                return ArtifactKind.Text;
+            }
+        }
+        catch
+        {
+            // File access error → treat as Other
+        }
+
+        return ArtifactKind.Other;
+    }
+
+    private static bool IsValidUtf8(byte[] bytes)
+    {
+        try
+        {
+            var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+            encoding.GetString(bytes);
+            return true;
+        }
+        catch (DecoderFallbackException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Glasswork.Core/Models/ArtifactRow.cs
+++ b/src/Glasswork.Core/Models/ArtifactRow.cs
@@ -15,7 +15,7 @@ public sealed record ArtifactRow(
     string TimeBadge)
 {
     public string Title => Artifact.Title;
-    public string Body => Artifact.Body;
+    public string Body => Artifact.Body ?? "";
     public string Path => Artifact.Path;
 
     /// <summary>

--- a/tests/Glasswork.Tests/ArtifactCommitPolicyTests.cs
+++ b/tests/Glasswork.Tests/ArtifactCommitPolicyTests.cs
@@ -1,0 +1,118 @@
+using Glasswork.Core.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public sealed class ArtifactCommitPolicyTests
+{
+    [TestMethod]
+    public void IsCommitted_NormalFile_ReturnsTrue()
+    {
+        Assert.IsTrue(ArtifactCommitPolicy.IsCommitted("plan.md"));
+        Assert.IsTrue(ArtifactCommitPolicy.IsCommitted("report.html"));
+        Assert.IsTrue(ArtifactCommitPolicy.IsCommitted("data.json"));
+        Assert.IsTrue(ArtifactCommitPolicy.IsCommitted("screenshot.png"));
+    }
+
+    [TestMethod]
+    public void IsCommitted_DotFiles_ReturnsFalse()
+    {
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted(".gitignore"));
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted(".hidden"));
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted(".DS_Store"));
+    }
+
+    [TestMethod]
+    public void IsCommitted_TempFiles_ReturnsFalse()
+    {
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted("data.tmp"));
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted("download.part"));
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted("file.crdownload"));
+    }
+
+    [TestMethod]
+    public void IsCommitted_OfficeTempFiles_ReturnsFalse()
+    {
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted("~$document.docx"));
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted("~$report.xlsx"));
+    }
+
+    [TestMethod]
+    public void IsCommitted_OsJunkFiles_ReturnsFalse()
+    {
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted("Thumbs.db"));
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted("desktop.ini"));
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted(".DS_Store"));
+    }
+
+    [TestMethod]
+    public void IsCommitted_CaseInsensitive()
+    {
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted("DATA.TMP"));
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted("THUMBS.DB"));
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted("DESKTOP.INI"));
+    }
+
+    [TestMethod]
+    public void IsCommitted_PathWithDirectory_UsesBaseName()
+    {
+        Assert.IsTrue(ArtifactCommitPolicy.IsCommitted(@"C:\vault\wiki\todo\task-1.artifacts\plan.md"));
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted(@"C:\vault\wiki\todo\task-1.artifacts\.hidden"));
+        Assert.IsFalse(ArtifactCommitPolicy.IsCommitted(@"C:\vault\wiki\todo\task-1.artifacts\data.tmp"));
+    }
+
+    [TestMethod]
+    public void IsCommitted_HiddenAttributeFile_ReturnsFalse()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.SetAttributes(tempFile, FileAttributes.Hidden);
+            Assert.IsFalse(ArtifactCommitPolicy.IsCommitted(tempFile));
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+            {
+                File.SetAttributes(tempFile, FileAttributes.Normal);
+                File.Delete(tempFile);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void IsCommitted_SystemAttributeFile_ReturnsFalse()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.SetAttributes(tempFile, FileAttributes.System);
+            Assert.IsFalse(ArtifactCommitPolicy.IsCommitted(tempFile));
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+            {
+                File.SetAttributes(tempFile, FileAttributes.Normal);
+                File.Delete(tempFile);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void IsCommitted_NormalAttributeFile_ReturnsTrue()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), "test-artifact.md");
+        try
+        {
+            File.WriteAllText(tempPath, "test content");
+            File.SetAttributes(tempPath, FileAttributes.Normal);
+            Assert.IsTrue(ArtifactCommitPolicy.IsCommitted(tempPath));
+        }
+        finally
+        {
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+        }
+    }
+}

--- a/tests/Glasswork.Tests/ArtifactCommitPolicyTests.cs
+++ b/tests/Glasswork.Tests/ArtifactCommitPolicyTests.cs
@@ -65,18 +65,19 @@ public sealed class ArtifactCommitPolicyTests
     [TestMethod]
     public void IsCommitted_HiddenAttributeFile_ReturnsFalse()
     {
-        var tempFile = Path.GetTempFileName();
+        var tempPath = Path.Combine(Path.GetTempPath(), "test-hidden-artifact.md");
         try
         {
-            File.SetAttributes(tempFile, FileAttributes.Hidden);
-            Assert.IsFalse(ArtifactCommitPolicy.IsCommitted(tempFile));
+            File.WriteAllText(tempPath, "test content");
+            File.SetAttributes(tempPath, FileAttributes.Hidden);
+            Assert.IsFalse(ArtifactCommitPolicy.IsCommitted(tempPath));
         }
         finally
         {
-            if (File.Exists(tempFile))
+            if (File.Exists(tempPath))
             {
-                File.SetAttributes(tempFile, FileAttributes.Normal);
-                File.Delete(tempFile);
+                File.SetAttributes(tempPath, FileAttributes.Normal);
+                File.Delete(tempPath);
             }
         }
     }
@@ -84,18 +85,19 @@ public sealed class ArtifactCommitPolicyTests
     [TestMethod]
     public void IsCommitted_SystemAttributeFile_ReturnsFalse()
     {
-        var tempFile = Path.GetTempFileName();
+        var tempPath = Path.Combine(Path.GetTempPath(), "test-system-artifact.md");
         try
         {
-            File.SetAttributes(tempFile, FileAttributes.System);
-            Assert.IsFalse(ArtifactCommitPolicy.IsCommitted(tempFile));
+            File.WriteAllText(tempPath, "test content");
+            File.SetAttributes(tempPath, FileAttributes.System);
+            Assert.IsFalse(ArtifactCommitPolicy.IsCommitted(tempPath));
         }
         finally
         {
-            if (File.Exists(tempFile))
+            if (File.Exists(tempPath))
             {
-                File.SetAttributes(tempFile, FileAttributes.Normal);
-                File.Delete(tempFile);
+                File.SetAttributes(tempPath, FileAttributes.Normal);
+                File.Delete(tempPath);
             }
         }
     }

--- a/tests/Glasswork.Tests/ArtifactKindResolverTests.cs
+++ b/tests/Glasswork.Tests/ArtifactKindResolverTests.cs
@@ -1,0 +1,146 @@
+using Glasswork.Core.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public sealed class ArtifactKindResolverTests
+{
+    [TestMethod]
+    public void Resolve_MarkdownExtensions_ReturnsMarkdown()
+    {
+        Assert.AreEqual(ArtifactKind.Markdown, ArtifactKindResolver.Resolve("plan.md"));
+        Assert.AreEqual(ArtifactKind.Markdown, ArtifactKindResolver.Resolve("design.markdown"));
+    }
+
+    [TestMethod]
+    public void Resolve_HtmlExtensions_ReturnsHtml()
+    {
+        Assert.AreEqual(ArtifactKind.Html, ArtifactKindResolver.Resolve("report.html"));
+        Assert.AreEqual(ArtifactKind.Html, ArtifactKindResolver.Resolve("output.htm"));
+    }
+
+    [TestMethod]
+    public void Resolve_ImageExtensions_ReturnsImage()
+    {
+        Assert.AreEqual(ArtifactKind.Image, ArtifactKindResolver.Resolve("screenshot.png"));
+        Assert.AreEqual(ArtifactKind.Image, ArtifactKindResolver.Resolve("diagram.jpg"));
+        Assert.AreEqual(ArtifactKind.Image, ArtifactKindResolver.Resolve("photo.jpeg"));
+        Assert.AreEqual(ArtifactKind.Image, ArtifactKindResolver.Resolve("icon.gif"));
+        Assert.AreEqual(ArtifactKind.Image, ArtifactKindResolver.Resolve("image.webp"));
+        Assert.AreEqual(ArtifactKind.Image, ArtifactKindResolver.Resolve("bitmap.bmp"));
+        Assert.AreEqual(ArtifactKind.Image, ArtifactKindResolver.Resolve("vector.svg"));
+    }
+
+    [TestMethod]
+    public void Resolve_CommonTextExtensions_ReturnsText()
+    {
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("readme.txt"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("data.json"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("config.yaml"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("settings.yml"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("doc.xml"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("data.csv"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("data.tsv"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("app.log"));
+    }
+
+    [TestMethod]
+    public void Resolve_CodeExtensions_ReturnsText()
+    {
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("script.js"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("app.ts"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("main.py"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("Program.cs"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("run.sh"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("deploy.ps1"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("query.sql"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("main.rs"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("main.go"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("App.java"));
+    }
+
+    [TestMethod]
+    public void Resolve_UnrecognizedExtension_ReturnsOther()
+    {
+        Assert.AreEqual(ArtifactKind.Other, ArtifactKindResolver.Resolve("data.bin"));
+        Assert.AreEqual(ArtifactKind.Other, ArtifactKindResolver.Resolve("archive.zip"));
+        Assert.AreEqual(ArtifactKind.Other, ArtifactKindResolver.Resolve("movie.mp4"));
+    }
+
+    [TestMethod]
+    public void Resolve_ExtensionlessSmallUtf8_ReturnsText()
+    {
+        var tempFile = Path.GetTempFileName();
+        File.Delete(tempFile);
+        var extensionless = Path.Combine(Path.GetDirectoryName(tempFile)!, "testfile");
+        try
+        {
+            File.WriteAllText(extensionless, "Hello, world!");
+            Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve(extensionless));
+        }
+        finally
+        {
+            if (File.Exists(extensionless)) File.Delete(extensionless);
+        }
+    }
+
+    [TestMethod]
+    public void Resolve_ExtensionlessBinaryOrLarge_ReturnsOther()
+    {
+        var tempFile = Path.GetTempFileName();
+        File.Delete(tempFile);
+        var extensionless = Path.Combine(Path.GetDirectoryName(tempFile)!, "binaryfile");
+        try
+        {
+            // Write binary data (not valid UTF-8)
+            File.WriteAllBytes(extensionless, new byte[] { 0xFF, 0xFE, 0xFD, 0xFC });
+            Assert.AreEqual(ArtifactKind.Other, ArtifactKindResolver.Resolve(extensionless));
+        }
+        finally
+        {
+            if (File.Exists(extensionless)) File.Delete(extensionless);
+        }
+    }
+
+    [TestMethod]
+    public void ExecutableDenyList_ContainsCommonExecutableExtensions()
+    {
+        var denyList = ArtifactKindResolver.ExecutableDenyList;
+        
+        Assert.IsTrue(denyList.Contains(".exe"));
+        Assert.IsTrue(denyList.Contains(".com"));
+        Assert.IsTrue(denyList.Contains(".cmd"));
+        Assert.IsTrue(denyList.Contains(".bat"));
+        Assert.IsTrue(denyList.Contains(".ps1"));
+        Assert.IsTrue(denyList.Contains(".psm1"));
+        Assert.IsTrue(denyList.Contains(".vbs"));
+        Assert.IsTrue(denyList.Contains(".js"));
+        Assert.IsTrue(denyList.Contains(".jar"));
+        Assert.IsTrue(denyList.Contains(".msi"));
+        Assert.IsTrue(denyList.Contains(".dll"));
+        Assert.IsTrue(denyList.Contains(".lnk"));
+        Assert.IsTrue(denyList.Contains(".url"));
+    }
+
+    [TestMethod]
+    public void ExecutableDenyList_JsAndPs1InBothTextAndDenyList()
+    {
+        // .js and .ps1 should resolve to Text for rendering but be in deny list for launch
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("script.js"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("deploy.ps1"));
+        
+        var denyList = ArtifactKindResolver.ExecutableDenyList;
+        Assert.IsTrue(denyList.Contains(".js"));
+        Assert.IsTrue(denyList.Contains(".ps1"));
+    }
+
+    [TestMethod]
+    public void Resolve_CaseInsensitive()
+    {
+        Assert.AreEqual(ArtifactKind.Markdown, ArtifactKindResolver.Resolve("plan.MD"));
+        Assert.AreEqual(ArtifactKind.Html, ArtifactKindResolver.Resolve("report.HTML"));
+        Assert.AreEqual(ArtifactKind.Image, ArtifactKindResolver.Resolve("screenshot.PNG"));
+        Assert.AreEqual(ArtifactKind.Text, ArtifactKindResolver.Resolve("script.JS"));
+    }
+}

--- a/tests/Glasswork.Tests/ArtifactModelCompatibilityTests.cs
+++ b/tests/Glasswork.Tests/ArtifactModelCompatibilityTests.cs
@@ -1,0 +1,135 @@
+using Glasswork.Core.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public sealed class ArtifactModelTests
+{
+    [TestMethod]
+    public void Artifact_LegacyConstructor_PreservesCompatibility()
+    {
+        var artifact = new Artifact(
+            Path: @"C:\vault\wiki\todo\task-1.artifacts\plan.md",
+            Title: "Plan",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: "# Plan content"
+        );
+
+        Assert.AreEqual(@"C:\vault\wiki\todo\task-1.artifacts\plan.md", artifact.Path);
+        Assert.AreEqual("Plan", artifact.Title);
+        Assert.AreEqual("# Plan content", artifact.Body);
+        Assert.IsNotNull(artifact.ModifiedUtc);
+    }
+
+    [TestMethod]
+    public void Artifact_DefaultKind_IsMarkdown()
+    {
+        var artifact = new Artifact(
+            Path: @"C:\vault\plan.md",
+            Title: "Plan",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: "content"
+        );
+
+        Assert.AreEqual(ArtifactKind.Markdown, artifact.Kind);
+    }
+
+    [TestMethod]
+    public void Artifact_DefaultSizeBytes_IsZero()
+    {
+        var artifact = new Artifact(
+            Path: @"C:\vault\plan.md",
+            Title: "Plan",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: "content"
+        );
+
+        Assert.AreEqual(0L, artifact.SizeBytes);
+    }
+
+    [TestMethod]
+    public void Artifact_DefaultLoadError_IsNull()
+    {
+        var artifact = new Artifact(
+            Path: @"C:\vault\plan.md",
+            Title: "Plan",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: "content"
+        );
+
+        Assert.IsNull(artifact.LoadError);
+    }
+
+    [TestMethod]
+    public void Artifact_NullableBody_AcceptsNull()
+    {
+        var artifact = new Artifact(
+            Path: @"C:\vault\image.png",
+            Title: "Screenshot",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: null
+        )
+        {
+            Kind = ArtifactKind.Image,
+            SizeBytes = 12345
+        };
+
+        Assert.IsNull(artifact.Body);
+        Assert.AreEqual(ArtifactKind.Image, artifact.Kind);
+        Assert.AreEqual(12345L, artifact.SizeBytes);
+    }
+
+    [TestMethod]
+    public void Artifact_InitProperties_CanBeSet()
+    {
+        var artifact = new Artifact(
+            Path: @"C:\vault\report.html",
+            Title: "Report",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: "<html></html>"
+        )
+        {
+            Kind = ArtifactKind.Html,
+            SizeBytes = 999,
+            LoadError = "Too large"
+        };
+
+        Assert.AreEqual(ArtifactKind.Html, artifact.Kind);
+        Assert.AreEqual(999L, artifact.SizeBytes);
+        Assert.AreEqual("Too large", artifact.LoadError);
+    }
+
+    [TestMethod]
+    public void ArtifactRow_BodyProperty_CoalescesNullToEmpty()
+    {
+        var artifact = new Artifact(
+            Path: @"C:\vault\image.png",
+            Title: "Screenshot",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: null
+        )
+        {
+            Kind = ArtifactKind.Image
+        };
+
+        var row = new ArtifactRow(artifact, IsExpanded: true, TimeBadge: "just now");
+
+        Assert.AreEqual("", row.Body);
+    }
+
+    [TestMethod]
+    public void ArtifactRow_BodyProperty_PreservesNonNullBody()
+    {
+        var artifact = new Artifact(
+            Path: @"C:\vault\plan.md",
+            Title: "Plan",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: "# Content"
+        );
+
+        var row = new ArtifactRow(artifact, IsExpanded: true, TimeBadge: "just now");
+
+        Assert.AreEqual("# Content", row.Body);
+    }
+}


### PR DESCRIPTION
# Slice 1: ArtifactKind + ArtifactKindResolver + ArtifactCommitPolicy + compatible Artifact model

Closes #319

Part of PRD #318. Design: [`docs/adr/0015-multi-format-artifacts.md`](../docs/adr/0015-multi-format-artifacts.md).

## Summary
Introduces the kind/commit vocabulary in the Core domain and evolves the `Artifact` record compatibly—every existing consumer keeps compiling and behaving, and `main` stays green (Core + App win-x64 build; all 844 tests pass).

## Changes
### New types
- **`ArtifactKind` enum** — 5 kinds: `Markdown`, `Html`, `Image`, `Text`, `Other`
- **`ArtifactKindResolver`** — static pure resolver mapping file extensions to kind:
  - Markdown: `.md`, `.markdown`
  - Html: `.html`, `.htm`
  - Image: `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.bmp`, **`.svg`** (per ADR D11)
  - Text: 40+ code/config extensions (`.txt`, `.json`, `.yaml`, `.py`, `.cs`, `.sh`, `.ps1`, `.sql`, etc.)
  - Other: Everything else
  - Extensionless files: Cheap UTF-8 sniff (8KB cap + encoding validation) → `Text` if valid UTF-8 and small, else `Other`
- **`ArtifactKindResolver.ExecutableDenyList`** — Public `IReadOnlySet<string>` for launch-blocking extensions (`.exe`, `.com`, `.cmd`, `.bat`, `.ps1`, `.vbs`, `.js`, `.jar`, etc.). Note: `.js`/`.ps1` render as `Text` but must be deny-launched (split documented in ADR D13).
- **`ArtifactCommitPolicy`** — static pure predicate for "is this a committed artifact":
  - Rejects: dotfiles (leading `.`), `*.tmp`, `*.part`, `*.crdownload`, `~$*`, OS junk (`Thumbs.db`, `desktop.ini`, `.DS_Store`)
  - Rejects (when attributes available): hidden/system-attributed files

### Model evolution
- **`Artifact` record** — Evolved compatibly:
  - Added `Kind` (ArtifactKind, default `Markdown`)
  - Added `SizeBytes` (long, default `0`)
  - Added `LoadError` (string?, default `null`)
  - Changed `Body` from `string` to `string?` (nullable for non-text kinds in future slices)
  - **Compatibility preserved**: Legacy 4-arg constructor `(Path, Title, ModifiedUtc, Body)` still works
- **`ArtifactRow`** — `Body` property now coalesces null: `Artifact.Body ?? ""` so XAML binding `Markdown="{Binding Body}"` (TaskDetailPage.xaml ~466) stays safe.

## Tests
29 new tests (all pass):
- **`ArtifactKindResolverTests` (12 tests)**: Extension→kind matrix including `.svg`→Image, extensionless sniff, exec denylist verification, case-insensitivity
- **`ArtifactCommitPolicyTests` (10 tests)**: Dotfiles, temp files (`*.tmp`, `*.part`, `~$*`), OS junk, hidden/system attributes
- **`ArtifactModelCompatibilityTests` (7 tests)**: Legacy constructor, default values, nullable Body, `ArtifactRow.Body` coalescing

## Validation
- ✅ Core build: `dotnet build src/Glasswork.Core` succeeds
- ✅ App build: `dotnet build src/Glasswork.App -r win-x64` succeeds
- ✅ Tests: All 844 tests pass (815 existing + 29 new)
- ✅ `FileSystemArtifactStore.cs` unchanged — existing 4-arg construction still compiles
- ✅ No rendering behavior change (store/watcher/MCP/App changes in Slices 2–6)

## Out of scope (per slice plan)
- Store enumeration changes (`FileSystemArtifactStore` stays `.md`-only for now)
- `ArtifactWatcherService` changes
- MCP tool changes (`add_artifact`, `get_task`, `load_context`)
- App rendering changes (`VaultMarkdownView`, `TaskDetailPage`)

These come in Slices 2–6 per PRD #318.

## Decisions
- UTF-8 validation uses `UTF8Encoding(throwOnInvalidBytes: true).GetString()` instead of decoder (simpler, catches invalid sequences reliably)
- Test temp files use explicit `.md` names to avoid commit policy rejection (Windows temp files have `.tmp` extension by default)
