### PR TITLE
Multi-format artifact rendering: per-kind row templates + sandboxed HTML preview (#323, #324)

### DIFF
--- a/scripts/visual-verification/artifacts-html-hostile.json
+++ b/scripts/visual-verification/artifacts-html-hostile.json
@@ -1,0 +1,28 @@
+{
+  "name": "artifacts-html-hostile",
+  "startUri": "glasswork://backlog",
+  "tasks": [
+    {
+      "id": "artifact-html-hostile",
+      "title": "Hostile HTML preview sandbox",
+      "status": "todo",
+      "artifacts": [
+        {
+          "name": "hostile.html",
+          "content": "<!DOCTYPE html>\n<html>\n<head>\n<meta http-equiv=\"refresh\" content=\"1;url=https://evil.example/redirect\">\n<style>body{font-family:Segoe UI;margin:20px;color:#222} .ext{background:url(https://evil.example/bg.png);padding:8px} h1{color:#0F6CBD}</style>\n</head>\n<body>\n<h1>Hostile fixture renders locally</h1>\n<p>This text proves the local document rendered. External fetches and navigation must be blocked.</p>\n<img src=\"https://evil.example/tracker.png\" alt=\"external image (should be blocked)\" width=\"220\" height=\"50\">\n<iframe src=\"file:///C:/Windows/win.ini\" width=\"220\" height=\"50\"></iframe>\n<div class=\"ext\">CSS url() background (should be blocked)</div>\n<p><a href=\"https://evil.example/\" target=\"_blank\">External link (new window blocked)</a></p>\n<script>document.body.style.background='red';document.body.innerHTML='SCRIPT RAN';</script>\n</body>\n</html>\n"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    { "type": "select", "automationId": "NavBacklog", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "BacklogHeader", "timeoutMilliseconds": 10000 },
+    { "type": "invoke", "name": "Hostile HTML preview sandbox", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "row:hostile.html", "timeoutMilliseconds": 15000 },
+    { "type": "wait-for", "name": "Preview", "timeoutMilliseconds": 6000 },
+    { "type": "invoke", "name": "Preview" }
+  ],
+  "captures": [
+    { "name": "html-hostile-preview", "waitMilliseconds": 4500 }
+  ]
+}

--- a/scripts/visual-verification/artifacts-html-preview.json
+++ b/scripts/visual-verification/artifacts-html-preview.json
@@ -1,0 +1,28 @@
+{
+  "name": "artifacts-html-preview",
+  "startUri": "glasswork://backlog",
+  "tasks": [
+    {
+      "id": "artifact-html",
+      "title": "HTML artifact preview",
+      "status": "todo",
+      "artifacts": [
+        {
+          "name": "report.html",
+          "content": "<!DOCTYPE html>\n<html>\n<head><title>Report</title>\n<style>body{font-family:Segoe UI,Arial;margin:24px;color:#222} h1{color:#0F6CBD} .box{background:#eef;padding:12px;border-radius:6px}</style>\n</head>\n<body>\n<h1>Quarterly Report</h1>\n<p>This HTML artifact renders inside a sandboxed WebView2 preview.</p>\n<div class=\"box\">Inline CSS works. No external resources are loaded.</div>\n<ul><li>Item A</li><li>Item B</li></ul>\n</body>\n</html>\n"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    { "type": "select", "automationId": "NavBacklog", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "BacklogHeader", "timeoutMilliseconds": 10000 },
+    { "type": "invoke", "name": "HTML artifact preview", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "row:report.html", "timeoutMilliseconds": 15000 },
+    { "type": "wait-for", "name": "Preview", "timeoutMilliseconds": 6000 },
+    { "type": "invoke", "name": "Preview" }
+  ],
+  "captures": [
+    { "name": "html-preview", "waitMilliseconds": 4000 }
+  ]
+}

--- a/scripts/visual-verification/artifacts-html-source.json
+++ b/scripts/visual-verification/artifacts-html-source.json
@@ -1,0 +1,27 @@
+{
+  "name": "artifacts-html-source",
+  "startUri": "glasswork://backlog",
+  "tasks": [
+    {
+      "id": "artifact-html",
+      "title": "HTML artifact source",
+      "status": "todo",
+      "artifacts": [
+        {
+          "name": "report.html",
+          "content": "<!DOCTYPE html>\n<html>\n<head><title>Report</title>\n<style>body{font-family:Segoe UI,Arial;margin:24px;color:#222} h1{color:#0F6CBD} .box{background:#eef;padding:12px;border-radius:6px}</style>\n</head>\n<body>\n<h1>Quarterly Report</h1>\n<p>This HTML artifact renders inside a sandboxed WebView2 preview.</p>\n<div class=\"box\">Inline CSS works. No external resources are loaded.</div>\n<ul><li>Item A</li><li>Item B</li></ul>\n</body>\n</html>\n"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    { "type": "select", "automationId": "NavBacklog", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "BacklogHeader", "timeoutMilliseconds": 10000 },
+    { "type": "invoke", "name": "HTML artifact source", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "row:report.html", "timeoutMilliseconds": 15000 },
+    { "type": "delay", "timeoutMilliseconds": 1200 }
+  ],
+  "captures": [
+    { "name": "html-source", "waitMilliseconds": 1500 }
+  ]
+}

--- a/scripts/visual-verification/artifacts-html-teardown.json
+++ b/scripts/visual-verification/artifacts-html-teardown.json
@@ -1,0 +1,37 @@
+{
+  "name": "artifacts-html-teardown",
+  "startUri": "glasswork://backlog",
+  "tasks": [
+    {
+      "id": "artifact-html-teardown",
+      "title": "Single live preview eviction",
+      "status": "todo",
+      "artifacts": [
+        {
+          "name": "first.html",
+          "content": "<!DOCTYPE html><html><head><style>body{font-family:Segoe UI;margin:20px;color:#0F6CBD}</style></head><body><h1>FIRST preview</h1><p>Activated first, should be torn down when SECOND activates.</p></body></html>\n"
+        },
+        {
+          "name": "second.html",
+          "content": "<!DOCTYPE html><html><head><style>body{font-family:Segoe UI;margin:20px;color:#107C10}</style></head><body><h1>SECOND preview</h1><p>Activating this should evict the FIRST preview.</p></body></html>\n"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    { "type": "select", "automationId": "NavBacklog", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "BacklogHeader", "timeoutMilliseconds": 10000 },
+    { "type": "invoke", "name": "Single live preview eviction", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "row:first.html", "timeoutMilliseconds": 15000 },
+    { "type": "expand", "automationId": "row:first.html" },
+    { "type": "expand", "automationId": "row:second.html" },
+    { "type": "wait-for", "automationId": "preview:first.html", "timeoutMilliseconds": 6000 },
+    { "type": "invoke", "automationId": "preview:first.html" },
+    { "type": "delay", "timeoutMilliseconds": 2800 },
+    { "type": "invoke", "automationId": "preview:second.html" },
+    { "type": "delay", "timeoutMilliseconds": 500 }
+  ],
+  "captures": [
+    { "name": "html-teardown", "waitMilliseconds": 4000 }
+  ]
+}

--- a/scripts/visual-verification/artifacts-image.json
+++ b/scripts/visual-verification/artifacts-image.json
@@ -1,0 +1,26 @@
+{
+  "name": "artifacts-image",
+  "startUri": "glasswork://backlog",
+  "tasks": [
+    {
+      "id": "artifact-image",
+      "title": "Image artifact render",
+      "status": "todo",
+      "artifacts": [
+        {
+          "name": "checker.png",
+          "base64": "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAKElEQVR42mNgmLbqPzJ+ViGHggnKDwMDSNaAJj8cDBhNB6PpYNqq/wBzhF0fEFyTJgAAAABJRU5ErkJggg=="
+        }
+      ]
+    }
+  ],
+  "actions": [
+    { "type": "select", "automationId": "NavBacklog", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "BacklogHeader", "timeoutMilliseconds": 10000 },
+    { "type": "invoke", "name": "Image artifact render", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "row:checker.png", "timeoutMilliseconds": 15000 }
+  ],
+  "captures": [
+    { "name": "image", "waitMilliseconds": 1500 }
+  ]
+}

--- a/scripts/visual-verification/artifacts-markdown.json
+++ b/scripts/visual-verification/artifacts-markdown.json
@@ -1,0 +1,27 @@
+{
+  "name": "artifacts-markdown",
+  "startUri": "glasswork://backlog",
+  "tasks": [
+    {
+      "id": "artifact-md",
+      "title": "Markdown artifact render",
+      "status": "todo",
+      "artifacts": [
+        {
+          "name": "summary.md",
+          "content": "# Release summary\n\nThis is **markdown** rendered through VaultMarkdownView with a [link](https://example.com).\n\n- First bullet\n- Second bullet\n- Third bullet\n\n> A blockquote for good measure.\n"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    { "type": "select", "automationId": "NavBacklog", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "BacklogHeader", "timeoutMilliseconds": 10000 },
+    { "type": "invoke", "name": "Markdown artifact render", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "row:Release summary", "timeoutMilliseconds": 15000 },
+    { "type": "expand", "automationId": "row:Release summary", "timeoutMilliseconds": 10000 }
+  ],
+  "captures": [
+    { "name": "markdown", "waitMilliseconds": 1500 }
+  ]
+}

--- a/scripts/visual-verification/artifacts-reference.json
+++ b/scripts/visual-verification/artifacts-reference.json
@@ -1,0 +1,26 @@
+{
+  "name": "artifacts-reference",
+  "startUri": "glasswork://backlog",
+  "tasks": [
+    {
+      "id": "artifact-reference",
+      "title": "Reference-card artifact",
+      "status": "todo",
+      "artifacts": [
+        {
+          "name": "dataset.bin",
+          "content": "binary-ish payload that the app does not inline; rendered as a by-reference card with Open externally / Show in folder"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    { "type": "select", "automationId": "NavBacklog", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "BacklogHeader", "timeoutMilliseconds": 10000 },
+    { "type": "invoke", "name": "Reference-card artifact", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "row:dataset.bin", "timeoutMilliseconds": 15000 }
+  ],
+  "captures": [
+    { "name": "reference", "waitMilliseconds": 1500 }
+  ]
+}

--- a/scripts/visual-verification/artifacts-svg-source.json
+++ b/scripts/visual-verification/artifacts-svg-source.json
@@ -1,0 +1,28 @@
+{
+  "name": "artifacts-svg-source",
+  "startUri": "glasswork://backlog",
+  "tasks": [
+    {
+      "id": "artifact-svg",
+      "title": "SVG artifact render",
+      "status": "todo",
+      "artifacts": [
+        {
+          "name": "diagram.svg",
+          "content": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"240\" height=\"120\" viewBox=\"0 0 240 120\"><rect x=\"0\" y=\"0\" width=\"240\" height=\"120\" fill=\"#1b3a4b\"/><circle cx=\"60\" cy=\"60\" r=\"40\" fill=\"#f6a623\"/><text x=\"120\" y=\"66\" font-family=\"Segoe UI\" font-size=\"20\" fill=\"#ffffff\">SVG artifact</text></svg>"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    { "type": "select", "automationId": "NavBacklog", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "BacklogHeader", "timeoutMilliseconds": 10000 },
+    { "type": "invoke", "name": "SVG artifact render", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "row:diagram.svg", "timeoutMilliseconds": 15000 },
+    { "type": "wait-for", "name": "View source", "timeoutMilliseconds": 6000 },
+    { "type": "invoke", "name": "View source" }
+  ],
+  "captures": [
+    { "name": "svg-source", "waitMilliseconds": 1500 }
+  ]
+}

--- a/scripts/visual-verification/artifacts-svg.json
+++ b/scripts/visual-verification/artifacts-svg.json
@@ -1,0 +1,26 @@
+{
+  "name": "artifacts-svg",
+  "startUri": "glasswork://backlog",
+  "tasks": [
+    {
+      "id": "artifact-svg",
+      "title": "SVG artifact render",
+      "status": "todo",
+      "artifacts": [
+        {
+          "name": "diagram.svg",
+          "content": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"240\" height=\"120\" viewBox=\"0 0 240 120\"><rect x=\"0\" y=\"0\" width=\"240\" height=\"120\" fill=\"#1b3a4b\"/><circle cx=\"60\" cy=\"60\" r=\"40\" fill=\"#f6a623\"/><text x=\"120\" y=\"66\" font-family=\"Segoe UI\" font-size=\"20\" fill=\"#ffffff\">SVG artifact</text></svg>"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    { "type": "select", "automationId": "NavBacklog", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "BacklogHeader", "timeoutMilliseconds": 10000 },
+    { "type": "invoke", "name": "SVG artifact render", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "row:diagram.svg", "timeoutMilliseconds": 15000 }
+  ],
+  "captures": [
+    { "name": "svg", "waitMilliseconds": 1500 }
+  ]
+}

--- a/scripts/visual-verification/artifacts-text.json
+++ b/scripts/visual-verification/artifacts-text.json
@@ -1,0 +1,26 @@
+{
+  "name": "artifacts-text",
+  "startUri": "glasswork://backlog",
+  "tasks": [
+    {
+      "id": "artifact-text",
+      "title": "Text artifact render",
+      "status": "todo",
+      "artifacts": [
+        {
+          "name": "build-log.txt",
+          "content": "[12:00:01] Restoring packages...\n[12:00:04] Build started\n[12:00:09]   Glasswork.Core -> bin/Debug/net10.0\n[12:00:14]   Glasswork.App  -> bin/x64/Debug\n[12:00:15] Build succeeded: 0 warnings, 0 errors\nNOTE: this is inert monospace text. No *markdown* and no auto-linking of https://example.com\n"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    { "type": "select", "automationId": "NavBacklog", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "BacklogHeader", "timeoutMilliseconds": 10000 },
+    { "type": "invoke", "name": "Text artifact render", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "row:build-log.txt", "timeoutMilliseconds": 15000 }
+  ],
+  "captures": [
+    { "name": "text", "waitMilliseconds": 1500 }
+  ]
+}

--- a/src/Glasswork.App/App.xaml.cs
+++ b/src/Glasswork.App/App.xaml.cs
@@ -44,6 +44,12 @@ public partial class App : Application
     public static AzCliAdoWorkItemFetcher AdoFetcher { get; } = new();
     public static Glasswork.Core.AppUpdate.UpdateCheckService Updater { get; private set; } = null!;
 
+    /// <summary>
+    /// Single app-wide owner of the live HTML-preview WebView2 (#324).
+    /// UI-thread only; constructed eagerly since it holds no startup state.
+    /// </summary>
+    public static HtmlPreviewService HtmlPreview { get; } = new();
+
     // Inner concrete service for SwitchVault to rebuild the decorator with a new vault.
     private static JsonFileUiStateService _uiStateImpl = null!;
 

--- a/src/Glasswork.App/Controls/ArtifactBodyTemplateSelector.cs
+++ b/src/Glasswork.App/Controls/ArtifactBodyTemplateSelector.cs
@@ -1,0 +1,47 @@
+using Glasswork.Core.Models;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Glasswork.Controls;
+
+/// <summary>
+/// Selects the per-kind body template for an artifact row inside the
+/// artifacts <c>Expander</c>. Selection is driven entirely by the explicit
+/// flags on <see cref="ArtifactRow"/> (never a raw <c>Body == null</c> check —
+/// <see cref="ArtifactRow.Body"/> coalesces null to ""). Anything that cannot
+/// render inline — load errors, <see cref="ArtifactKind.Other"/>, over-cap
+/// markdown/text/image — falls back to the by-reference card.
+/// </summary>
+public partial class ArtifactBodyTemplateSelector : DataTemplateSelector
+{
+    public DataTemplate? MarkdownTemplate { get; set; }
+    public DataTemplate? TextTemplate { get; set; }
+    public DataTemplate? ImageTemplate { get; set; }
+    public DataTemplate? HtmlTemplate { get; set; }
+    public DataTemplate? ReferenceTemplate { get; set; }
+
+    protected override DataTemplate SelectTemplateCore(object item)
+    {
+        if (item is not ArtifactRow row)
+        {
+            return ReferenceTemplate!;
+        }
+
+        if (row.IsReference)
+        {
+            return ReferenceTemplate!;
+        }
+
+        return row.Kind switch
+        {
+            ArtifactKind.Markdown => row.ShouldRenderInlineMarkdown ? MarkdownTemplate! : ReferenceTemplate!,
+            ArtifactKind.Text => row.ShouldRenderInlineText ? TextTemplate! : ReferenceTemplate!,
+            ArtifactKind.Image => ImageTemplate!,
+            ArtifactKind.Html => HtmlTemplate!,
+            _ => ReferenceTemplate!,
+        };
+    }
+
+    protected override DataTemplate SelectTemplateCore(object item, DependencyObject container)
+        => SelectTemplateCore(item);
+}

--- a/src/Glasswork.App/Controls/ArtifactReferenceCard.xaml
+++ b/src/Glasswork.App/Controls/ArtifactReferenceCard.xaml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="Glasswork.Controls.ArtifactReferenceCard"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Border
+        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+        BorderThickness="1"
+        CornerRadius="6"
+        Padding="12">
+        <StackPanel Spacing="8">
+            <TextBlock
+                x:Name="TitleText"
+                FontWeight="SemiBold"
+                TextWrapping="Wrap" />
+            <TextBlock
+                x:Name="SubtitleText"
+                FontSize="12"
+                Opacity="0.7"
+                TextWrapping="Wrap" />
+            <TextBlock
+                x:Name="ErrorText"
+                FontSize="12"
+                Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                TextWrapping="Wrap"
+                Visibility="Collapsed" />
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <Button
+                    x:Name="OpenExternallyButton"
+                    Click="OnOpenExternallyClick"
+                    Content="Open externally" />
+                <Button
+                    x:Name="ShowInFolderButton"
+                    Click="OnShowInFolderClick"
+                    Content="Show in folder" />
+            </StackPanel>
+            <TextBlock
+                x:Name="StatusText"
+                FontSize="12"
+                Opacity="0.7"
+                TextWrapping="Wrap"
+                Visibility="Collapsed" />
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/src/Glasswork.App/Controls/ArtifactReferenceCard.xaml.cs
+++ b/src/Glasswork.App/Controls/ArtifactReferenceCard.xaml.cs
@@ -1,0 +1,104 @@
+using System;
+using Glasswork.Core.Models;
+using Glasswork.Services;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Glasswork.Controls;
+
+/// <summary>
+/// By-reference fallback card for artifacts the app cannot render inline:
+/// load errors, <see cref="ArtifactKind.Other"/>, over-cap markdown/text, and
+/// over-cap images. Shows filename + size (+ load error) with "Open externally"
+/// and "Show in folder" actions. It binds to the inherited
+/// <see cref="ArtifactRow"/> DataContext via <see cref="FrameworkElement.DataContextChanged"/>
+/// and never self-assigns its DataContext, so it composes safely both as a
+/// standalone body template and as the decode-failure fallback inside
+/// <see cref="ImageArtifactBody"/>.
+/// </summary>
+public sealed partial class ArtifactReferenceCard : UserControl
+{
+    private ArtifactRow? _row;
+
+    public ArtifactReferenceCard()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+    {
+        _row = args.NewValue as ArtifactRow;
+        Render();
+    }
+
+    private void Render()
+    {
+        StatusText.Visibility = Visibility.Collapsed;
+        StatusText.Text = string.Empty;
+
+        if (_row is null)
+        {
+            TitleText.Text = string.Empty;
+            SubtitleText.Text = string.Empty;
+            ErrorText.Visibility = Visibility.Collapsed;
+            OpenExternallyButton.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        TitleText.Text = _row.Title;
+        SubtitleText.Text = _row.SizeDisplay;
+
+        if (_row.HasLoadError)
+        {
+            ErrorText.Text = _row.LoadError;
+            ErrorText.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            ErrorText.Visibility = Visibility.Collapsed;
+        }
+
+        // Executable/script extensions are never launched; reveal in folder only.
+        OpenExternallyButton.Visibility = _row.CanLaunchExternally
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+    }
+
+    private async void OnOpenExternallyClick(object sender, RoutedEventArgs e)
+    {
+        var row = _row;
+        if (row is null)
+        {
+            return;
+        }
+
+        var error = await ArtifactExternalOpener.OpenExternallyAsync(row.Path);
+        ShowStatus(error);
+    }
+
+    private void OnShowInFolderClick(object sender, RoutedEventArgs e)
+    {
+        var row = _row;
+        if (row is null)
+        {
+            return;
+        }
+
+        var error = ArtifactExternalOpener.ShowInFolder(row.Path);
+        ShowStatus(error);
+    }
+
+    private void ShowStatus(string? error)
+    {
+        if (string.IsNullOrEmpty(error))
+        {
+            StatusText.Visibility = Visibility.Collapsed;
+            StatusText.Text = string.Empty;
+            return;
+        }
+
+        StatusText.Text = error;
+        StatusText.Visibility = Visibility.Visible;
+    }
+}

--- a/src/Glasswork.App/Controls/HtmlArtifactBody.xaml
+++ b/src/Glasswork.App/Controls/HtmlArtifactBody.xaml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="Glasswork.Controls.HtmlArtifactBody"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:conv="using:Glasswork.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <conv:ArtifactAutomationIdConverter x:Key="ArtifactAutoId" />
+    </UserControl.Resources>
+
+    <StackPanel
+        x:Name="Root"
+        Loaded="OnRootLoaded"
+        Spacing="6"
+        Unloaded="OnRootUnloaded">
+        <StackPanel Orientation="Horizontal" Spacing="6">
+            <Button
+                x:Name="SourceButton"
+                Click="OnSourceClick"
+                Content="Source" />
+            <Button
+                x:Name="PreviewButton"
+                AutomationProperties.AutomationId="{Binding Title, Converter={StaticResource ArtifactAutoId}, ConverterParameter='preview:'}"
+                Click="OnPreviewClick"
+                Content="Preview" />
+            <Button
+                x:Name="OpenBrowserButton"
+                Click="OnOpenBrowserClick"
+                Content="Open in browser" />
+        </StackPanel>
+        <TextBlock
+            x:Name="StatusNote"
+            FontSize="12"
+            Opacity="0.7"
+            TextWrapping="Wrap"
+            Visibility="Collapsed" />
+        <ContentControl
+            x:Name="HtmlHost"
+            HorizontalAlignment="Stretch"
+            HorizontalContentAlignment="Stretch"
+            VerticalContentAlignment="Stretch"
+            MinHeight="120" />
+    </StackPanel>
+</UserControl>

--- a/src/Glasswork.App/Controls/HtmlArtifactBody.xaml.cs
+++ b/src/Glasswork.App/Controls/HtmlArtifactBody.xaml.cs
@@ -1,0 +1,258 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Glasswork.Core.Models;
+using Glasswork.Services;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace Glasswork.Controls;
+
+/// <summary>
+/// HTML artifact body: a Source / Preview / Open-in-browser toggle over a
+/// swappable host. The Core store never inlines HTML bodies, so this control
+/// reads the file itself — always asynchronously, capped at
+/// <see cref="ArtifactCaps.InlineTextBytes"/>, and only on explicit activation
+/// (never synchronous IO during construction or Loaded).
+///
+/// Source (the default) shows inert monospace text. Preview hands the HTML to
+/// the single app-wide <see cref="HtmlPreviewService"/> (#324); only one preview
+/// is live at a time, so activating elsewhere evicts this one back to a
+/// "Preview closed" notice with a Re-activate button. If the WebView2 runtime is
+/// missing, Preview falls back to Source plus an Open-in-browser hint.
+///
+/// Async continuations are guarded by a generation counter and a DataContext
+/// identity check so a recycled/unloaded row never mutates a newer row's UI.
+/// </summary>
+public sealed partial class HtmlArtifactBody : UserControl
+{
+    private const double PreviewHeight = 480;
+
+    private int _generation;
+
+    public HtmlArtifactBody()
+    {
+        InitializeComponent();
+    }
+
+    private ArtifactRow? CurrentRow => Root.DataContext as ArtifactRow;
+
+    private void OnRootLoaded(object sender, RoutedEventArgs e)
+    {
+        var gen = ++_generation;
+        ShowNote(null);
+        HtmlHost.Content = null;
+        HtmlHost.Height = double.NaN;
+
+        var row = CurrentRow;
+        if (row is null || row.Kind != ArtifactKind.Html)
+        {
+            return;
+        }
+
+        // Default to Source, posted off the Loaded callback (no synchronous IO here).
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            if (gen == _generation)
+            {
+                _ = ShowSourceAsync(row, gen);
+            }
+        });
+    }
+
+    private void OnRootUnloaded(object sender, RoutedEventArgs e)
+    {
+        _generation++;
+        App.HtmlPreview?.Release(HtmlHost);
+    }
+
+    private void OnSourceClick(object sender, RoutedEventArgs e)
+    {
+        var row = CurrentRow;
+        if (row is null)
+        {
+            return;
+        }
+
+        ShowNote(null);
+        _ = ShowSourceAsync(row, _generation);
+    }
+
+    private void OnPreviewClick(object sender, RoutedEventArgs e)
+    {
+        var row = CurrentRow;
+        if (row is null)
+        {
+            return;
+        }
+
+        _ = ActivatePreviewAsync(row, _generation);
+    }
+
+    private async void OnOpenBrowserClick(object sender, RoutedEventArgs e)
+    {
+        var row = CurrentRow;
+        if (row is null)
+        {
+            return;
+        }
+
+        var error = await ArtifactExternalOpener.OpenExternallyAsync(row.Path);
+        ShowNote(error);
+    }
+
+    private async Task ShowSourceAsync(ArtifactRow row, int gen)
+    {
+        // Switching to Source tears down any preview this host owns.
+        App.HtmlPreview?.Release(HtmlHost);
+        HtmlHost.Height = double.NaN;
+
+        try
+        {
+            var info = new FileInfo(row.Path);
+            string text;
+            if (info.Length > ArtifactCaps.InlineTextBytes)
+            {
+                text = $"(file too large to show inline: {row.SizeDisplay} — use Open in browser)";
+            }
+            else
+            {
+                text = await File.ReadAllTextAsync(row.Path);
+            }
+
+            if (!IsCurrent(row, gen))
+            {
+                return;
+            }
+
+            ShowSourceText(text);
+        }
+        catch (Exception ex)
+        {
+            if (IsCurrent(row, gen))
+            {
+                ShowNote($"Couldn't read file: {ex.Message}");
+            }
+        }
+    }
+
+    private async Task ActivatePreviewAsync(ArtifactRow row, int gen)
+    {
+        string html;
+        try
+        {
+            var info = new FileInfo(row.Path);
+            if (info.Length > ArtifactCaps.InlineTextBytes)
+            {
+                ShowNote("File too large to preview — use Open in browser.");
+                return;
+            }
+
+            html = await File.ReadAllTextAsync(row.Path);
+        }
+        catch (Exception ex)
+        {
+            if (IsCurrent(row, gen))
+            {
+                ShowNote($"Couldn't read file: {ex.Message}");
+            }
+
+            return;
+        }
+
+        if (!IsCurrent(row, gen))
+        {
+            return;
+        }
+
+        var preview = App.HtmlPreview;
+        if (preview is null)
+        {
+            ShowNote("Preview unavailable.");
+            return;
+        }
+
+        HtmlHost.Height = PreviewHeight;
+        var result = await preview.ActivateAsync(HtmlHost, html, OnEvicted);
+        if (!IsCurrent(row, gen))
+        {
+            return;
+        }
+
+        switch (result)
+        {
+            case HtmlPreviewActivation.Activated:
+                ShowNote(null);
+                break;
+            case HtmlPreviewActivation.RuntimeMissing:
+                ShowNote("WebView2 runtime unavailable — showing source. Use Open in browser for full rendering.");
+                _ = ShowSourceAsync(row, gen);
+                break;
+            case HtmlPreviewActivation.Superseded:
+                // A newer activation already owns the live preview; leave the host alone.
+                break;
+        }
+    }
+
+    private void OnEvicted()
+    {
+        HtmlHost.Height = double.NaN;
+
+        var panel = new StackPanel { Spacing = 8 };
+        panel.Children.Add(new TextBlock
+        {
+            Text = "Preview closed — another preview is active.",
+            Opacity = 0.7,
+            TextWrapping = TextWrapping.Wrap,
+        });
+
+        var reactivate = new Button { Content = "Re-activate preview" };
+        reactivate.Click += (_, _) =>
+        {
+            var row = CurrentRow;
+            if (row is not null)
+            {
+                _ = ActivatePreviewAsync(row, _generation);
+            }
+        };
+        panel.Children.Add(reactivate);
+
+        HtmlHost.Content = panel;
+    }
+
+    private void ShowSourceText(string text)
+    {
+        var scroller = new ScrollViewer
+        {
+            MaxHeight = 480,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+        };
+        scroller.Content = new TextBlock
+        {
+            Text = text,
+            FontFamily = new FontFamily("Consolas"),
+            FontSize = 13,
+            IsTextSelectionEnabled = true,
+            TextWrapping = TextWrapping.Wrap,
+        };
+        HtmlHost.Content = scroller;
+    }
+
+    private void ShowNote(string? note)
+    {
+        if (string.IsNullOrEmpty(note))
+        {
+            StatusNote.Visibility = Visibility.Collapsed;
+            StatusNote.Text = string.Empty;
+            return;
+        }
+
+        StatusNote.Text = note;
+        StatusNote.Visibility = Visibility.Visible;
+    }
+
+    private bool IsCurrent(ArtifactRow row, int gen)
+        => gen == _generation && Root.Parent is not null && ReferenceEquals(Root.DataContext, row);
+}

--- a/src/Glasswork.App/Controls/ImageArtifactBody.xaml
+++ b/src/Glasswork.App/Controls/ImageArtifactBody.xaml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="Glasswork.Controls.ImageArtifactBody"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Glasswork.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <StackPanel
+        x:Name="Root"
+        Loaded="OnRootLoaded"
+        Spacing="6"
+        Unloaded="OnRootUnloaded">
+        <Button
+            x:Name="SvgToggle"
+            Click="OnSvgToggleClick"
+            Content="View source"
+            Visibility="Collapsed" />
+        <ScrollViewer
+            x:Name="ImageScroller"
+            HorizontalScrollBarVisibility="Auto"
+            MaxHeight="520"
+            VerticalScrollBarVisibility="Auto">
+            <Image
+                x:Name="ArtifactImage"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Top"
+                Stretch="None" />
+        </ScrollViewer>
+        <ScrollViewer
+            x:Name="SvgSourceScroller"
+            HorizontalScrollBarVisibility="Auto"
+            MaxHeight="400"
+            VerticalScrollBarVisibility="Auto"
+            Visibility="Collapsed">
+            <TextBlock
+                x:Name="SvgSourceText"
+                FontFamily="Consolas"
+                FontSize="13"
+                IsTextSelectionEnabled="True"
+                TextWrapping="Wrap" />
+        </ScrollViewer>
+        <controls:ArtifactReferenceCard x:Name="Fallback" Visibility="Collapsed" />
+    </StackPanel>
+</UserControl>

--- a/src/Glasswork.App/Controls/ImageArtifactBody.xaml.cs
+++ b/src/Glasswork.App/Controls/ImageArtifactBody.xaml.cs
@@ -1,0 +1,200 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Glasswork.Core.Models;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Windows.Storage;
+
+namespace Glasswork.Controls;
+
+/// <summary>
+/// Inline, read-only image body. Raster images decode through
+/// <see cref="BitmapImage"/> with a pixel-width cap (decompression-bomb guard
+/// on top of the Core byte cap); SVGs rasterize through <see cref="SvgImageSource"/>
+/// (no script) plus a "View source" toggle. Decode failures or over-cap files
+/// swap to the by-reference <see cref="ArtifactReferenceCard"/> fallback.
+///
+/// All asynchronous work is guarded by a monotonically increasing generation
+/// counter plus a DataContext identity check, so a row that is unloaded or
+/// rebound while a load is in flight never has a stale image assigned
+/// (honors copilot-instructions hard rule 6 and the Loaded/Unloaded ordering
+/// caveats).
+/// </summary>
+public sealed partial class ImageArtifactBody : UserControl
+{
+    private const int MaxDecodePixels = 4096;
+
+    private int _generation;
+    private bool _svgSourceLoaded;
+
+    public ImageArtifactBody()
+    {
+        InitializeComponent();
+        ArtifactImage.ImageFailed += OnImageFailed;
+    }
+
+    private ArtifactRow? CurrentRow => Root.DataContext as ArtifactRow;
+
+    private void OnRootLoaded(object sender, RoutedEventArgs e)
+    {
+        var gen = ++_generation;
+        _svgSourceLoaded = false;
+        SvgToggle.Visibility = Visibility.Collapsed;
+        SvgSourceScroller.Visibility = Visibility.Collapsed;
+        ImageScroller.Visibility = Visibility.Visible;
+        Fallback.Visibility = Visibility.Collapsed;
+        ArtifactImage.Source = null;
+
+        var row = CurrentRow;
+        if (row is null || row.Kind != ArtifactKind.Image)
+        {
+            return;
+        }
+
+        // Over-cap images never reach here (selector routes them to the reference
+        // card), but guard defensively in case of a race.
+        if (row.IsReference || row.SizeBytes > ArtifactCaps.InlineImageBytes)
+        {
+            ShowFallback();
+            return;
+        }
+
+        if (row.IsSvg)
+        {
+            SvgToggle.Visibility = Visibility.Visible;
+            _ = LoadSvgAsync(row, gen);
+        }
+        else
+        {
+            LoadRaster(row);
+        }
+    }
+
+    private void OnRootUnloaded(object sender, RoutedEventArgs e)
+    {
+        // Invalidate any in-flight async load and release the decoded pixels.
+        _generation++;
+        ArtifactImage.Source = null;
+    }
+
+    private void LoadRaster(ArtifactRow row)
+    {
+        try
+        {
+            var bitmap = new BitmapImage
+            {
+                DecodePixelType = DecodePixelType.Logical,
+                DecodePixelWidth = MaxDecodePixels,
+                UriSource = new Uri(row.Path),
+            };
+            ArtifactImage.Source = bitmap;
+        }
+        catch
+        {
+            ShowFallback();
+        }
+    }
+
+    private async Task LoadSvgAsync(ArtifactRow row, int gen)
+    {
+        try
+        {
+            var file = await StorageFile.GetFileFromPathAsync(row.Path);
+            using var stream = await file.OpenReadAsync();
+            if (!IsCurrent(row, gen))
+            {
+                return;
+            }
+
+            var svg = new SvgImageSource();
+            var status = await svg.SetSourceAsync(stream);
+            if (!IsCurrent(row, gen))
+            {
+                return;
+            }
+
+            if (status == SvgImageSourceLoadStatus.Success)
+            {
+                ArtifactImage.Source = svg;
+            }
+            else
+            {
+                ShowFallback();
+            }
+        }
+        catch
+        {
+            if (IsCurrent(row, gen))
+            {
+                ShowFallback();
+            }
+        }
+    }
+
+    private async void OnSvgToggleClick(object sender, RoutedEventArgs e)
+    {
+        var row = CurrentRow;
+        if (row is null)
+        {
+            return;
+        }
+
+        var showingSource = SvgSourceScroller.Visibility == Visibility.Visible;
+        if (showingSource)
+        {
+            SvgSourceScroller.Visibility = Visibility.Collapsed;
+            ImageScroller.Visibility = Visibility.Visible;
+            SvgToggle.Content = "View source";
+            return;
+        }
+
+        if (!_svgSourceLoaded)
+        {
+            var gen = _generation;
+            try
+            {
+                var info = new FileInfo(row.Path);
+                if (info.Length > ArtifactCaps.InlineTextBytes)
+                {
+                    SvgSourceText.Text = $"(source too large to display: {row.SizeDisplay})";
+                }
+                else
+                {
+                    var text = await File.ReadAllTextAsync(row.Path);
+                    if (!IsCurrent(row, gen))
+                    {
+                        return;
+                    }
+
+                    SvgSourceText.Text = text;
+                }
+
+                _svgSourceLoaded = true;
+            }
+            catch (Exception ex)
+            {
+                SvgSourceText.Text = $"(couldn't read source: {ex.Message})";
+            }
+        }
+
+        ImageScroller.Visibility = Visibility.Collapsed;
+        SvgSourceScroller.Visibility = Visibility.Visible;
+        SvgToggle.Content = "View image";
+    }
+
+    private void OnImageFailed(object sender, ExceptionRoutedEventArgs e) => ShowFallback();
+
+    private void ShowFallback()
+    {
+        ArtifactImage.Source = null;
+        ImageScroller.Visibility = Visibility.Collapsed;
+        SvgSourceScroller.Visibility = Visibility.Collapsed;
+        SvgToggle.Visibility = Visibility.Collapsed;
+        Fallback.Visibility = Visibility.Visible;
+    }
+
+    private bool IsCurrent(ArtifactRow row, int gen)
+        => gen == _generation && Root.Parent is not null && ReferenceEquals(Root.DataContext, row);
+}

--- a/src/Glasswork.App/Converters/RowConverters.cs
+++ b/src/Glasswork.App/Converters/RowConverters.cs
@@ -120,6 +120,26 @@ public sealed class CollapseChevronGlyphConverter : IValueConverter
         => throw new NotImplementedException();
 }
 /// <summary>
+/// Builds a deterministic AutomationId for an artifact-row element by prefixing
+/// the artifact Title (its filename) with the ConverterParameter. Visual
+/// verification uses this to target a specific artifact's Expander
+/// (parameter "row:") or HTML Preview button (parameter "preview:") without
+/// relying on document order. Not used for any user-facing behavior.
+/// </summary>
+public sealed class ArtifactAutomationIdConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        var prefix = parameter as string ?? string.Empty;
+        var title = value as string ?? string.Empty;
+        return prefix + title;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+        => throw new NotImplementedException();
+}
+
+/// <summary>
 /// Converts hex color strings (e.g., "#0F6CBD") to SolidColorBrush instances.
 /// Used for type badges in the Links section (slice 4).
 /// </summary>

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml
@@ -14,6 +14,45 @@
         <local:BoolToVisibilityConverter x:Key="BoolToVis" />
         <local:HexToBrushConverter x:Key="HexToBrush" />
         <conv:MyDayBrushConverter x:Key="MyDayBrush" />
+        <conv:ArtifactAutomationIdConverter x:Key="ArtifactAutoId" />
+
+        <!-- Per-ArtifactKind body templates (ADR 0015). Declared before the
+             selector that references them (StaticResource needs prior order). -->
+        <DataTemplate x:Key="ArtifactMarkdownTemplate">
+            <controls:VaultMarkdownView
+                Markdown="{Binding Body}"
+                Loaded="OnArtifactMarkdownLoaded"
+                Unloaded="OnArtifactMarkdownUnloaded" />
+        </DataTemplate>
+        <DataTemplate x:Key="ArtifactTextTemplate">
+            <ScrollViewer
+                HorizontalScrollBarVisibility="Auto"
+                MaxHeight="400"
+                VerticalScrollBarVisibility="Auto">
+                <TextBlock
+                    FontFamily="Consolas"
+                    FontSize="13"
+                    IsTextSelectionEnabled="True"
+                    Text="{Binding Body}"
+                    TextWrapping="Wrap" />
+            </ScrollViewer>
+        </DataTemplate>
+        <DataTemplate x:Key="ArtifactImageTemplate">
+            <controls:ImageArtifactBody />
+        </DataTemplate>
+        <DataTemplate x:Key="ArtifactHtmlTemplate">
+            <controls:HtmlArtifactBody />
+        </DataTemplate>
+        <DataTemplate x:Key="ArtifactReferenceTemplate">
+            <controls:ArtifactReferenceCard />
+        </DataTemplate>
+        <controls:ArtifactBodyTemplateSelector
+            x:Key="ArtifactBodySelector"
+            HtmlTemplate="{StaticResource ArtifactHtmlTemplate}"
+            ImageTemplate="{StaticResource ArtifactImageTemplate}"
+            MarkdownTemplate="{StaticResource ArtifactMarkdownTemplate}"
+            ReferenceTemplate="{StaticResource ArtifactReferenceTemplate}"
+            TextTemplate="{StaticResource ArtifactTextTemplate}" />
     </Page.Resources>
 
     <!-- Issue #174: banners live above the ScrollViewer so they stay
@@ -442,7 +481,10 @@
                                 <Expander HorizontalAlignment="Stretch"
                                           HorizontalContentAlignment="Stretch"
                                           Margin="0,0,0,4"
-                                          IsExpanded="{Binding IsExpanded}">
+                                          AutomationProperties.AutomationId="{Binding Title, Converter={StaticResource ArtifactAutoId}, ConverterParameter='row:'}"
+                                          IsExpanded="{Binding IsExpanded}"
+                                          Expanding="OnArtifactExpanding"
+                                          Collapsed="OnArtifactCollapsed">
                                     <Expander.Header>
                                         <Grid HorizontalAlignment="Stretch">
                                             <Grid.ColumnDefinitions>
@@ -457,15 +499,17 @@
                                                              Content="Open in Obsidian"
                                                              Tag="{Binding Path}"
                                                              Click="OpenArtifactInObsidian_Click"
+                                                             Visibility="{Binding ShowOpenInObsidian, Converter={StaticResource BoolToVis}}"
                                                              FontSize="12"
                                                              Padding="8,2"
                                                              VerticalAlignment="Center"
                                                              Margin="8,0,8,0" />
                                         </Grid>
                                     </Expander.Header>
-                                    <controls:VaultMarkdownView Markdown="{Binding Body}"
-                                                                Loaded="OnArtifactMarkdownLoaded"
-                                                                Unloaded="OnArtifactMarkdownUnloaded" />
+                                    <ContentControl HorizontalAlignment="Stretch"
+                                                    HorizontalContentAlignment="Stretch"
+                                                    Content="{Binding}"
+                                                    ContentTemplateSelector="{StaticResource ArtifactBodySelector}" />
                                 </Expander>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -29,6 +29,16 @@ public sealed partial class TaskDetailPage : Page
     private string _pendingDiskNotes = string.Empty;
     private ParentLinkResolution? _parentResolution;
 
+    /// <summary>
+    /// Per-artifact expand state (keyed by absolute Path, case-insensitive),
+    /// preserved across watcher-driven <see cref="BindArtifacts"/> refreshes so a
+    /// background file change does not collapse a row the user opened. Cleared
+    /// when the displayed task changes; stale keys are pruned on each rebind.
+    /// The live HTML preview is deliberately NOT preserved across refreshes.
+    /// </summary>
+    private readonly Dictionary<string, bool> _artifactExpandState = new(StringComparer.OrdinalIgnoreCase);
+    private string? _artifactsTaskId;
+
     public TaskDetailPage()
     {
         InitializeComponent();
@@ -273,6 +283,13 @@ public sealed partial class TaskDetailPage : Page
 
     private void BindArtifacts(string taskId)
     {
+        // Reset preserved expand state when the displayed task changes.
+        if (!string.Equals(_artifactsTaskId, taskId, StringComparison.OrdinalIgnoreCase))
+        {
+            _artifactExpandState.Clear();
+            _artifactsTaskId = taskId;
+        }
+
         IReadOnlyList<Artifact> artifacts;
         try
         {
@@ -291,8 +308,40 @@ public sealed partial class TaskDetailPage : Page
             return;
         }
 
+        var rows = ArtifactRow.Project(artifacts, DateTime.UtcNow);
+
+        // Prune expand state for artifacts that no longer exist, then apply any
+        // user-set state on top of the projection's default (newest expanded).
+        var livePaths = new HashSet<string>(rows.Select(r => r.Path), StringComparer.OrdinalIgnoreCase);
+        foreach (var stale in _artifactExpandState.Keys.Where(k => !livePaths.Contains(k)).ToList())
+        {
+            _artifactExpandState.Remove(stale);
+        }
+
+        var projected = rows
+            .Select(r => _artifactExpandState.TryGetValue(r.Path, out var expanded)
+                ? r with { IsExpanded = expanded }
+                : r)
+            .ToList();
+
         ArtifactsSection.Visibility = Visibility.Visible;
-        ArtifactsList.ItemsSource = ArtifactRow.Project(artifacts, DateTime.UtcNow);
+        ArtifactsList.ItemsSource = projected;
+    }
+
+    private void OnArtifactExpanding(Expander sender, ExpanderExpandingEventArgs args)
+    {
+        if (sender.DataContext is ArtifactRow row)
+        {
+            _artifactExpandState[row.Path] = true;
+        }
+    }
+
+    private void OnArtifactCollapsed(Expander sender, ExpanderCollapsedEventArgs args)
+    {
+        if (sender.DataContext is ArtifactRow row)
+        {
+            _artifactExpandState[row.Path] = false;
+        }
     }
 
 
@@ -594,6 +643,7 @@ public sealed partial class TaskDetailPage : Page
         App.ArtifactChangedExternally -= OnArtifactChangedExternally;
         App.BacklinksChangedExternally -= OnBacklinksChangedExternally;
         App.ObsidianLauncher.NotInstalled -= OnObsidianNotInstalled;
+        App.HtmlPreview.ReleaseAll();
         App.ActiveTask.Clear();
     }
 

--- a/src/Glasswork.App/Services/ArtifactExternalOpener.cs
+++ b/src/Glasswork.App/Services/ArtifactExternalOpener.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Windows.Storage;
+using Windows.System;
+
+namespace Glasswork.Services;
+
+/// <summary>
+/// Trusted, read-only escape hatches for artifacts the app cannot render inline.
+/// "Open externally" launches the file with its OS-default handler (bypassing
+/// <c>ArtifactLinkPolicy</c>, which only governs in-document links). "Show in
+/// folder" reveals the file in Explorer. Both are non-crashing: failures are
+/// returned as a short message for the caller to surface, never thrown.
+/// </summary>
+public static class ArtifactExternalOpener
+{
+    /// <summary>
+    /// Launches <paramref name="absolutePath"/> with the OS-default handler.
+    /// Returns null on success, or a short error message on failure.
+    /// Callers MUST gate on <c>ArtifactRow.CanLaunchExternally</c> first —
+    /// executable/script extensions should use <see cref="ShowInFolder"/> instead.
+    /// </summary>
+    public static async Task<string?> OpenExternallyAsync(string absolutePath)
+    {
+        if (string.IsNullOrWhiteSpace(absolutePath))
+        {
+            return "No file path.";
+        }
+
+        try
+        {
+            var file = await StorageFile.GetFileFromPathAsync(absolutePath);
+            var launched = await Launcher.LaunchFileAsync(file);
+            return launched ? null : "The system declined to open this file.";
+        }
+        catch (Exception ex)
+        {
+            return $"Couldn't open externally: {ex.Message}";
+        }
+    }
+
+    /// <summary>
+    /// Reveals <paramref name="absolutePath"/> in Explorer (selected).
+    /// Returns null on success, or a short error message on failure.
+    /// </summary>
+    public static string? ShowInFolder(string absolutePath)
+    {
+        if (string.IsNullOrWhiteSpace(absolutePath))
+        {
+            return "No file path.";
+        }
+
+        try
+        {
+            // Use the full, normalized path. explorer.exe's /select switch needs the
+            // path as a single quoted token: /select,"C:\dir\file.ext".
+            var full = Path.GetFullPath(absolutePath);
+            var argument = $"/select,\"{full}\"";
+            var psi = new ProcessStartInfo("explorer.exe", argument)
+            {
+                UseShellExecute = true,
+            };
+            Process.Start(psi);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return $"Couldn't show in folder: {ex.Message}";
+        }
+    }
+}

--- a/src/Glasswork.App/Services/HtmlPreviewService.cs
+++ b/src/Glasswork.App/Services/HtmlPreviewService.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.Web.WebView2.Core;
+using Windows.Foundation;
+using MuxWebView2 = Microsoft.UI.Xaml.Controls.WebView2;
+
+namespace Glasswork.Services;
+
+/// <summary>
+/// Outcome of <see cref="HtmlPreviewService.ActivateAsync"/>.
+/// </summary>
+public enum HtmlPreviewActivation
+{
+    /// <summary>A sandboxed preview was created and navigation started.</summary>
+    Activated,
+
+    /// <summary>The WebView2 runtime is unavailable; caller should fall back to Source.</summary>
+    RuntimeMissing,
+
+    /// <summary>A newer activation superseded this one while it was initializing.</summary>
+    Superseded,
+}
+
+/// <summary>
+/// Owns the single, app-wide live <see cref="MuxWebView2"/> used for sandboxed
+/// HTML artifact preview (#324). Only one preview can be active at a time:
+/// activating a second tears the first down and notifies it via its
+/// <c>onEvicted</c> callback ("Preview closed — another preview is active").
+///
+/// A fresh WebView2 is created on every activation and disposed on the next
+/// activation, on <see cref="Release"/>, or on <see cref="ReleaseAll"/>. The
+/// instance is never re-parented between hosts (re-parenting inside a list is
+/// fragile and leaks visual-tree references). All methods must be called on the
+/// UI thread.
+///
+/// Sandbox hardening, applied before navigating: script, host objects, web
+/// messages, script dialogs, and dev tools are all disabled; new windows,
+/// permission requests, and every web-resource request are blocked; and any
+/// navigation after the initial <see cref="CoreWebView2.NavigateToString"/> is
+/// cancelled. The document is supplied inline, so every web-resource request is
+/// an external subresource and is denied — local structure/text renders while
+/// external fetches and navigations do not.
+/// </summary>
+public sealed class HtmlPreviewService
+{
+    private ContentControl? _activeHost;
+    private Action? _activeOnEvicted;
+    private MuxWebView2? _webView;
+    private CoreWebView2? _core;
+    private bool _sawInitialNav;
+
+    private TypedEventHandler<CoreWebView2, CoreWebView2NavigationStartingEventArgs>? _navStarting;
+    private TypedEventHandler<CoreWebView2, CoreWebView2NewWindowRequestedEventArgs>? _newWindow;
+    private TypedEventHandler<CoreWebView2, CoreWebView2PermissionRequestedEventArgs>? _permission;
+    private TypedEventHandler<CoreWebView2, CoreWebView2WebResourceRequestedEventArgs>? _resource;
+
+    /// <summary>
+    /// Activates a sandboxed preview of <paramref name="html"/> inside
+    /// <paramref name="host"/>. If a different host is currently previewing, it
+    /// is torn down first and its <paramref name="onEvicted"/> equivalent is
+    /// invoked. <paramref name="onEvicted"/> is stored for this host and called
+    /// if a later activation evicts it.
+    /// </summary>
+    public async Task<HtmlPreviewActivation> ActivateAsync(ContentControl host, string html, Action onEvicted)
+    {
+        if (_activeHost is not null && !ReferenceEquals(_activeHost, host))
+        {
+            var prior = _activeOnEvicted;
+            DisposeWebView();
+            _activeHost = null;
+            _activeOnEvicted = null;
+            prior?.Invoke();
+        }
+        else if (ReferenceEquals(_activeHost, host))
+        {
+            DisposeWebView();
+        }
+
+        _activeHost = host;
+        _activeOnEvicted = onEvicted;
+
+        var webView = new MuxWebView2();
+        _webView = webView;
+        host.Content = webView;
+
+        try
+        {
+            await webView.EnsureCoreWebView2Async();
+        }
+        catch (Exception)
+        {
+            if (ReferenceEquals(_webView, webView))
+            {
+                DisposeWebView();
+                if (ReferenceEquals(host.Content, webView))
+                {
+                    host.Content = null;
+                }
+
+                _activeHost = null;
+                _activeOnEvicted = null;
+            }
+
+            return HtmlPreviewActivation.RuntimeMissing;
+        }
+
+        if (!ReferenceEquals(_webView, webView))
+        {
+            try { webView.Close(); } catch { /* best effort */ }
+            return HtmlPreviewActivation.Superseded;
+        }
+
+        var core = webView.CoreWebView2;
+        _core = core;
+        _sawInitialNav = false;
+
+        var settings = core.Settings;
+        settings.IsScriptEnabled = false;
+        settings.AreHostObjectsAllowed = false;
+        settings.IsWebMessageEnabled = false;
+        settings.AreDefaultScriptDialogsEnabled = false;
+        settings.AreDevToolsEnabled = false;
+        settings.IsBuiltInErrorPageEnabled = false;
+        settings.AreBrowserAcceleratorKeysEnabled = false;
+
+        _navStarting = (_, e) =>
+        {
+            if (_sawInitialNav)
+            {
+                e.Cancel = true;
+            }
+            else
+            {
+                _sawInitialNav = true;
+            }
+        };
+        core.NavigationStarting += _navStarting;
+
+        _newWindow = (_, e) => e.Handled = true;
+        core.NewWindowRequested += _newWindow;
+
+        _permission = (_, e) => e.State = CoreWebView2PermissionState.Deny;
+        core.PermissionRequested += _permission;
+
+        core.AddWebResourceRequestedFilter("*", CoreWebView2WebResourceContext.All);
+        _resource = (_, e) =>
+        {
+            try
+            {
+                e.Response = core.Environment.CreateWebResourceResponse(null, 403, "Blocked", string.Empty);
+            }
+            catch
+            {
+                // Best effort: if a response can't be synthesized, the request still
+                // cannot run script and external navigation is already cancelled.
+            }
+        };
+        core.WebResourceRequested += _resource;
+
+        core.NavigateToString(html);
+        return HtmlPreviewActivation.Activated;
+    }
+
+    /// <summary>Tears down the preview if <paramref name="host"/> is the active one.</summary>
+    public void Release(ContentControl host)
+    {
+        if (!ReferenceEquals(_activeHost, host))
+        {
+            return;
+        }
+
+        var webView = _webView;
+        DisposeWebView();
+        if (ReferenceEquals(host.Content, webView))
+        {
+            host.Content = null;
+        }
+
+        _activeHost = null;
+        _activeOnEvicted = null;
+    }
+
+    /// <summary>Tears down any active preview. Does not invoke the eviction callback.</summary>
+    public void ReleaseAll()
+    {
+        if (_activeHost is null)
+        {
+            return;
+        }
+
+        var host = _activeHost;
+        DisposeWebView();
+        if (host.Content is MuxWebView2)
+        {
+            host.Content = null;
+        }
+
+        _activeHost = null;
+        _activeOnEvicted = null;
+    }
+
+    private void DisposeWebView()
+    {
+        if (_core is not null)
+        {
+            if (_navStarting is not null) _core.NavigationStarting -= _navStarting;
+            if (_newWindow is not null) _core.NewWindowRequested -= _newWindow;
+            if (_permission is not null) _core.PermissionRequested -= _permission;
+            if (_resource is not null) _core.WebResourceRequested -= _resource;
+        }
+
+        _navStarting = null;
+        _newWindow = null;
+        _permission = null;
+        _resource = null;
+        _core = null;
+        _sawInitialNav = false;
+
+        if (_webView is not null)
+        {
+            try { _webView.Close(); } catch { /* best effort */ }
+            _webView = null;
+        }
+    }
+}

--- a/src/Glasswork.Core/Models/ArtifactRow.cs
+++ b/src/Glasswork.Core/Models/ArtifactRow.cs
@@ -18,6 +18,71 @@ public sealed record ArtifactRow(
     public string Body => Artifact.Body ?? "";
     public string Path => Artifact.Path;
 
+    /// <summary>The render/handling strategy for this artifact.</summary>
+    public ArtifactKind Kind => Artifact.Kind;
+
+    /// <summary>File size in bytes.</summary>
+    public long SizeBytes => Artifact.SizeBytes;
+
+    /// <summary>Load error message, if any.</summary>
+    public string? LoadError => Artifact.LoadError;
+
+    /// <summary>True when the Core store inlined a body for this artifact.</summary>
+    /// <remarks>
+    /// <see cref="Body"/> coalesces null to the empty string, so a null check on
+    /// <see cref="Body"/> is always false. Templates and the body selector MUST use
+    /// this explicit flag to decide whether inline content exists.
+    /// </remarks>
+    public bool HasInlineBody => Artifact.Body is not null;
+
+    /// <summary>True when the artifact failed to load.</summary>
+    public bool HasLoadError => Artifact.LoadError is not null;
+
+    /// <summary>Render the body inline through VaultMarkdownView.</summary>
+    public bool ShouldRenderInlineMarkdown => Kind == ArtifactKind.Markdown && HasInlineBody && !HasLoadError;
+
+    /// <summary>Render the body inline as inert monospace text.</summary>
+    public bool ShouldRenderInlineText => Kind == ArtifactKind.Text && HasInlineBody && !HasLoadError;
+
+    /// <summary>"Open in Obsidian" only applies to vault markdown pages.</summary>
+    public bool ShowOpenInObsidian => Kind == ArtifactKind.Markdown;
+
+    /// <summary>True for SVG images, which rasterize via SvgImageSource (no script).</summary>
+    public bool IsSvg => Kind == ArtifactKind.Image
+        && string.Equals(System.IO.Path.GetExtension(Path), ".svg", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>True when the file extension is unsafe to launch directly.</summary>
+    public bool IsLaunchDenied => ArtifactKindResolver.ExecutableDenyList.Contains(System.IO.Path.GetExtension(Path));
+
+    /// <summary>True when "Open externally" (launch) is permitted for this artifact.</summary>
+    public bool CanLaunchExternally => !IsLaunchDenied;
+
+    /// <summary>
+    /// True when the row must render as a by-reference card rather than inline:
+    /// load errors, unrecognized/binary (Other), over-cap text/markdown (null body),
+    /// or over-cap images.
+    /// </summary>
+    public bool IsReference =>
+        HasLoadError
+        || Kind == ArtifactKind.Other
+        || (Kind == ArtifactKind.Markdown && !HasInlineBody)
+        || (Kind == ArtifactKind.Text && !HasInlineBody)
+        || (Kind == ArtifactKind.Image && SizeBytes > ArtifactCaps.InlineImageBytes);
+
+    /// <summary>Human-readable size, e.g. "0 B", "512 B", "12.3 KB", "1.5 MB".</summary>
+    public string SizeDisplay => FormatSize(SizeBytes);
+
+    private static string FormatSize(long bytes)
+    {
+        const long kb = 1024;
+        const long mb = kb * 1024;
+        const long gb = mb * 1024;
+        if (bytes < kb) return $"{bytes} B";
+        if (bytes < mb) return $"{bytes / (double)kb:0.0} KB";
+        if (bytes < gb) return $"{bytes / (double)mb:0.0} MB";
+        return $"{bytes / (double)gb:0.0} GB";
+    }
+
     /// <summary>
     /// Projects a time-ordered list of artifacts into rows. The newest
     /// artifact row has <see cref="IsExpanded"/> true; the rest are collapsed.

--- a/src/Glasswork.Core/VisualVerification/VisualVerificationScenario.cs
+++ b/src/Glasswork.Core/VisualVerification/VisualVerificationScenario.cs
@@ -172,7 +172,26 @@ public sealed class VisualVerificationSubtask
 public sealed class VisualVerificationArtifact
 {
     public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Raw text content for text-like artifacts (md/html/txt/svg). Takes
+    /// precedence over <see cref="Markdown"/> when set. Ignored when
+    /// <see cref="Base64"/> is provided.
+    /// </summary>
+    public string? Content { get; init; }
+
+    /// <summary>
+    /// Back-compat alias for <see cref="Content"/>; the original scenarios only
+    /// seeded markdown bodies.
+    /// </summary>
     public string Markdown { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Base64-encoded bytes for binary artifacts (e.g. a PNG). When set, the
+    /// file is written verbatim from the decoded bytes and text fields are
+    /// ignored.
+    /// </summary>
+    public string? Base64 { get; init; }
 }
 
 public sealed class VisualVerificationAction

--- a/tests/Glasswork.Tests/ArtifactRowTests.cs
+++ b/tests/Glasswork.Tests/ArtifactRowTests.cs
@@ -10,6 +10,26 @@ public class ArtifactRowTests
     private static Artifact MakeArtifact(string title, DateTime mtimeUtc)
         => new(Path: $"C:\\fake\\{title}.md", Title: title, ModifiedUtc: mtimeUtc, Body: "body");
 
+    private static ArtifactRow MakeRow(
+        string path,
+        ArtifactKind kind,
+        string? body,
+        long sizeBytes = 0,
+        string? loadError = null)
+    {
+        var artifact = new Artifact(
+            Path: path,
+            Title: System.IO.Path.GetFileName(path),
+            ModifiedUtc: DateTime.UtcNow,
+            Body: body)
+        {
+            Kind = kind,
+            SizeBytes = sizeBytes,
+            LoadError = loadError,
+        };
+        return new ArtifactRow(artifact, IsExpanded: false, TimeBadge: "just now");
+    }
+
     [TestMethod]
     public void Project_Empty_ReturnsEmpty()
     {
@@ -65,5 +85,110 @@ public class ArtifactRowTests
         Assert.AreSame(a, rows[0].Artifact);
         Assert.AreEqual("plan", rows[0].Title);
         Assert.AreEqual("body", rows[0].Body);
+    }
+
+    // ---- Per-kind flags (multi-format artifacts, ADR 0015) ----
+
+    [TestMethod]
+    public void Kind_And_SizeBytes_PassThroughFromArtifact()
+    {
+        var row = MakeRow("C:\\v\\a.png", ArtifactKind.Image, body: null, sizeBytes: 4096);
+        Assert.AreEqual(ArtifactKind.Image, row.Kind);
+        Assert.AreEqual(4096, row.SizeBytes);
+    }
+
+    [TestMethod]
+    public void HasInlineBody_TrueOnlyWhenBodyNonNull()
+    {
+        Assert.IsTrue(MakeRow("C:\\v\\a.md", ArtifactKind.Markdown, body: "x").HasInlineBody);
+        Assert.IsFalse(MakeRow("C:\\v\\a.md", ArtifactKind.Markdown, body: null).HasInlineBody);
+        // Body getter coalesces null->"" so a null check on Body is unreliable; HasInlineBody is the source of truth.
+        Assert.AreEqual("", MakeRow("C:\\v\\a.md", ArtifactKind.Markdown, body: null).Body);
+    }
+
+    [TestMethod]
+    public void HasLoadError_ReflectsLoadError()
+    {
+        Assert.IsTrue(MakeRow("C:\\v\\a.txt", ArtifactKind.Text, body: null, loadError: "boom").HasLoadError);
+        Assert.IsFalse(MakeRow("C:\\v\\a.txt", ArtifactKind.Text, body: "x").HasLoadError);
+    }
+
+    [TestMethod]
+    public void ShouldRenderInlineMarkdown_RequiresMarkdownKind_Body_AndNoError()
+    {
+        Assert.IsTrue(MakeRow("C:\\v\\a.md", ArtifactKind.Markdown, body: "x").ShouldRenderInlineMarkdown);
+        Assert.IsFalse(MakeRow("C:\\v\\a.md", ArtifactKind.Markdown, body: null).ShouldRenderInlineMarkdown);
+        Assert.IsFalse(MakeRow("C:\\v\\a.md", ArtifactKind.Markdown, body: "x", loadError: "e").ShouldRenderInlineMarkdown);
+        Assert.IsFalse(MakeRow("C:\\v\\a.txt", ArtifactKind.Text, body: "x").ShouldRenderInlineMarkdown);
+    }
+
+    [TestMethod]
+    public void ShouldRenderInlineText_RequiresTextKind_Body_AndNoError()
+    {
+        Assert.IsTrue(MakeRow("C:\\v\\a.txt", ArtifactKind.Text, body: "x").ShouldRenderInlineText);
+        Assert.IsFalse(MakeRow("C:\\v\\a.txt", ArtifactKind.Text, body: null).ShouldRenderInlineText);
+        Assert.IsFalse(MakeRow("C:\\v\\a.txt", ArtifactKind.Text, body: "x", loadError: "e").ShouldRenderInlineText);
+        Assert.IsFalse(MakeRow("C:\\v\\a.md", ArtifactKind.Markdown, body: "x").ShouldRenderInlineText);
+    }
+
+    [TestMethod]
+    public void ShowOpenInObsidian_OnlyForMarkdown()
+    {
+        Assert.IsTrue(MakeRow("C:\\v\\a.md", ArtifactKind.Markdown, body: "x").ShowOpenInObsidian);
+        Assert.IsTrue(MakeRow("C:\\v\\big.md", ArtifactKind.Markdown, body: null).ShowOpenInObsidian);
+        Assert.IsFalse(MakeRow("C:\\v\\a.html", ArtifactKind.Html, body: null).ShowOpenInObsidian);
+        Assert.IsFalse(MakeRow("C:\\v\\a.png", ArtifactKind.Image, body: null).ShowOpenInObsidian);
+        Assert.IsFalse(MakeRow("C:\\v\\a.txt", ArtifactKind.Text, body: "x").ShowOpenInObsidian);
+    }
+
+    [TestMethod]
+    public void IsSvg_OnlyForSvgImage()
+    {
+        Assert.IsTrue(MakeRow("C:\\v\\a.svg", ArtifactKind.Image, body: null).IsSvg);
+        Assert.IsTrue(MakeRow("C:\\v\\A.SVG", ArtifactKind.Image, body: null).IsSvg);
+        Assert.IsFalse(MakeRow("C:\\v\\a.png", ArtifactKind.Image, body: null).IsSvg);
+        Assert.IsFalse(MakeRow("C:\\v\\a.svg", ArtifactKind.Other, body: null).IsSvg);
+    }
+
+    [TestMethod]
+    public void LaunchGating_DeniesExecutableExtensions()
+    {
+        var denied = MakeRow("C:\\v\\run.ps1", ArtifactKind.Text, body: "x");
+        Assert.IsTrue(denied.IsLaunchDenied);
+        Assert.IsFalse(denied.CanLaunchExternally);
+
+        var allowed = MakeRow("C:\\v\\data.json", ArtifactKind.Text, body: "x");
+        Assert.IsFalse(allowed.IsLaunchDenied);
+        Assert.IsTrue(allowed.CanLaunchExternally);
+    }
+
+    [TestMethod]
+    public void IsReference_TrueForOther_LoadError_OverCapImage_AndBodylessTextOrMarkdown()
+    {
+        Assert.IsTrue(MakeRow("C:\\v\\a.bin", ArtifactKind.Other, body: null).IsReference, "Other");
+        Assert.IsTrue(MakeRow("C:\\v\\a.txt", ArtifactKind.Text, body: null, loadError: "e").IsReference, "load error");
+        Assert.IsTrue(MakeRow("C:\\v\\big.md", ArtifactKind.Markdown, body: null).IsReference, "over-cap markdown (null body)");
+        Assert.IsTrue(MakeRow("C:\\v\\big.txt", ArtifactKind.Text, body: null).IsReference, "over-cap text (null body)");
+        Assert.IsTrue(MakeRow("C:\\v\\huge.png", ArtifactKind.Image, body: null, sizeBytes: ArtifactCaps.InlineImageBytes + 1).IsReference, "over-cap image");
+    }
+
+    [TestMethod]
+    public void IsReference_FalseForRenderableKinds()
+    {
+        Assert.IsFalse(MakeRow("C:\\v\\a.md", ArtifactKind.Markdown, body: "x").IsReference, "inline markdown");
+        Assert.IsFalse(MakeRow("C:\\v\\a.txt", ArtifactKind.Text, body: "x").IsReference, "inline text");
+        Assert.IsFalse(MakeRow("C:\\v\\a.png", ArtifactKind.Image, body: null, sizeBytes: 4096).IsReference, "under-cap image (null body is expected)");
+        Assert.IsFalse(MakeRow("C:\\v\\a.html", ArtifactKind.Html, body: null).IsReference, "html renders via source");
+    }
+
+    [TestMethod]
+    public void SizeDisplay_FormatsHumanReadable()
+    {
+        Assert.AreEqual("0 B", MakeRow("C:\\v\\a.bin", ArtifactKind.Other, body: null, sizeBytes: 0).SizeDisplay);
+        Assert.AreEqual("512 B", MakeRow("C:\\v\\a.bin", ArtifactKind.Other, body: null, sizeBytes: 512).SizeDisplay);
+        Assert.AreEqual("1.0 KB", MakeRow("C:\\v\\a.bin", ArtifactKind.Other, body: null, sizeBytes: 1024).SizeDisplay);
+        Assert.AreEqual("12.3 KB", MakeRow("C:\\v\\a.bin", ArtifactKind.Other, body: null, sizeBytes: 12595).SizeDisplay);
+        Assert.AreEqual("1.5 MB", MakeRow("C:\\v\\a.bin", ArtifactKind.Other, body: null, sizeBytes: 1572864).SizeDisplay);
+        Assert.AreEqual("2.0 GB", MakeRow("C:\\v\\a.bin", ArtifactKind.Other, body: null, sizeBytes: 2L * 1024 * 1024 * 1024).SizeDisplay);
     }
 }

--- a/tools/Glasswork.VisualVerification/Program.cs
+++ b/tools/Glasswork.VisualVerification/Program.cs
@@ -87,6 +87,7 @@ internal static partial class VisualVerificationRunner
         try
         {
             var hwnd = WaitForWindow(process, TimeSpan.FromSeconds(scenario.LaunchTimeoutSeconds));
+            ResizeWindowTall(hwnd);
             await Task.Delay(scenario.InitialWaitMilliseconds);
 
             foreach (var action in scenario.Actions)
@@ -150,10 +151,23 @@ internal static partial class VisualVerificationRunner
                 if (string.IsNullOrWhiteSpace(artifact.Name))
                     throw new FormatException($"Artifact on task '{task.Id}' requires a non-empty name.");
 
-                var fileName = artifact.Name.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
+                // Use the name verbatim so scenarios can seed any extension
+                // (.md/.html/.txt/.svg/.png/...). Names with no extension default
+                // to .md to preserve the original markdown-only behavior.
+                var fileName = Path.HasExtension(artifact.Name)
                     ? artifact.Name
                     : artifact.Name + ".md";
-                File.WriteAllText(Path.Combine(artifactsDir, SanitizeFileName(fileName)), artifact.Markdown);
+                var fullPath = Path.Combine(artifactsDir, SanitizeFileName(fileName));
+
+                if (!string.IsNullOrEmpty(artifact.Base64))
+                {
+                    File.WriteAllBytes(fullPath, Convert.FromBase64String(artifact.Base64));
+                }
+                else
+                {
+                    var text = artifact.Content ?? artifact.Markdown;
+                    File.WriteAllText(fullPath, text);
+                }
             }
         }
     }
@@ -211,6 +225,12 @@ internal static partial class VisualVerificationRunner
                 return;
             case "select":
                 SelectElement(WaitForElement(hwnd, action));
+                return;
+            case "expand":
+                ExpandElement(WaitForElement(hwnd, action));
+                return;
+            case "delay":
+                System.Threading.Thread.Sleep(Math.Max(0, action.TimeoutMilliseconds));
                 return;
             default:
                 throw new FormatException($"Unsupported visual verification action type '{action.Type}'.");
@@ -382,20 +402,87 @@ internal static partial class VisualVerificationRunner
 
     private static AutomationElement? FindElement(AutomationElement root, VisualVerificationAction action)
     {
-        if (!string.IsNullOrWhiteSpace(action.AutomationId))
+        var hasAutomationId = !string.IsNullOrWhiteSpace(action.AutomationId);
+        var hasName = !string.IsNullOrWhiteSpace(action.Name);
+        if (!hasAutomationId && !hasName)
+            throw new FormatException("UI action requires automationId or name.");
+
+        if (hasAutomationId)
         {
             var condition = new PropertyCondition(AutomationElement.AutomationIdProperty, action.AutomationId);
             var match = root.FindFirst(TreeScope.Descendants, condition);
             if (match is not null) return match;
         }
 
-        if (!string.IsNullOrWhiteSpace(action.Name))
+        if (hasName)
         {
             var condition = new PropertyCondition(AutomationElement.NameProperty, action.Name);
-            return root.FindFirst(TreeScope.Descendants, condition);
+            var match = root.FindFirst(TreeScope.Descendants, condition);
+            if (match is not null) return match;
         }
 
-        throw new FormatException("UI action requires automationId or name.");
+        // FindFirst(Descendants) does a synchronous cross-process descendant walk
+        // that can stall on (and fail to traverse past) a live out-of-process
+        // WebView2 subtree (#324). Fall back to a manual sibling-by-sibling
+        // ControlView traversal, which reliably steps over such nodes.
+        return ManualFind(root, action);
+    }
+
+    private static AutomationElement? ManualFind(AutomationElement root, VisualVerificationAction action)
+    {
+        const int maxDepth = 40;
+        var walker = TreeWalker.ControlViewWalker;
+
+        bool Matches(AutomationElement element)
+        {
+            if (!string.IsNullOrWhiteSpace(action.AutomationId)
+                && string.Equals(TryGet(() => element.Current.AutomationId), action.AutomationId, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrWhiteSpace(action.Name)
+                && string.Equals(TryGet(() => element.Current.Name), action.Name, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        AutomationElement? Search(AutomationElement element, int depth)
+        {
+            if (depth > maxDepth)
+            {
+                return null;
+            }
+
+            if (Matches(element))
+            {
+                return element;
+            }
+
+            AutomationElement? child;
+            try { child = walker.GetFirstChild(element); }
+            catch { return null; }
+
+            while (child is not null)
+            {
+                var found = Search(child, depth + 1);
+                if (found is not null)
+                {
+                    return found;
+                }
+
+                try { child = walker.GetNextSibling(child); }
+                catch { break; }
+            }
+
+            return null;
+        }
+
+        try { return Search(root, 0); }
+        catch { return null; }
     }
 
     private static void InvokeElement(AutomationElement element)
@@ -434,6 +521,19 @@ internal static partial class VisualVerificationRunner
         InvokeElement(element);
     }
 
+    private static void ExpandElement(AutomationElement element)
+    {
+        if (element.TryGetCurrentPattern(ExpandCollapsePattern.Pattern, out var pattern) &&
+            pattern is ExpandCollapsePattern expand)
+        {
+            if (expand.Current.ExpandCollapseState != ExpandCollapseState.Expanded)
+                expand.Expand();
+            return;
+        }
+
+        throw new InvalidOperationException($"Element '{element.Current.Name}' does not support ExpandCollapsePattern.");
+    }
+
     private static async Task RunProcessAsync(string fileName, string arguments, string workingDirectory)
     {
         var psi = new ProcessStartInfo(fileName, arguments)
@@ -465,8 +565,18 @@ internal static partial class VisualVerificationRunner
             throw new InvalidOperationException("Window has zero size.");
 
         using var bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
-        using (var graphics = Graphics.FromImage(bitmap))
+
+        // PrintWindow (even with PW_RENDERFULLCONTENT) cannot rasterize this app's
+        // WinUI 3 client content: it is hosted in a DesktopChildSiteBridge
+        // DirectComposition surface that PrintWindow leaves blank, yielding only the
+        // non-client caption chrome. Prefer a screen-region BitBlt of the foregrounded
+        // window, which captures the already-composited desktop (real WinUI pixels)
+        // when the session is interactive and the window is unobscured. Fall back to
+        // PrintWindow if the screen grab is unavailable or uniform (e.g. locked or
+        // non-interactive session, or the window is occluded).
+        if (!TryCaptureFromScreen(hwnd, rect, width, height, bitmap))
         {
+            using var graphics = Graphics.FromImage(bitmap);
             var hdc = graphics.GetHdc();
             try
             {
@@ -480,6 +590,85 @@ internal static partial class VisualVerificationRunner
         }
 
         bitmap.Save(path, ImageFormat.Png);
+    }
+
+    private static bool TryCaptureFromScreen(IntPtr hwnd, Rect rect, int width, int height, Bitmap bitmap)
+    {
+        try
+        {
+            ForegroundWindowBestEffort(hwnd);
+            // Allow the compositor to settle and any foreground/restore animation to finish.
+            Thread.Sleep(600);
+
+            using (var graphics = Graphics.FromImage(bitmap))
+            {
+                graphics.CopyFromScreen(rect.Left, rect.Top, 0, 0, new Size(width, height), CopyPixelOperation.SourceCopy);
+            }
+
+            return !IsUniformBitmap(bitmap);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool IsUniformBitmap(Bitmap bitmap)
+    {
+        var colors = new HashSet<int>();
+        var stepX = Math.Max(1, bitmap.Width / 80);
+        var stepY = Math.Max(1, bitmap.Height / 80);
+        for (var y = 0; y < bitmap.Height; y += stepY)
+        {
+            for (var x = 0; x < bitmap.Width; x += stepX)
+            {
+                colors.Add(bitmap.GetPixel(x, y).ToArgb());
+                if (colors.Count > 1)
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void ResizeWindowTall(IntPtr hwnd)
+    {
+        // Long pages (e.g. a task with an Artifacts section near the bottom) lay
+        // their lower content out below the page ScrollViewer's viewport, where it
+        // is scroll-clipped and never gets a UI Automation peer. Growing the window
+        // so the whole page fits without scrolling brings that content into the
+        // live visual tree so both the UIA walk and screen capture can see it.
+        try
+        {
+            if (IsIconic(hwnd))
+                ShowWindow(hwnd, ShowWindowRestore);
+
+            SetWindowPos(hwnd, IntPtr.Zero, 0, 0, 1500, 2400, SwpShowWindow);
+        }
+        catch
+        {
+            // Best-effort: verification still works at the default size for short pages.
+        }
+    }
+
+    private static void ForegroundWindowBestEffort(IntPtr hwnd)
+    {
+        try
+        {
+            if (IsIconic(hwnd))
+                ShowWindow(hwnd, ShowWindowRestore);
+
+            // Topmost flip is the most reliable way to surface a window without
+            // requiring foreground-activation rights, then drop back to non-topmost.
+            SetWindowPos(hwnd, HwndTopmost, 0, 0, 0, 0, SwpNoMove | SwpNoSize | SwpShowWindow);
+            SetWindowPos(hwnd, HwndNoTopmost, 0, 0, 0, 0, SwpNoMove | SwpNoSize | SwpShowWindow);
+            BringWindowToTop(hwnd);
+            SetForegroundWindow(hwnd);
+        }
+        catch
+        {
+            // Best-effort only; screen capture falls back to PrintWindow if this fails.
+        }
     }
 
     private static ImageStats AnalyzeImage(string path)
@@ -516,6 +705,26 @@ internal static partial class VisualVerificationRunner
 
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool BringWindowToTop(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsIconic(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool GetWindowRect(IntPtr hWnd, out Rect lpRect);
 
     [DllImport("dwmapi.dll")]
@@ -533,6 +742,13 @@ internal static partial class VisualVerificationRunner
 
     private const uint PrintWindowRenderFullContent = 2;
     private const int DwmWindowAttributeExtendedFrameBounds = 9;
+
+    private const int ShowWindowRestore = 9;
+    private static readonly IntPtr HwndTopmost = new(-1);
+    private static readonly IntPtr HwndNoTopmost = new(-2);
+    private const uint SwpNoSize = 0x0001;
+    private const uint SwpNoMove = 0x0002;
+    private const uint SwpShowWindow = 0x0040;
 
     [StructLayout(LayoutKind.Sequential)]
     private struct Rect


### PR DESCRIPTION
Implements multi-format artifact rendering in the App layer for **#323** (per-kind row templates, no WebView2) and **#324** (sandboxed WebView2 HTML preview). Core/MCP groundwork was already on main. Read-only rendering per **ADR 0015**.

Closes #323
Closes #324

## What each kind renders
- **Markdown** -> `VaultMarkdownView` (single sanctioned renderer, LinkClicked wiring preserved). Open-in-Obsidian shown for Markdown rows only.
- **Text** -> inert selectable Consolas `ScrollViewer` (capped, no markdown/auto-link).
- **Image** -> `BitmapImage` with decode caps; `.svg` via `SvgImageSource` (`SetSourceAsync`) + **View source** toggle. Over byte/pixel cap -> reference card.
- **Other / over-cap / load-error** -> reference card: filename + size + **Open externally** + **Show in folder** (Open externally hidden for `ExecutableDenyList` extensions).
- **Html** -> **Source** (default, async capped read) / **Preview** / **Open in browser**.

## #324 — sandboxed preview
Single app-wide WebView2 (`App.HtmlPreview`). Activating a second preview tears down the first host (row shows *"Preview closed — another preview is active"* + Re-activate). Before navigating: script, host objects, web message, default dialogs and devtools all disabled; `NavigationStarting` / `NewWindowRequested` / `PermissionRequested` / `WebResourceRequested` (filter `*`) cancelled after the initial `NavigateToString`. Missing runtime -> Source + Open-in-browser fallback. Preview invalidated (not auto-reactivated) on watcher refresh. Row expand state preserved across refreshes by Path.

## Architecture
One outer `Expander` DataTemplate with a common header + a `ContentControl` whose `ArtifactBodyTemplateSelector` swaps the body by `ArtifactRow.Kind` (header stays DRY). Per-kind body templates in `Page.Resources`. `ArtifactRow` exposes explicit computed flags (`ShouldRenderInlineMarkdown/Text`, `HasInlineBody`, `ShowOpenInObsidian`, `IsSvg`, launch/reference flags) with **no WinUI dependency**. Honors **HARD RULE 6** (no init-time sibling named-element deref).

## Tests & verification
- Core: **865 passing** (11 new `ArtifactRowTests` for the flags + size formatting).
- App build clean (0 warnings / 0 errors), `-c Debug /p:Platform=x64`.
- **HARD RULE 7 visual verification**: extended the VV runner (`MaterializeVault` arbitrary extension + base64 binary seeding; `ResizeWindowTall`; manual UIA descendant fallback). Scenarios added: `artifacts-markdown`, `-text`, `-image`, `-svg`, `-svg-source`, `-reference`, `-html-source`, `-html-preview`, `-html-hostile`, `-html-teardown`. Every kind verified to render (no blank/uniform screen, no `STOWED_EXCEPTION`). HTML preview activation, hostile-content blocking (external `img`/CSS `url()` blocked, `meta refresh` cancelled, script off), and second-preview eviction all verified.

### Verification notes
- This is a headless env: full-screen capture is blank (caption chrome only); the **UIA tree** (`inspect-app.ps1`) is the authoritative oracle.
- **WebView2 is out-of-process**, so its content is invisible to both the UIA tree and screen capture — preview activation + sandbox behavior were verified via focused diagnostic logging during development (since removed). The WebView2 Evergreen runtime is installed, so `EnsureCoreWebView2Async` genuinely succeeds.