### PR TITLE
feat: add Task context bundles for agent handoff

### DIFF
--- a/src/Glasswork.Core/Models/TaskContextBundle.cs
+++ b/src/Glasswork.Core/Models/TaskContextBundle.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace Glasswork.Core.Models;
+
+/// <summary>
+/// A compact handoff packet for one Task: Description, Notes, active Subtasks,
+/// Links, latest Artifacts, Backlinks, open blockers, and relevant Vault paths.
+/// Designed for agent handoff — includes enough context for a Copilot-style agent
+/// to resume work without re-discovering the Task manually.
+/// </summary>
+public sealed record TaskContextBundle(
+    string TaskId,
+    string Title,
+    string Status,
+    string? Description,
+    string? Notes,
+    List<SubTask> ActiveSubtasks,
+    List<TaskLink> Links,
+    List<Artifact> LatestArtifacts,
+    List<Backlink> Backlinks,
+    List<SubTask> OpenBlockers,
+    string TaskFilePath,
+    string? ArtifactsPath);

--- a/src/Glasswork.Core/Services/TaskContextService.cs
+++ b/src/Glasswork.Core/Services/TaskContextService.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Glasswork.Core.Models;
+
+namespace Glasswork.Core.Services;
+
+/// <summary>
+/// Builds Task context bundles for agent handoff. Assembles a compact packet
+/// containing all relevant context for resuming work on a task.
+/// </summary>
+public class TaskContextService
+{
+    private readonly VaultService _vault;
+    private readonly IArtifactStore? _artifactStore;
+    private readonly IBacklinkIndex? _backlinkIndex;
+
+    public TaskContextService(VaultService vault, IArtifactStore? artifactStore = null, IBacklinkIndex? backlinkIndex = null)
+    {
+        _vault = vault;
+        _artifactStore = artifactStore;
+        _backlinkIndex = backlinkIndex;
+    }
+
+    /// <summary>
+    /// Builds a context bundle for the specified task.
+    /// Returns null if the task does not exist.
+    /// </summary>
+    public TaskContextBundle? BuildContextBundle(string taskId)
+    {
+        var task = _vault.Load(taskId);
+        if (task == null)
+            return null;
+
+        var taskFilePath = Path.Combine(_vault.VaultPath, $"{taskId}.md");
+
+        // Active subtasks: todo, in_progress, blocked (not done or dropped)
+        var activeSubtasks = task.Subtasks
+            .Where(s => s.Status != "done" && s.Status != "dropped")
+            .ToList();
+
+        // Open blockers: subtasks in blocked status
+        var openBlockers = task.Subtasks
+            .Where(s => s.Status == "blocked")
+            .ToList();
+
+        // Latest artifacts (sorted by mtime descending)
+        var artifacts = _artifactStore?.Load(taskId) ?? new List<Artifact>();
+
+        // Backlinks
+        var backlinks = _backlinkIndex?.GetBacklinks(taskId) ?? new List<Backlink>();
+
+        // Artifacts path
+        var artifactsPath = Path.Combine(_vault.VaultPath, $"{taskId}.artifacts");
+        var hasArtifactsDir = Directory.Exists(artifactsPath);
+
+        return new TaskContextBundle(
+            TaskId: task.Id,
+            Title: task.Title,
+            Status: task.Status,
+            Description: task.Description,
+            Notes: task.Notes,
+            ActiveSubtasks: activeSubtasks,
+            Links: task.Links,
+            LatestArtifacts: artifacts.ToList(),
+            Backlinks: backlinks.ToList(),
+            OpenBlockers: openBlockers,
+            TaskFilePath: taskFilePath,
+            ArtifactsPath: hasArtifactsDir ? artifactsPath : null);
+    }
+}

--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -2183,4 +2183,107 @@ public sealed class GlassworkTools
         [property: JsonPropertyName("tasks")] List<OverdueTask> Tasks,
         [property: JsonPropertyName("count")] int Count,
         [property: JsonPropertyName("as_of")] string AsOf);
+
+    [McpServerTool(Name = "get_task_context")]
+    [ToolPrecondition(VaultPathReadablePrecondition.PreconditionName)]
+    [Description("Get a compact handoff packet for one task: Description, Notes, active Subtasks, Links, latest Artifacts, Backlinks, open blockers, and relevant Vault paths. Designed for agent handoff — includes enough context to resume work without re-discovering the task manually.")]
+    public string GetTaskContext(
+        [Description("Task ID to retrieve context for.")] string task_id)
+    {
+        using var scope = _logger?.BeginCall("get_task_context");
+        try
+        {
+            var safeId = SanitizeId(task_id);
+            if (safeId is null)
+            {
+                scope?.SetResult("error");
+                return JsonSerializer.Serialize(new ErrorResult("invalid_id", 
+                    $"task_id '{task_id}' is invalid."));
+            }
+
+            // Build artifact store and backlink index
+            var artifactStore = new FileSystemArtifactStore(_vaultRoot);
+            var backlinkIndex = new BacklinkIndex();
+            backlinkIndex.Build(_vaultRoot);
+
+            var contextService = new TaskContextService(_vault, artifactStore, backlinkIndex);
+            var bundle = contextService.BuildContextBundle(safeId);
+
+            if (bundle is null)
+            {
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("not_found", 
+                    $"Task '{task_id}' not found."));
+            }
+
+            var result = new GetTaskContextResult(
+                TaskId: bundle.TaskId,
+                Title: bundle.Title,
+                Status: MapToExternalStatus(bundle.Status),
+                Description: bundle.Description,
+                Notes: bundle.Notes,
+                ActiveSubtasks: bundle.ActiveSubtasks.Select(s => new ContextSubtaskInfo(
+                    Text: s.Text,
+                    Status: s.Status,
+                    Notes: s.Notes)).ToArray(),
+                Links: bundle.Links.Select(l => new LinkResult(l.Type, l.Value, l.Label)).ToArray(),
+                LatestArtifacts: bundle.LatestArtifacts.Select(a => new ContextArtifactInfo(
+                    Path: TodoRelativeArtifactPath(bundle.TaskId, Path.GetFileName(a.Path)),
+                    Title: a.Title,
+                    Kind: a.Kind.ToString(),
+                    ModifiedUtc: a.ModifiedUtc.ToString("O"),
+                    SizeBytes: a.SizeBytes)).ToArray(),
+                Backlinks: bundle.Backlinks.Select(b => new ContextBacklinkInfo(
+                    LinkingPagePath: b.LinkingPagePath,
+                    LinkingPageTitle: b.LinkingPageTitle,
+                    PageType: b.PageType.ToString())).ToArray(),
+                OpenBlockers: bundle.OpenBlockers.Select(s => new ContextSubtaskInfo(
+                    Text: s.Text,
+                    Status: s.Status,
+                    Notes: s.Notes)).ToArray(),
+                TaskFilePath: TodoRelativeTaskPath(bundle.TaskId),
+                ArtifactsPath: bundle.ArtifactsPath != null 
+                    ? TodoRelativeTaskPath(bundle.TaskId).Replace(".md", ".artifacts")
+                    : null);
+
+            scope?.SetResult("success");
+            return JsonSerializer.Serialize(result);
+        }
+        catch
+        {
+            scope?.SetResult("error");
+            throw;
+        }
+    }
+
+    private sealed record GetTaskContextResult(
+        [property: JsonPropertyName("task_id")] string TaskId,
+        [property: JsonPropertyName("title")] string Title,
+        [property: JsonPropertyName("status")] string Status,
+        [property: JsonPropertyName("description")] string? Description,
+        [property: JsonPropertyName("notes")] string? Notes,
+        [property: JsonPropertyName("active_subtasks")] ContextSubtaskInfo[] ActiveSubtasks,
+        [property: JsonPropertyName("links")] LinkResult[] Links,
+        [property: JsonPropertyName("latest_artifacts")] ContextArtifactInfo[] LatestArtifacts,
+        [property: JsonPropertyName("backlinks")] ContextBacklinkInfo[] Backlinks,
+        [property: JsonPropertyName("open_blockers")] ContextSubtaskInfo[] OpenBlockers,
+        [property: JsonPropertyName("task_file_path")] string TaskFilePath,
+        [property: JsonPropertyName("artifacts_path")] string? ArtifactsPath);
+
+    private sealed record ContextSubtaskInfo(
+        [property: JsonPropertyName("text")] string Text,
+        [property: JsonPropertyName("status")] string Status,
+        [property: JsonPropertyName("notes")] string? Notes);
+
+    private sealed record ContextArtifactInfo(
+        [property: JsonPropertyName("path")] string Path,
+        [property: JsonPropertyName("title")] string Title,
+        [property: JsonPropertyName("kind")] string Kind,
+        [property: JsonPropertyName("modified_utc")] string ModifiedUtc,
+        [property: JsonPropertyName("size_bytes")] long SizeBytes);
+
+    private sealed record ContextBacklinkInfo(
+        [property: JsonPropertyName("linking_page_path")] string LinkingPagePath,
+        [property: JsonPropertyName("linking_page_title")] string LinkingPageTitle,
+        [property: JsonPropertyName("page_type")] string PageType);
 }

--- a/tests/Glasswork.Tests/TaskContextServiceTests.cs
+++ b/tests/Glasswork.Tests/TaskContextServiceTests.cs
@@ -1,0 +1,228 @@
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class TaskContextServiceTests
+{
+    private string _tempDir = null!;
+    private VaultService _vault = null!;
+    private TaskContextService _contextService = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-ctx-" + Guid.NewGuid().ToString("N")[..8]);
+        _vault = new VaultService(_tempDir);
+        _contextService = new TaskContextService(_vault);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public void BuildContextBundle_ValidTask_ReturnsBasicFields()
+    {
+        // Arrange
+        var task = new GlassworkTask
+        {
+            Id = "research-api",
+            Title = "Research API integration",
+            Status = GlassworkTask.Statuses.InProgress,
+            Description = "## Context\n\nInvestigate third-party API options.",
+            Notes = "Started with vendor docs.",
+        };
+        _vault.Save(task);
+
+        // Act
+        var bundle = _contextService.BuildContextBundle("research-api");
+
+        // Assert
+        Assert.IsNotNull(bundle);
+        Assert.AreEqual("research-api", bundle.TaskId);
+        Assert.AreEqual("Research API integration", bundle.Title);
+        Assert.AreEqual(GlassworkTask.Statuses.InProgress, bundle.Status);
+        Assert.AreEqual("## Context\n\nInvestigate third-party API options.", bundle.Description);
+        Assert.AreEqual("Started with vendor docs.", bundle.Notes);
+        Assert.IsTrue(bundle.TaskFilePath.EndsWith("research-api.md"));
+    }
+
+    [TestMethod]
+    public void BuildContextBundle_IncludesActiveSubtasks()
+    {
+        // Arrange
+        var task = new GlassworkTask
+        {
+            Id = "setup-ci",
+            Title = "Set up CI pipeline",
+            Status = GlassworkTask.Statuses.InProgress,
+            Subtasks = new List<SubTask>
+            {
+                new() { Text = "Configure GitHub Actions", Status = "todo" },
+                new() { Text = "Add test job", Status = "in_progress" },
+                new() { Text = "Enable status checks", Status = "blocked" },
+            }
+        };
+        _vault.Save(task);
+
+        // Act
+        var bundle = _contextService.BuildContextBundle("setup-ci");
+
+        // Assert
+        Assert.IsNotNull(bundle);
+        Assert.AreEqual(3, bundle.ActiveSubtasks.Count);
+        Assert.AreEqual("Configure GitHub Actions", bundle.ActiveSubtasks[0].Text);
+        Assert.AreEqual("todo", bundle.ActiveSubtasks[0].Status);
+        Assert.AreEqual("Add test job", bundle.ActiveSubtasks[1].Text);
+        Assert.AreEqual("in_progress", bundle.ActiveSubtasks[1].Status);
+        Assert.AreEqual("Enable status checks", bundle.ActiveSubtasks[2].Text);
+        Assert.AreEqual("blocked", bundle.ActiveSubtasks[2].Status);
+    }
+
+    [TestMethod]
+    public void BuildContextBundle_ExcludesDoneAndDroppedSubtasks()
+    {
+        // Arrange
+        var task = new GlassworkTask
+        {
+            Id = "migration-task",
+            Title = "Database migration",
+            Status = GlassworkTask.Statuses.InProgress,
+            Subtasks = new List<SubTask>
+            {
+                new() { Text = "Backup database", Status = "done" },
+                new() { Text = "Run migration scripts", Status = "in_progress" },
+                new() { Text = "Old approach", Status = "dropped" },
+                new() { Text = "Verify data integrity", Status = "todo" },
+            }
+        };
+        _vault.Save(task);
+
+        // Act
+        var bundle = _contextService.BuildContextBundle("migration-task");
+
+        // Assert
+        Assert.IsNotNull(bundle);
+        Assert.AreEqual(2, bundle.ActiveSubtasks.Count);
+        Assert.AreEqual("Run migration scripts", bundle.ActiveSubtasks[0].Text);
+        Assert.AreEqual("Verify data integrity", bundle.ActiveSubtasks[1].Text);
+    }
+
+    [TestMethod]
+    public void BuildContextBundle_IncludesOpenBlockers()
+    {
+        // Arrange
+        var task = new GlassworkTask
+        {
+            Id = "deploy-app",
+            Title = "Deploy application",
+            Status = GlassworkTask.Statuses.InProgress,
+            Subtasks = new List<SubTask>
+            {
+                new() { Text = "Run tests", Status = "blocked" },
+                new() { Text = "Review changes", Status = "blocked" },
+                new() { Text = "Deploy to prod", Status = "todo" },
+            }
+        };
+        _vault.Save(task);
+
+        // Act
+        var bundle = _contextService.BuildContextBundle("deploy-app");
+
+        // Assert
+        Assert.IsNotNull(bundle);
+        Assert.AreEqual(2, bundle.OpenBlockers.Count);
+        Assert.AreEqual("Run tests", bundle.OpenBlockers[0].Text);
+        Assert.AreEqual("blocked", bundle.OpenBlockers[0].Status);
+        Assert.AreEqual("Review changes", bundle.OpenBlockers[1].Text);
+        Assert.AreEqual("blocked", bundle.OpenBlockers[1].Status);
+    }
+
+    [TestMethod]
+    public void BuildContextBundle_WithArtifactStore_IncludesArtifacts()
+    {
+        // Arrange
+        // Create a proper vault structure: vaultRoot/wiki/todo/
+        var vaultRoot = Path.Combine(Path.GetTempPath(), "glasswork-artifact-" + Guid.NewGuid().ToString("N")[..8]);
+        var todoDir = Path.Combine(vaultRoot, "wiki", "todo");
+        Directory.CreateDirectory(todoDir);
+
+        var vault = new VaultService(todoDir);
+        var artifactStore = new FileSystemArtifactStore(vaultRoot);
+        var contextService = new TaskContextService(vault, artifactStore);
+
+        var task = new GlassworkTask
+        {
+            Id = "test-task",
+            Title = "Test task",
+            Status = GlassworkTask.Statuses.Todo,
+        };
+        vault.Save(task);
+
+        // Create an artifact
+        var artifactsDir = Path.Combine(todoDir, "test-task.artifacts");
+        Directory.CreateDirectory(artifactsDir);
+        File.WriteAllText(Path.Combine(artifactsDir, "plan.md"), "# Implementation Plan");
+
+        // Act
+        var bundle = contextService.BuildContextBundle("test-task");
+
+        // Assert
+        Assert.IsNotNull(bundle);
+        Assert.AreEqual(1, bundle.LatestArtifacts.Count);
+        Assert.AreEqual("Implementation Plan", bundle.LatestArtifacts[0].Title);
+        Assert.IsNotNull(bundle.ArtifactsPath);
+        Assert.IsTrue(bundle.ArtifactsPath.EndsWith("test-task.artifacts"));
+
+        // Cleanup
+        if (Directory.Exists(vaultRoot))
+            Directory.Delete(vaultRoot, recursive: true);
+    }
+
+    [TestMethod]
+    public void BuildContextBundle_WithBacklinkIndex_IncludesBacklinks()
+    {
+        // Arrange
+        // Create a proper vault structure: vaultRoot/wiki/todo/
+        var vaultRoot = Path.Combine(Path.GetTempPath(), "glasswork-backlink-" + Guid.NewGuid().ToString("N")[..8]);
+        var todoDir = Path.Combine(vaultRoot, "wiki", "todo");
+        var conceptsDir = Path.Combine(vaultRoot, "wiki", "concepts");
+        Directory.CreateDirectory(todoDir);
+        Directory.CreateDirectory(conceptsDir);
+
+        var vault = new VaultService(todoDir);
+
+        var task = new GlassworkTask
+        {
+            Id = "api-task",
+            Title = "API task",
+            Status = GlassworkTask.Statuses.Todo,
+        };
+        vault.Save(task);
+
+        // Create a backlink after the task exists
+        File.WriteAllText(Path.Combine(conceptsDir, "api-design.md"), "See [[api-task]] for implementation.");
+
+        var backlinkIndex = new BacklinkIndex();
+        backlinkIndex.Build(vaultRoot);
+        var contextService = new TaskContextService(vault, null, backlinkIndex);
+
+        // Act
+        var bundle = contextService.BuildContextBundle("api-task");
+
+        // Assert
+        Assert.IsNotNull(bundle);
+        Assert.AreEqual(1, bundle.Backlinks.Count);
+        Assert.AreEqual("api-design", bundle.Backlinks[0].LinkingPageTitle);
+        Assert.AreEqual(BacklinkPageType.Concept, bundle.Backlinks[0].PageType);
+
+        // Cleanup
+        if (Directory.Exists(vaultRoot))
+            Directory.Delete(vaultRoot, recursive: true);
+    }
+}


### PR DESCRIPTION
# Add Task context bundles for agent handoff

Implements #274

## What Changed

- Added `TaskContextBundle` model in `Glasswork.Core.Models` to represent a compact handoff packet for one task
- Added `TaskContextService` in `Glasswork.Core.Services` to assemble context bundles from vault, artifact store, and backlink index
- Added `get_task_context` MCP tool to expose context bundles as JSON for agent consumption
- Included 6 integration tests covering basic fields, active subtasks, excluded done/dropped subtasks, open blockers, artifacts, and backlinks

## Design Decisions

- **MCP-first surface**: Primary interface is the `get_task_context` MCP tool, designed for agent handoff scenarios
- **Active subtasks only**: Bundle includes `todo`, `in_progress`, and `blocked` subtasks; excludes `done` and `dropped` for focus on actionable work
- **Optional dependencies**: Service accepts optional `IArtifactStore` and `IBacklinkIndex` to support environments where these aren't available
- **Open blockers**: Explicitly surfaced as a separate collection (`blocked` status subtasks) for agent attention

## Context Bundle Contents

- Task ID, title, status
- Description and Notes (markdown prose)
- Active subtasks (excluding done/dropped)
- Links (ADO, PR, incident, doc, build, other)
- Latest artifacts (sorted by mtime descending)
- Backlinks (incoming wiki-links from vault pages)
- Open blockers (subtasks in blocked status)
- Task file path and artifacts path

## Testing

All 860 tests pass, including 6 new tests for `TaskContextService`:
- Basic fields (task ID, title, status, description, notes, paths)
- Active subtasks inclusion
- Done/dropped subtasks exclusion
- Open blockers identification
- Artifact integration via `FileSystemArtifactStore`
- Backlink integration via `BacklinkIndex`

## Validation

- ✅ `dotnet build src/Glasswork.Core/Glasswork.Core.csproj`
- ✅ `dotnet build src/Glasswork.App -r win-x64` (WinUI build)
- ✅ `dotnet test tests/Glasswork.Tests/` (860 tests pass)

Closes #274
