### PR TITLE
feat: multi-format artifact store with kind-driven body reading

### DIFF
--- a/src/Glasswork.Core/Models/ArtifactCaps.cs
+++ b/src/Glasswork.Core/Models/ArtifactCaps.cs
@@ -1,0 +1,21 @@
+namespace Glasswork.Core.Models;
+
+/// <summary>
+/// Size cap constants for artifact processing. Text/code inline rendering and
+/// body reads stop at <see cref="InlineTextBytes"/>; image decoding and display
+/// stops at <see cref="InlineImageBytes"/>.
+/// </summary>
+public static class ArtifactCaps
+{
+    /// <summary>
+    /// Maximum size for inlining text/markdown/code artifact bodies (256 KB).
+    /// Over-cap → Body = null, listed by reference only.
+    /// </summary>
+    public const long InlineTextBytes = 256 * 1024;
+
+    /// <summary>
+    /// Maximum size for inlining image artifacts (10 MB).
+    /// Over-cap → by reference, no inline render.
+    /// </summary>
+    public const long InlineImageBytes = 10 * 1024 * 1024;
+}

--- a/src/Glasswork.Core/Services/FileSystemArtifactStore.cs
+++ b/src/Glasswork.Core/Services/FileSystemArtifactStore.cs
@@ -23,14 +23,51 @@ public sealed class FileSystemArtifactStore : IArtifactStore
             return Array.Empty<Artifact>();
         }
 
-        var files = Directory.EnumerateFiles(folder, "*.md", SearchOption.TopDirectoryOnly);
+        var files = Directory.EnumerateFiles(folder, "*", SearchOption.TopDirectoryOnly)
+            .Where(ArtifactCommitPolicy.IsCommitted);
         var artifacts = new List<Artifact>();
+        
         foreach (var file in files)
         {
-            var raw = File.ReadAllText(file);
-            var title = WikiPageTitleResolver.Resolve(raw, file);
-            var modified = File.GetLastWriteTimeUtc(file);
-            artifacts.Add(new Artifact(file, title, modified, raw));
+            var fileInfo = new FileInfo(file);
+            var kind = ArtifactKindResolver.Resolve(file);
+            var sizeBytes = fileInfo.Length;
+            var modified = fileInfo.LastWriteTimeUtc;
+            
+            string? body = null;
+            string? loadError = null;
+            
+            // Read body only for Markdown/Text kinds AND under the inline cap
+            if ((kind == ArtifactKind.Markdown || kind == ArtifactKind.Text) && 
+                sizeBytes <= ArtifactCaps.InlineTextBytes)
+            {
+                try
+                {
+                    body = File.ReadAllText(file);
+                }
+                catch (Exception ex)
+                {
+                    loadError = ex.Message;
+                }
+            }
+            
+            // Title: Markdown → WikiPageTitleResolver; others → filename with extension
+            string title;
+            if (kind == ArtifactKind.Markdown && body != null)
+            {
+                title = WikiPageTitleResolver.Resolve(body, file);
+            }
+            else
+            {
+                title = Path.GetFileName(file);
+            }
+            
+            artifacts.Add(new Artifact(file, title, modified, body)
+            {
+                Kind = kind,
+                SizeBytes = sizeBytes,
+                LoadError = loadError
+            });
         }
 
         return artifacts

--- a/tests/Glasswork.Tests/FileSystemArtifactStoreTests.cs
+++ b/tests/Glasswork.Tests/FileSystemArtifactStoreTests.cs
@@ -63,8 +63,11 @@ public class FileSystemArtifactStoreTests
 
         var result = new FileSystemArtifactStore(_vaultRoot).Load("my-task");
 
-        Assert.HasCount(1, result);
-        Assert.AreEqual("real", result[0].Title);
+        // After Slice 2: we include data.json as Text, but still exclude .tmp files
+        Assert.HasCount(2, result);
+        Assert.IsTrue(result.Any(a => a.Path.EndsWith("real.md")));
+        Assert.IsTrue(result.Any(a => a.Path.EndsWith("data.json")));
+        Assert.IsFalse(result.Any(a => a.Path.Contains(".tmp")));
     }
 
     [TestMethod]
@@ -140,5 +143,128 @@ public class FileSystemArtifactStoreTests
 
         Assert.HasCount(1, result);
         Assert.AreEqual("Good Fallback", result[0].Title);
+    }
+
+    // === Multi-format artifact tests (Slice 2) ===
+
+    [TestMethod]
+    public void Load_MixedFormatFolder_EachRowHasCorrectKindAndSize()
+    {
+        var folder = ArtifactsFolder("multi-task");
+        var mdPath = Path.Combine(folder, "plan.md");
+        var htmlPath = Path.Combine(folder, "report.html");
+        var pngPath = Path.Combine(folder, "screenshot.png");
+        var txtPath = Path.Combine(folder, "notes.txt");
+        var svgPath = Path.Combine(folder, "diagram.svg");
+        
+        File.WriteAllText(mdPath, "# Plan\n\nSome markdown");
+        File.WriteAllText(htmlPath, "<html><body>Report</body></html>");
+        File.WriteAllBytes(pngPath, new byte[] { 0x89, 0x50, 0x4E, 0x47 }); // PNG header
+        File.WriteAllText(txtPath, "Plain text notes");
+        File.WriteAllText(svgPath, "<svg></svg>");
+
+        var result = new FileSystemArtifactStore(_vaultRoot).Load("multi-task");
+
+        Assert.HasCount(5, result);
+        
+        var md = result.First(a => a.Path.EndsWith("plan.md"));
+        Assert.AreEqual(ArtifactKind.Markdown, md.Kind);
+        Assert.IsNotNull(md.Body);
+        Assert.IsTrue(md.SizeBytes > 0);
+        
+        var html = result.First(a => a.Path.EndsWith("report.html"));
+        Assert.AreEqual(ArtifactKind.Html, html.Kind);
+        Assert.IsNull(html.Body);
+        Assert.IsTrue(html.SizeBytes > 0);
+        
+        var png = result.First(a => a.Path.EndsWith("screenshot.png"));
+        Assert.AreEqual(ArtifactKind.Image, png.Kind);
+        Assert.IsNull(png.Body);
+        Assert.IsTrue(png.SizeBytes > 0);
+        
+        var txt = result.First(a => a.Path.EndsWith("notes.txt"));
+        Assert.AreEqual(ArtifactKind.Text, txt.Kind);
+        Assert.IsNotNull(txt.Body);
+        Assert.IsTrue(txt.SizeBytes > 0);
+        
+        var svg = result.First(a => a.Path.EndsWith("diagram.svg"));
+        Assert.AreEqual(ArtifactKind.Image, svg.Kind);
+        Assert.IsNull(svg.Body);
+        Assert.IsTrue(svg.SizeBytes > 0);
+    }
+
+    [TestMethod]
+    public void Load_JunkAndTransientFiles_Excluded()
+    {
+        var folder = ArtifactsFolder("junk-task");
+        File.WriteAllText(Path.Combine(folder, "real.md"), "real content");
+        File.WriteAllText(Path.Combine(folder, ".DS_Store"), "junk");
+        File.WriteAllText(Path.Combine(folder, "~$temp.md"), "office temp");
+        File.WriteAllText(Path.Combine(folder, "scratch.tmp"), "transient");
+
+        var result = new FileSystemArtifactStore(_vaultRoot).Load("junk-task");
+
+        Assert.HasCount(1, result);
+        Assert.AreEqual("real", result[0].Title);
+    }
+
+    [TestMethod]
+    public void Load_OverCapTextFile_BodyNullButSizeCorrect()
+    {
+        var folder = ArtifactsFolder("big-task");
+        var bigContent = new string('x', (int)ArtifactCaps.InlineTextBytes + 1000);
+        var path = Path.Combine(folder, "huge.txt");
+        File.WriteAllText(path, bigContent);
+
+        var result = new FileSystemArtifactStore(_vaultRoot).Load("big-task");
+
+        Assert.HasCount(1, result);
+        var artifact = result[0];
+        Assert.AreEqual(ArtifactKind.Text, artifact.Kind);
+        Assert.IsNull(artifact.Body);
+        Assert.IsTrue(artifact.SizeBytes > ArtifactCaps.InlineTextBytes);
+        Assert.AreEqual("huge.txt", artifact.Title);
+    }
+
+    [TestMethod]
+    public void Load_UnreadableFile_LoadErrorPopulatedOtherRowsReturned()
+    {
+        var folder = ArtifactsFolder("error-task");
+        var goodPath = Path.Combine(folder, "good.txt");
+        var badPath = Path.Combine(folder, "bad.txt");
+        File.WriteAllText(goodPath, "good content");
+        File.WriteAllText(badPath, "bad content");
+        
+        // Make the file unreadable by opening it exclusively
+        using (var stream = File.Open(badPath, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            var result = new FileSystemArtifactStore(_vaultRoot).Load("error-task");
+
+            Assert.HasCount(2, result);
+            var good = result.First(a => a.Path.EndsWith("good.txt"));
+            Assert.IsNull(good.LoadError);
+            Assert.IsNotNull(good.Body);
+            
+            var bad = result.First(a => a.Path.EndsWith("bad.txt"));
+            Assert.IsNotNull(bad.LoadError);
+            Assert.IsNull(bad.Body);
+        }
+    }
+
+    [TestMethod]
+    public void Load_NonMarkdownFiles_TitleIsFilenameWithExtension()
+    {
+        var folder = ArtifactsFolder("title-task");
+        File.WriteAllText(Path.Combine(folder, "report.html"), "<html>test</html>");
+        File.WriteAllText(Path.Combine(folder, "notes.txt"), "plain text");
+
+        var result = new FileSystemArtifactStore(_vaultRoot).Load("title-task");
+
+        Assert.HasCount(2, result);
+        var html = result.First(a => a.Path.EndsWith("report.html"));
+        Assert.AreEqual("report.html", html.Title);
+        
+        var txt = result.First(a => a.Path.EndsWith("notes.txt"));
+        Assert.AreEqual("notes.txt", txt.Title);
     }
 }


### PR DESCRIPTION
# Slice 2: Multi-Format Artifact Store

Part of PRD #318. Implements multi-format artifact enumeration with kind-driven body reading.

Closes #320

## Changes

### Core
- **ArtifactCaps** (new): Constants for inline size caps
  - `InlineTextBytes = 256 * 1024` (256KB)
  - `InlineImageBytes = 10 * 1024 * 1024` (10MB, reserved for App use)

- **FileSystemArtifactStore**: Multi-format enumeration
  - Enumerate ALL committed files (removed `*.md` filter)
  - Filter via `ArtifactCommitPolicy.IsCommitted()` (junk/transient/hidden exclusion)
  - Compute `Kind` via `ArtifactKindResolver` per file
  - Capture `SizeBytes` before any read operation
  - Read `Body` ONLY when `(Kind == Markdown || Kind == Text) && SizeBytes <= InlineTextBytes`
  - Over-cap or non-text kinds → `Body = null`, `SizeBytes` accurate
  - Per-file read failure → `LoadError` populated, other rows continue
  - Title bifurcation: markdown uses `WikiPageTitleResolver`, others use filename with extension
  - Preserve `ModifiedUtc` ordering

### Tests (TDD vertical slices)
1. ✅ Mixed-format folder (`.md`, `.html`, `.png`, `.txt`, `.svg`) → correct Kind/Size/Body
2. ✅ Junk/transient exclusion (`.DS_Store`, `~$temp`, `*.tmp`) via `ArtifactCommitPolicy`
3. ✅ Over-cap text file (>256KB) → `Body=null`, `SizeBytes` correct
4. ✅ Unreadable file → `LoadError` populated, other rows returned
5. ✅ Title rules: markdown uses wiki title, others use `filename.ext`

### Compatibility
- Updated `Load_IgnoresNonMarkdownFiles` test to reflect multi-format behavior
- All 849 tests pass (full suite green)
- Markdown artifacts still render exactly as today (body populated, `WikiPageTitleResolver` applied)

## Validation
```
✓ dotnet build src/Glasswork.Core/Glasswork.Core.csproj -nologo
✓ dotnet build src/Glasswork.App -nologo -r win-x64
✓ dotnet test tests/Glasswork.Tests/Glasswork.Tests.csproj -nologo (849 passed)
```

## Decisions
- **Binary file handling**: Never opened for reading (assert via test). Kind detection is extension-based only.
- **Error isolation**: Per-file read failures don't abort the entire `Load()` operation, allowing partial results.
- **Title extension inclusion**: Non-markdown artifacts show filename WITH extension for clarity (e.g., `report.html` not just `report`).

## Review Notes
(To be populated by dual-model code review)
