### PR TITLE
Harden file-watcher: rehydrate index on overflow to clear stale due chips

### DIFF
--- a/scripts/visual-verification/backlog-due-chips.json
+++ b/scripts/visual-verification/backlog-due-chips.json
@@ -1,0 +1,69 @@
+{
+  // Option B hardening — rule 7 visual verification for the App wiring
+  // (Watcher.Overflowed -> Index.Rehydrate). The watcher-overflow trigger
+  // itself is load/timing-dependent and cannot be fired deterministically from
+  // the scenario harness (there is no out-of-band mid-run write action), so the
+  // Overflowed -> Rehydrate -> delta logic is proven by the deterministic Core
+  // tests (IndexRehydrateTests, FileWatcherServiceTests). What this scenario
+  // verifies is the part rule 7 actually guards: with the new App wiring in
+  // place the app still launches without a startup crash (no STOWED_EXCEPTION),
+  // and the due-chip surface at the heart of the overdue-flag bug renders
+  // correctly — a future due date must NOT show as overdue.
+  "name": "Backlog due chips",
+  "startUri": "glasswork://backlog",
+  "tasks": [
+    {
+      "id": "due-overdue",
+      "title": "Overdue task should show overdue chip",
+      "description": "Due yesterday — must render with the overdue (past) due chip.",
+      "status": "todo",
+      "priority": "high",
+      "due": "yesterday"
+    },
+    {
+      "id": "due-today",
+      "title": "Today task should show today chip",
+      "description": "Due today — must render with the today due chip.",
+      "status": "todo",
+      "priority": "medium",
+      "due": "today"
+    },
+    {
+      "id": "due-future",
+      "title": "Future task must not show overdue",
+      "description": "Newer-schema repro: a future due date (~2 weeks out) must render as Future, never overdue.",
+      "status": "in-progress",
+      "priority": "medium",
+      "due": "2026-07-11",
+      "myDay": "yesterday"
+    }
+  ],
+  "actions": [
+    {
+      "type": "select",
+      "automationId": "NavBacklog",
+      "timeoutMilliseconds": 10000
+    },
+    {
+      "type": "wait-for",
+      "automationId": "BacklogHeader",
+      "timeoutMilliseconds": 10000
+    },
+    {
+      "type": "wait-for",
+      "name": "Future task must not show overdue",
+      "timeoutMilliseconds": 10000
+    },
+    {
+      "type": "wait-for",
+      "name": "Overdue task should show overdue chip",
+      "timeoutMilliseconds": 10000
+    }
+  ],
+  "captures": [
+    {
+      "name": "backlog-due-chips",
+      "waitMilliseconds": 500
+    }
+  ]
+}

--- a/src/Glasswork.App/App.xaml.cs
+++ b/src/Glasswork.App/App.xaml.cs
@@ -50,6 +50,16 @@ public partial class App : Application
     // flight; debouncing lets the disk settle before we re-read the whole vault.
     private static Glasswork.Core.Services.Debouncer? _overflowRehydrateDebouncer;
 
+    // Finding B (bounded convergence): a rehydrate can legitimately leave an entry
+    // unreconciled — it skipped a value that a concurrent write was mid-applying, or
+    // kept a present-but-unparseable (mid-write) file. Normally the next per-file
+    // watcher event converges it, but in the exact overflow scenario this recovery
+    // exists for, that triggering event may ALSO have been dropped. So when Index
+    // raises ConvergencePending, schedule exactly ONE bounded follow-up rehydrate per
+    // overflow episode — never an unbounded loop on a permanently-corrupt file.
+    private static Glasswork.Core.Services.Debouncer? _convergenceRehydrateDebouncer;
+    private static int _convergenceFollowUpsRemaining;
+
     /// <summary>
     /// Single app-wide owner of the live HTML-preview WebView2 (#324).
     /// UI-thread only; constructed eagerly since it holds no startup state.
@@ -388,7 +398,34 @@ public partial class App : Application
                 try { Index.Rehydrate(); }
                 catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Index.Rehydrate after watcher overflow failed: {ex.Message}"); }
             });
-        Watcher.Overflowed += (_, _) => _overflowRehydrateDebouncer.Trigger();
+
+        // The single bounded follow-up pass. Debounced on its own timer so the
+        // repaired/quiesced disk has settled before the second read. Each overflow
+        // episode arms exactly one of these (see _convergenceFollowUpsRemaining).
+        _convergenceRehydrateDebouncer = new Glasswork.Core.Services.Debouncer(
+            TimeSpan.FromMilliseconds(500),
+            () =>
+            {
+                try { Index.Rehydrate(); }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Index.Rehydrate convergence follow-up failed: {ex.Message}"); }
+            });
+
+        // An overflow opens a fresh convergence budget: arm one follow-up, then
+        // kick the primary rehydrate.
+        Watcher.Overflowed += (_, _) =>
+        {
+            System.Threading.Interlocked.Exchange(ref _convergenceFollowUpsRemaining, 1);
+            _overflowRehydrateDebouncer!.Trigger();
+        };
+
+        // A rehydrate that couldn't fully reconcile asks for a follow-up. Spend the
+        // single budgeted pass if one is available; otherwise ignore (bounded — a
+        // permanently-corrupt file can't spin us forever).
+        Index.ConvergencePending += (_, _) =>
+        {
+            if (System.Threading.Interlocked.Exchange(ref _convergenceFollowUpsRemaining, 0) > 0)
+                _convergenceRehydrateDebouncer!.Trigger();
+        };
         Watcher.Start();
 
         ArtifactsWatcher = new ArtifactWatcherService(vaultPath);

--- a/src/Glasswork.App/App.xaml.cs
+++ b/src/Glasswork.App/App.xaml.cs
@@ -369,6 +369,16 @@ public partial class App : Application
             try { Index.OnFileChangedOnDisk(change); }
             catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Index.OnFileChangedOnDisk failed: {ex.Message}"); }
         };
+        // When the OS change buffer overflows during a bulk burst of writes (e.g.
+        // an ADO sprint import), the watcher silently drops the queued per-file
+        // events and those tasks' snapshots go stale until restart. Recover by
+        // re-reading the whole vault from disk and emitting deltas for whatever
+        // drifted, so chips converge to the on-disk Due/urgency instead of sticking.
+        Watcher.Overflowed += (_, _) =>
+        {
+            try { Index.Rehydrate(); }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Index.Rehydrate after watcher overflow failed: {ex.Message}"); }
+        };
         Watcher.Start();
 
         ArtifactsWatcher = new ArtifactWatcherService(vaultPath);

--- a/src/Glasswork.App/App.xaml.cs
+++ b/src/Glasswork.App/App.xaml.cs
@@ -45,6 +45,11 @@ public partial class App : Application
     public static AzCliAdoWorkItemFetcher AdoFetcher { get; } = new();
     public static Glasswork.Core.AppUpdate.UpdateCheckService Updater { get; private set; } = null!;
 
+    // Coalesces a burst of watcher-overflow events into a single full rehydrate.
+    // An OS buffer overflow can fire repeatedly while a bulk write is still in
+    // flight; debouncing lets the disk settle before we re-read the whole vault.
+    private static Glasswork.Core.Services.Debouncer? _overflowRehydrateDebouncer;
+
     /// <summary>
     /// Single app-wide owner of the live HTML-preview WebView2 (#324).
     /// UI-thread only; constructed eagerly since it holds no startup state.
@@ -374,11 +379,16 @@ public partial class App : Application
         // events and those tasks' snapshots go stale until restart. Recover by
         // re-reading the whole vault from disk and emitting deltas for whatever
         // drifted, so chips converge to the on-disk Due/urgency instead of sticking.
-        Watcher.Overflowed += (_, _) =>
-        {
-            try { Index.Rehydrate(); }
-            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Index.Rehydrate after watcher overflow failed: {ex.Message}"); }
-        };
+        // Debounced so a storm of overflow signals collapses into one rehydrate
+        // once the write burst has quieted.
+        _overflowRehydrateDebouncer = new Glasswork.Core.Services.Debouncer(
+            TimeSpan.FromMilliseconds(500),
+            () =>
+            {
+                try { Index.Rehydrate(); }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Index.Rehydrate after watcher overflow failed: {ex.Message}"); }
+            });
+        Watcher.Overflowed += (_, _) => _overflowRehydrateDebouncer.Trigger();
         Watcher.Start();
 
         ArtifactsWatcher = new ArtifactWatcherService(vaultPath);

--- a/src/Glasswork.Core/Services/FileWatcherService.cs
+++ b/src/Glasswork.Core/Services/FileWatcherService.cs
@@ -29,6 +29,20 @@ public class FileWatcherService : IDisposable
     /// </summary>
     public event EventHandler<TaskFileChange>? TaskFileChange;
 
+    /// <summary>
+    /// Raised when the underlying <see cref="FileSystemWatcher"/> reports an
+    /// error — most importantly an <b>internal buffer overflow</b>. When the OS
+    /// change buffer overflows during a bulk burst of writes (e.g. an ADO sprint
+    /// import writing many <c>*.md</c> files at once) the watcher silently drops
+    /// the queued change events, so the per-file <see cref="TaskFileChange"/>
+    /// path misses them and in-memory snapshots go stale until restart.
+    /// Subscribers should respond with a full resync
+    /// (<see cref="IndexService.Rehydrate"/>). Carries no per-file detail — by
+    /// the time an overflow fires, the specific dropped events are already gone,
+    /// so the only safe recovery is to re-read everything from disk.
+    /// </summary>
+    public event EventHandler? Overflowed;
+
     public FileWatcherService(string vaultPath) : this(vaultPath, null) { }
 
     public FileWatcherService(string vaultPath, SelfWriteCoordinator? selfWrites)
@@ -42,13 +56,18 @@ public class FileWatcherService : IDisposable
         _watcher = new FileSystemWatcher(vaultPath, "*.md")
         {
             NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.CreationTime,
-            IncludeSubdirectories = false
+            IncludeSubdirectories = false,
+            // Default is 8 KB — enough headroom for a handful of edits but easily
+            // overrun by a bulk import. 64 KB (the documented practical max for
+            // reliable delivery) sharply reduces the odds of a dropped burst.
+            InternalBufferSize = 64 * 1024,
         };
 
         _watcher.Changed += (s, e) => RaiseEvent(TaskFileChangeKind.CreatedOrChanged, oldPath: null, e.FullPath);
         _watcher.Created += (s, e) => RaiseEvent(TaskFileChangeKind.CreatedOrChanged, oldPath: null, e.FullPath);
         _watcher.Deleted += (s, e) => RaiseEvent(TaskFileChangeKind.Deleted, oldPath: null, e.FullPath);
         _watcher.Renamed += (s, e) => RaiseEvent(TaskFileChangeKind.Renamed, e.OldFullPath, e.FullPath);
+        _watcher.Error += (s, e) => HandleWatcherError(e.GetException());
     }
 
     public void Start() => _watcher.EnableRaisingEvents = true;
@@ -83,6 +102,29 @@ public class FileWatcherService : IDisposable
 
         if (!isOwn)
             TaskFileChange?.Invoke(this, new TaskFileChange(kind, oldFileName, newFileName));
+    }
+
+    /// <summary>
+    /// Handle a <see cref="FileSystemWatcher.Error"/> report by surfacing
+    /// <see cref="Overflowed"/>. Exposed as <c>internal</c> so unit tests can
+    /// drive it directly — a real <c>InternalBufferOverflowException</c> is
+    /// load/timing-dependent and cannot be triggered deterministically in a
+    /// test, but the recovery contract (error ⇒ Overflowed ⇒ rehydrate) can be.
+    /// Subscriber exceptions are swallowed so one bad handler can't tear down
+    /// the watcher's error callback.
+    /// </summary>
+    internal void HandleWatcherError(Exception? exception)
+    {
+        System.Diagnostics.Debug.WriteLine(
+            $"FileWatcherService: watcher error (likely buffer overflow), requesting rehydrate: {exception?.Message}");
+        try
+        {
+            Overflowed?.Invoke(this, EventArgs.Empty);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"FileWatcherService.Overflowed subscriber threw: {ex}");
+        }
     }
 
     public void Dispose()

--- a/src/Glasswork.Core/Services/IndexService.cs
+++ b/src/Glasswork.Core/Services/IndexService.cs
@@ -53,6 +53,37 @@ public class IndexService
     private readonly FrontmatterParser _serializer = new();
 
     /// <summary>
+    /// Monotonic store-mutation sequence and the per-id version it stamps. Every
+    /// <c>_store</c> insert / update / remove bumps <see cref="_versionSeq"/> under
+    /// <see cref="_gate"/> and records the new value as the touched id's version.
+    /// <see cref="Rehydrate"/> captures <see cref="_versionSeq"/> <b>before</b> its
+    /// unlocked disk read and, at apply time, skips any entry whose per-id version
+    /// advanced past that capture — a concurrent per-file write moved it under us, so
+    /// replaying the older parse would re-stale the newer store value. A counter is
+    /// immune to filesystem mtime resolution / coalescing and, because it is read
+    /// strictly before the content, to a write that lands <i>during</i> the read
+    /// (the ordering flaw that a post-read mtime sample cannot detect).
+    /// </summary>
+    private long _versionSeq;
+    private readonly Dictionary<string, long> _versions = new(StringComparer.Ordinal);
+
+    /// <summary>Stamp the id with a fresh version. MUST be called under <see cref="_gate"/>.</summary>
+    private void BumpVersion(string id) => _versions[id] = ++_versionSeq;
+
+    /// <summary>Forget an id's version on removal. MUST be called under <see cref="_gate"/>.</summary>
+    private void DropVersion(string id) => _versions.Remove(id);
+
+    /// <summary>
+    /// Snapshot returned by the <see cref="ReadDiskSnapshot"/> seam: every task
+    /// parsed from disk, paired with the store-version sequence captured
+    /// <b>immediately before</b> the content read began. <see cref="Rehydrate"/>
+    /// compares each task's per-id version against <see cref="ReadStartSeq"/> to
+    /// detect a per-file write that landed during the read. Public only so the test
+    /// seam subclass (another assembly) can construct and return it.
+    /// </summary>
+    public readonly record struct DiskSnapshot(IReadOnlyList<GlassworkTask> Tasks, long ReadStartSeq);
+
+    /// <summary>
     /// Raised after the in-memory store has been mutated by a vault event or
     /// a watcher-observed file change. Carries old+new snapshots so filtered
     /// views can detect removal-from-set. Subscribers may throw — exceptions
@@ -69,6 +100,21 @@ public class IndexService
     /// subscribers are caught and logged.
     /// </summary>
     public event EventHandler<TasksChanged>? Changed;
+
+    /// <summary>
+    /// Raised once at the end of a <see cref="Rehydrate"/> pass that could not fully
+    /// reconcile in a single shot — it skipped an entry whose source file was
+    /// concurrently rewritten, or kept a present-but-unparseable file. In the
+    /// watcher-overflow scenario <see cref="Rehydrate"/> exists for, the per-file
+    /// event that would otherwise converge that entry may itself have been dropped by
+    /// the same overflow, so the store cannot be assumed to already hold the newer
+    /// value and — once writes quiesce — no further overflow will fire. The app
+    /// subscribes and re-arms a single <b>bounded</b>, debounced follow-up
+    /// <see cref="Rehydrate"/> so eventual convergence does not depend on another
+    /// overflow event. Raised after the lock is released and after the data deltas;
+    /// subscriber exceptions are caught and logged.
+    /// </summary>
+    public event EventHandler? ConvergencePending;
 
     public IndexService(VaultService vault)
     {
@@ -166,10 +212,14 @@ public class IndexService
         {
             if (_loaded) return;
             _store.Clear();
+            _versions.Clear();
             foreach (var t in _vault.LoadAll())
             {
                 if (!string.IsNullOrEmpty(t.Id))
+                {
                     _store[t.Id] = t;
+                    BumpVersion(t.Id);
+                }
             }
             _loaded = true;
         }
@@ -204,19 +254,22 @@ public class IndexService
     /// </summary>
     public void Rehydrate()
     {
-        // Read disk OUTSIDE the lock — LoadAll does file IO + parsing. Each entry
-        // carries the source file's last-write time captured at read, so the apply
-        // phase can detect (and skip) any entry whose file changed under us between
-        // this unlocked read and taking the lock.
-        var fresh = ReadDiskSnapshot();
-        var freshById = new Dictionary<string, (GlassworkTask Task, DateTime ReadMtimeUtc)>(StringComparer.Ordinal);
-        foreach (var entry in fresh)
+        // Capture the store-version sequence BEFORE the unlocked disk read begins,
+        // then read disk OUTSIDE the lock (LoadAll does file IO + parsing). Any
+        // per-file store mutation that lands during the read bumps a per-id version
+        // past this captured baseline, so the apply phase can detect (and skip) it.
+        // The counter is sampled strictly before the content — unlike a post-read
+        // mtime sample, it cannot miss a write that occurs DURING the read.
+        var snapshot = ReadDiskSnapshot();
+        var freshById = new Dictionary<string, GlassworkTask>(StringComparer.Ordinal);
+        foreach (var t in snapshot.Tasks)
         {
-            if (!string.IsNullOrEmpty(entry.Task.Id))
-                freshById[entry.Task.Id] = entry;
+            if (!string.IsNullOrEmpty(t.Id))
+                freshById[t.Id] = t;
         }
 
         var changes = new List<TaskChange>();
+        bool convergencePending = false;
         lock (_gate)
         {
             // Removed: present in the store, absent from the fresh snapshot — but
@@ -230,35 +283,51 @@ public class IndexService
             foreach (var kv in _store)
             {
                 if (freshById.ContainsKey(kv.Key)) continue;
-                if (File.Exists(Path.Combine(_vault.VaultPath, kv.Key + ".md"))) continue;
+                if (File.Exists(Path.Combine(_vault.VaultPath, kv.Key + ".md")))
+                {
+                    // Present on disk but missing from the snapshot => it was
+                    // unparseable / mid-write when LoadAll ran, or written after the
+                    // snapshot. Keep the prior value and request a bounded follow-up
+                    // so a final write whose event was also dropped still converges.
+                    convergencePending = true;
+                    continue;
+                }
                 changes.Add(new TaskChange(kv.Value.Clone(), null));
                 removedIds.Add(kv.Key);
             }
             foreach (var id in removedIds)
+            {
                 _store.Remove(id);
+                DropVersion(id);
+            }
 
-            // Added or content-changed — but skip any entry whose source file
-            // changed on disk since the unlocked read. A newer per-file update may
-            // have landed in the store while we were reading; replaying our older
-            // snapshot would re-stale it. The store already holds the newer value;
-            // the next watcher event / rehydrate converges anything genuinely missed.
+            // Added or content-changed — but skip any entry whose per-id version
+            // advanced past the sequence captured before the read. A newer per-file
+            // update landed in the store while we were reading; replaying our older
+            // parse would re-stale it. Per-id compare (not the global current seq) so
+            // Rehydrate's own bumps on OTHER ids this pass don't self-interfere.
             foreach (var kv in freshById)
             {
                 var id = kv.Key;
-                var task = kv.Value.Task;
+                var task = kv.Value;
 
-                if (CurrentMtimeUtc(id) != kv.Value.ReadMtimeUtc)
+                if (_versions.TryGetValue(id, out var ver) && ver > snapshot.ReadStartSeq)
+                {
+                    convergencePending = true;
                     continue;
+                }
 
                 if (!_store.TryGetValue(id, out var existing))
                 {
                     _store[id] = task;
+                    BumpVersion(id);
                     changes.Add(new TaskChange(null, task.Clone()));
                 }
                 else if (!ContentEquals(existing, task))
                 {
                     var old = existing.Clone();
                     _store[id] = task;
+                    BumpVersion(id);
                     changes.Add(new TaskChange(old, task.Clone()));
                 }
             }
@@ -268,37 +337,44 @@ public class IndexService
 
         if (changes.Count > 0)
             RaiseTasksChanged(changes);
+
+        if (convergencePending)
+            RaiseConvergencePending();
     }
 
     /// <summary>
-    /// Test seam: reads every task from disk via <see cref="VaultService.LoadAll"/>,
-    /// pairing each parsed snapshot with its source file's last-write time captured
-    /// at read. <c>protected virtual</c> so tests can inject a snapshot that is
-    /// already stale relative to disk by the time <see cref="Rehydrate"/> applies it
-    /// (the read-outside-lock / apply-inside-lock race the reconciliation guards
-    /// against). Production reads the live vault.
+    /// Test seam: captures the store-version sequence (under <see cref="_gate"/>)
+    /// <b>before</b> reading every task from disk via <see cref="VaultService.LoadAll"/>,
+    /// returning both. <c>protected virtual</c> so tests can inject a snapshot whose
+    /// captured <see cref="DiskSnapshot.ReadStartSeq"/> predates a store mutation that
+    /// lands before <see cref="Rehydrate"/> applies it (the read-outside-lock /
+    /// apply-inside-lock race the version guard defends against). Production reads the
+    /// live vault.
     /// </summary>
-    protected virtual IReadOnlyList<(GlassworkTask Task, DateTime ReadMtimeUtc)> ReadDiskSnapshot()
+    protected virtual DiskSnapshot ReadDiskSnapshot()
     {
-        var list = new List<(GlassworkTask, DateTime)>();
+        long readStartSeq;
+        lock (_gate)
+        {
+            readStartSeq = _versionSeq;
+        }
+        var list = new List<GlassworkTask>();
         foreach (var t in _vault.LoadAll())
         {
             if (string.IsNullOrEmpty(t.Id)) continue;
-            list.Add((t, CurrentMtimeUtc(t.Id)));
+            list.Add(t);
         }
-        return list;
+        return new DiskSnapshot(list, readStartSeq);
     }
 
-    /// <summary>
-    /// Last-write time (UTC) of the task's <c>.md</c> file, or a sentinel
-    /// (<see cref="DateTime.MinValue"/> on IO error; the 1601 epoch when the file
-    /// is simply absent) that compares unequal to any real timestamp. Used by
-    /// <see cref="Rehydrate"/> to detect concurrent on-disk writes.
-    /// </summary>
-    private DateTime CurrentMtimeUtc(string taskId)
+    /// <summary>Raise <see cref="ConvergencePending"/>, swallowing subscriber faults.</summary>
+    private void RaiseConvergencePending()
     {
-        try { return File.GetLastWriteTimeUtc(Path.Combine(_vault.VaultPath, taskId + ".md")); }
-        catch { return DateTime.MinValue; }
+        try { ConvergencePending?.Invoke(this, EventArgs.Empty); }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"IndexService: ConvergencePending subscriber threw: {ex.Message}");
+        }
     }
 
     /// <summary>
@@ -454,6 +530,7 @@ public class IndexService
         {
             _store.TryGetValue(taskId, out oldEntry);
             _store[taskId] = parsed;
+            BumpVersion(taskId);
             // Clone OUTSIDE the lock? Cheap enough to do under it; avoids racing
             // with another mutation. Then we hand the clones out.
             newEntry = parsed.Clone();
@@ -470,6 +547,7 @@ public class IndexService
         {
             if (!_store.TryGetValue(taskId, out oldEntry)) return;
             _store.Remove(taskId);
+            DropVersion(taskId);
         }
         changes.Add(new TaskChange(oldEntry.Clone(), null));
     }

--- a/src/Glasswork.Core/Services/IndexService.cs
+++ b/src/Glasswork.Core/Services/IndexService.cs
@@ -319,6 +319,18 @@ public class IndexService
 
                 if (!_store.TryGetValue(id, out var existing))
                 {
+                    // Don't resurrect a file that was deleted between the unlocked
+                    // read and this apply. Its RemoveSnapshot dropped the version,
+                    // so the per-id guard above can't catch it (TryGetValue=false,
+                    // same path as a brand-new id). Mirror the removed-branch
+                    // File.Exists check; request a bounded follow-up so the next
+                    // pass — whose snapshot won't contain the deleted id — reconciles
+                    // cleanly via the removed-branch's genuine-absence handling.
+                    if (!File.Exists(Path.Combine(_vault.VaultPath, id + ".md")))
+                    {
+                        convergencePending = true;
+                        continue;
+                    }
                     _store[id] = task;
                     BumpVersion(id);
                     changes.Add(new TaskChange(null, task.Clone()));

--- a/src/Glasswork.Core/Services/IndexService.cs
+++ b/src/Glasswork.Core/Services/IndexService.cs
@@ -204,43 +204,62 @@ public class IndexService
     /// </summary>
     public void Rehydrate()
     {
-        // Read disk OUTSIDE the lock — LoadAll does file IO + parsing.
-        var fresh = new Dictionary<string, GlassworkTask>(StringComparer.Ordinal);
-        foreach (var t in _vault.LoadAll())
+        // Read disk OUTSIDE the lock — LoadAll does file IO + parsing. Each entry
+        // carries the source file's last-write time captured at read, so the apply
+        // phase can detect (and skip) any entry whose file changed under us between
+        // this unlocked read and taking the lock.
+        var fresh = ReadDiskSnapshot();
+        var freshById = new Dictionary<string, (GlassworkTask Task, DateTime ReadMtimeUtc)>(StringComparer.Ordinal);
+        foreach (var entry in fresh)
         {
-            if (!string.IsNullOrEmpty(t.Id))
-                fresh[t.Id] = t;
+            if (!string.IsNullOrEmpty(entry.Task.Id))
+                freshById[entry.Task.Id] = entry;
         }
 
         var changes = new List<TaskChange>();
         lock (_gate)
         {
-            // Removed: present in the store, absent on disk.
+            // Removed: present in the store, absent from the fresh snapshot — but
+            // only when the file is GENUINELY absent from disk. A file that is
+            // present-but-unparseable (mid-write / invalid YAML during a bulk
+            // import) is silently omitted by LoadAll; and a file written + committed
+            // to the store after the unlocked read but before this lock (TOCTOU) is
+            // also missing from the snapshot. Both must KEEP their prior snapshot,
+            // mirroring OnFileChangedOnDisk's File.Exists guard, not be deleted.
             var removedIds = new List<string>();
             foreach (var kv in _store)
             {
-                if (!fresh.ContainsKey(kv.Key))
-                {
-                    changes.Add(new TaskChange(kv.Value.Clone(), null));
-                    removedIds.Add(kv.Key);
-                }
+                if (freshById.ContainsKey(kv.Key)) continue;
+                if (File.Exists(Path.Combine(_vault.VaultPath, kv.Key + ".md"))) continue;
+                changes.Add(new TaskChange(kv.Value.Clone(), null));
+                removedIds.Add(kv.Key);
             }
             foreach (var id in removedIds)
                 _store.Remove(id);
 
-            // Added or content-changed.
-            foreach (var kv in fresh)
+            // Added or content-changed — but skip any entry whose source file
+            // changed on disk since the unlocked read. A newer per-file update may
+            // have landed in the store while we were reading; replaying our older
+            // snapshot would re-stale it. The store already holds the newer value;
+            // the next watcher event / rehydrate converges anything genuinely missed.
+            foreach (var kv in freshById)
             {
-                if (!_store.TryGetValue(kv.Key, out var existing))
+                var id = kv.Key;
+                var task = kv.Value.Task;
+
+                if (CurrentMtimeUtc(id) != kv.Value.ReadMtimeUtc)
+                    continue;
+
+                if (!_store.TryGetValue(id, out var existing))
                 {
-                    _store[kv.Key] = kv.Value;
-                    changes.Add(new TaskChange(null, kv.Value.Clone()));
+                    _store[id] = task;
+                    changes.Add(new TaskChange(null, task.Clone()));
                 }
-                else if (!ContentEquals(existing, kv.Value))
+                else if (!ContentEquals(existing, task))
                 {
                     var old = existing.Clone();
-                    _store[kv.Key] = kv.Value;
-                    changes.Add(new TaskChange(old, kv.Value.Clone()));
+                    _store[id] = task;
+                    changes.Add(new TaskChange(old, task.Clone()));
                 }
             }
 
@@ -249,6 +268,37 @@ public class IndexService
 
         if (changes.Count > 0)
             RaiseTasksChanged(changes);
+    }
+
+    /// <summary>
+    /// Test seam: reads every task from disk via <see cref="VaultService.LoadAll"/>,
+    /// pairing each parsed snapshot with its source file's last-write time captured
+    /// at read. <c>protected virtual</c> so tests can inject a snapshot that is
+    /// already stale relative to disk by the time <see cref="Rehydrate"/> applies it
+    /// (the read-outside-lock / apply-inside-lock race the reconciliation guards
+    /// against). Production reads the live vault.
+    /// </summary>
+    protected virtual IReadOnlyList<(GlassworkTask Task, DateTime ReadMtimeUtc)> ReadDiskSnapshot()
+    {
+        var list = new List<(GlassworkTask, DateTime)>();
+        foreach (var t in _vault.LoadAll())
+        {
+            if (string.IsNullOrEmpty(t.Id)) continue;
+            list.Add((t, CurrentMtimeUtc(t.Id)));
+        }
+        return list;
+    }
+
+    /// <summary>
+    /// Last-write time (UTC) of the task's <c>.md</c> file, or a sentinel
+    /// (<see cref="DateTime.MinValue"/> on IO error; the 1601 epoch when the file
+    /// is simply absent) that compares unequal to any real timestamp. Used by
+    /// <see cref="Rehydrate"/> to detect concurrent on-disk writes.
+    /// </summary>
+    private DateTime CurrentMtimeUtc(string taskId)
+    {
+        try { return File.GetLastWriteTimeUtc(Path.Combine(_vault.VaultPath, taskId + ".md")); }
+        catch { return DateTime.MinValue; }
     }
 
     /// <summary>

--- a/src/Glasswork.Core/Services/IndexService.cs
+++ b/src/Glasswork.Core/Services/IndexService.cs
@@ -46,6 +46,13 @@ public class IndexService
     private bool _loaded;
 
     /// <summary>
+    /// Stateless serializer used by <see cref="Rehydrate"/> as a content
+    /// signature for change detection — two tasks are considered equal iff they
+    /// serialize to identical markdown. Cheap to hold; never writes to disk.
+    /// </summary>
+    private readonly FrontmatterParser _serializer = new();
+
+    /// <summary>
     /// Raised after the in-memory store has been mutated by a vault event or
     /// a watcher-observed file change. Carries old+new snapshots so filtered
     /// views can detect removal-from-set. Subscribers may throw — exceptions
@@ -167,6 +174,91 @@ public class IndexService
             _loaded = true;
         }
     }
+
+    /// <summary>
+    /// Full reconciliation recovery path (Option B hardening). Re-reads every
+    /// task from disk via <see cref="VaultService.LoadAll"/>, diffs it against
+    /// the in-memory store, and emits a single batched delta covering every
+    /// task that was added, content-changed, or removed. Both
+    /// <see cref="TasksChanged"/> and <see cref="Changed"/> fire (once) so
+    /// subscribed pages catch back up.
+    ///
+    /// <para>
+    /// This is the recovery for <b>dropped watcher events</b>: when the
+    /// <see cref="FileSystemWatcher"/> buffer overflows during a bulk burst of
+    /// writes (e.g. an ADO sprint import) it raises <c>Error</c> and silently
+    /// drops queued changes, leaving in-memory snapshots stale until restart.
+    /// <see cref="FileWatcherService.Overflowed"/> wires here to resync live.
+    /// </para>
+    ///
+    /// <para>
+    /// Change detection compares <see cref="FrontmatterParser.Serialize"/>
+    /// signatures — conservative by design: an unchanged file parses to an
+    /// identical snapshot and serializes identically, so it produces no delta
+    /// (true no-op when disk matches memory); any real edit differs and is
+    /// surfaced. Read-only — does <b>not</b> write the vault, so it needs no
+    /// <see cref="SelfWriteCoordinator"/> registration (hard rule 5). Safe to
+    /// call before <see cref="EnsureLoaded"/>: an empty store reconciles to
+    /// "everything on disk is Added" and the store is marked loaded.
+    /// </para>
+    /// </summary>
+    public void Rehydrate()
+    {
+        // Read disk OUTSIDE the lock — LoadAll does file IO + parsing.
+        var fresh = new Dictionary<string, GlassworkTask>(StringComparer.Ordinal);
+        foreach (var t in _vault.LoadAll())
+        {
+            if (!string.IsNullOrEmpty(t.Id))
+                fresh[t.Id] = t;
+        }
+
+        var changes = new List<TaskChange>();
+        lock (_gate)
+        {
+            // Removed: present in the store, absent on disk.
+            var removedIds = new List<string>();
+            foreach (var kv in _store)
+            {
+                if (!fresh.ContainsKey(kv.Key))
+                {
+                    changes.Add(new TaskChange(kv.Value.Clone(), null));
+                    removedIds.Add(kv.Key);
+                }
+            }
+            foreach (var id in removedIds)
+                _store.Remove(id);
+
+            // Added or content-changed.
+            foreach (var kv in fresh)
+            {
+                if (!_store.TryGetValue(kv.Key, out var existing))
+                {
+                    _store[kv.Key] = kv.Value;
+                    changes.Add(new TaskChange(null, kv.Value.Clone()));
+                }
+                else if (!ContentEquals(existing, kv.Value))
+                {
+                    var old = existing.Clone();
+                    _store[kv.Key] = kv.Value;
+                    changes.Add(new TaskChange(old, kv.Value.Clone()));
+                }
+            }
+
+            _loaded = true;
+        }
+
+        if (changes.Count > 0)
+            RaiseTasksChanged(changes);
+    }
+
+    /// <summary>
+    /// Content equality by serialized signature: two snapshots are equal iff
+    /// they serialize to identical markdown. Over-reporting (a spurious Changed)
+    /// only costs a UI refresh; under-reporting would leave a stale chip, so the
+    /// conservative direction is correct here.
+    /// </summary>
+    private bool ContentEquals(GlassworkTask a, GlassworkTask b)
+        => _serializer.Serialize(a) == _serializer.Serialize(b);
 
     /// <summary>
     /// Async hydrate (issue #186 contract). Today the implementation is

--- a/tests/Glasswork.Tests/DueUrgencyTests.cs
+++ b/tests/Glasswork.Tests/DueUrgencyTests.cs
@@ -1,0 +1,98 @@
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+/// <summary>
+/// Regression guard for the "future due shown as overdue" report. A task using the
+/// newer frontmatter schema (a <c>links:</c> block sequence plus a past <c>my_day:</c>)
+/// with a future <c>due:</c> must parse to <see cref="DueUrgency.Future"/>, never
+/// <see cref="DueUrgency.Overdue"/>. Dates are computed relative to today so the test
+/// does not rot when the wall clock passes a hardcoded date.
+/// </summary>
+[TestClass]
+public class DueUrgencyTests
+{
+    private readonly FrontmatterParser _parser = new();
+
+    [TestMethod]
+    public void Parse_NewerSchema_FutureDue_IsFutureNotOverdue()
+    {
+        var due = DateTime.Today.AddDays(12);
+        var myDay = DateTime.Today.AddDays(-1); // yesterday — must not feed overdue
+
+        var markdown = $"""
+            ---
+            id: honor-manifest-expectedasyncoperationduration-on-subse
+            title: Honor manifest expectedAsyncOperationDuration on subsequent batch polls
+            status: in-progress
+            priority: medium
+            created: 2026-06-08
+            due: {due:yyyy-MM-dd}
+            my_day: {myDay:yyyy-MM-dd}
+            parent: 32681761
+            links:
+            - type: ado
+              value: 38213284
+            ---
+
+            Some notes.
+            """;
+
+        var task = _parser.Parse(markdown);
+
+        Assert.AreEqual(due.Date, task.Due!.Value.Date, "newer-schema due should parse to the future date");
+        Assert.AreNotEqual(DueUrgency.Overdue, task.DueUrgency, "a future due must not be flagged overdue");
+        Assert.AreEqual(DueUrgency.Future, task.DueUrgency);
+    }
+
+    [TestMethod]
+    public void Parse_OlderSchema_FutureDue_IsFutureNotOverdue()
+    {
+        // Parity check: the flat ado_link scalar (older schema, no my_day) yields the
+        // same urgency, proving the schema is not what drives the overdue flag.
+        var due = DateTime.Today.AddDays(12);
+
+        var markdown = $"""
+            ---
+            id: legacy-task
+            title: Legacy imported task
+            status: in-progress
+            priority: medium
+            created: 2026-06-08
+            due: {due:yyyy-MM-dd}
+            ado_link: 38213284
+            parent: 32681761
+            ---
+            """;
+
+        var task = _parser.Parse(markdown);
+
+        Assert.AreEqual(due.Date, task.Due!.Value.Date);
+        Assert.AreEqual(DueUrgency.Future, task.DueUrgency);
+    }
+
+    [TestMethod]
+    public void Parse_NoDue_IsNoneNotOverdue()
+    {
+        // A missing/unparsed due must read as None, never Overdue.
+        var markdown = """
+            ---
+            id: no-due-task
+            title: Task without a due date
+            status: in-progress
+            priority: medium
+            created: 2026-06-08
+            links:
+            - type: ado
+              value: 38213284
+            ---
+            """;
+
+        var task = _parser.Parse(markdown);
+
+        Assert.IsFalse(task.Due.HasValue);
+        Assert.AreEqual(DueUrgency.None, task.DueUrgency);
+        Assert.AreNotEqual(DueUrgency.Overdue, task.DueUrgency);
+    }
+}

--- a/tests/Glasswork.Tests/FileWatcherServiceTests.cs
+++ b/tests/Glasswork.Tests/FileWatcherServiceTests.cs
@@ -328,4 +328,44 @@ public class FileWatcherServiceTests
         Assert.IsFalse(signal.Wait(TimeSpan.FromSeconds(2)));
         Assert.IsNull(observed);
     }
+
+    // ── Watcher overflow recovery (Option B hardening) ──────────────────────
+    //
+    // A real FileSystemWatcher InternalBufferOverflowException is load- and
+    // timing-dependent and can't be triggered deterministically. The recovery
+    // seam (HandleWatcherError ⇒ Overflowed) is exercised directly instead; the
+    // app wires Overflowed → IndexService.Rehydrate() so a dropped burst still
+    // converges to the on-disk state instead of leaving stale chips.
+
+    [TestMethod]
+    public void HandleWatcherError_RaisesOverflowed()
+    {
+        using var watcher = new FileWatcherService(_tempDir);
+        var fired = 0;
+        watcher.Overflowed += (_, _) => fired++;
+
+        watcher.HandleWatcherError(new InternalBufferOverflowException("buffer overflow"));
+
+        Assert.AreEqual(1, fired,
+            "A watcher error must surface exactly one Overflowed event for the app to rehydrate on.");
+    }
+
+    [TestMethod]
+    public void HandleWatcherError_WithNoSubscriber_DoesNotThrow()
+    {
+        using var watcher = new FileWatcherService(_tempDir);
+
+        // No Overflowed subscriber attached — must be a safe no-op.
+        watcher.HandleWatcherError(new Exception("boom"));
+    }
+
+    [TestMethod]
+    public void HandleWatcherError_SwallowsSubscriberException()
+    {
+        using var watcher = new FileWatcherService(_tempDir);
+        watcher.Overflowed += (_, _) => throw new InvalidOperationException("subscriber blew up");
+
+        // A throwing subscriber must not propagate out of the error callback.
+        watcher.HandleWatcherError(new Exception("boom"));
+    }
 }

--- a/tests/Glasswork.Tests/IndexRehydrateTests.cs
+++ b/tests/Glasswork.Tests/IndexRehydrateTests.cs
@@ -346,6 +346,53 @@ public class IndexRehydrateTests
         Assert.AreEqual(1, convergence, "a version-skipped entry must request exactly one bounded follow-up.");
     }
 
+    // ── Finding C: delete-during-read must not resurrect ────────────────────
+    //
+    // ReadDiskSnapshot/LoadAll is lock-free; the watcher thread can run
+    // RemoveSnapshot concurrently. If a task is deleted on disk AFTER the read
+    // captured it but BEFORE the apply lock, its id is gone from _store and —
+    // critically — DROPPED from _versions. The add-branch version guard is
+    // `_versions.TryGetValue(id, ...)`, which returns false for a dropped id, so
+    // the guard is skipped exactly as for a brand-new id → the stale parse would
+    // re-add the task as a phantom (an Added delta), reappearing in the UI until
+    // the next overflow or restart. That is WORSE than the stale-chip bug this PR
+    // fixes. The add-branch must mirror the removed-branch File.Exists guard.
+    [TestMethod]
+    public void Rehydrate_WhenFileDeletedDuringRead_DoesNotResurrectDeletedTask()
+    {
+        _vault.Save(new GlassworkTask { Id = "x", Title = "Ex", Due = DateTime.Today.AddDays(5) });
+
+        SeamIndex seam = null!;
+        seam = new SeamIndex(_vault, () =>
+        {
+            // The snapshot captured "x" while x.md still existed…
+            var captured = new GlassworkTask { Id = "x", Title = "Ex", Due = DateTime.Today.AddDays(5) };
+
+            // …then, during the unlocked read, x is deleted on disk and the delete
+            // event is delivered + processed by the real watcher path: store loses
+            // "x" and DropVersion("x") erases its version (so the add-branch's
+            // version guard cannot catch it).
+            File.Delete(Path.Combine(_tempDir, "x.md"));
+            seam.OnFileChangedOnDisk("x"); // file gone => RemoveSnapshot("x")
+
+            return new IndexService.DiskSnapshot(new[] { captured }, ReadStartSeq: 0);
+        });
+        var seamChanges = new List<TasksChanged>();
+        seam.Changed += (_, e) => seamChanges.Add(e);
+        seam.EnsureLoaded();
+
+        int convergence = 0;
+        seam.ConvergencePending += (_, _) => convergence++;
+
+        seam.Rehydrate();
+
+        Assert.IsNull(seam.ById("x"), "a task deleted during the unlocked read must not be resurrected by the apply.");
+        Assert.IsFalse(
+            seamChanges.Any(e => e.Added.Any(t => t.Id == "x")),
+            "the apply must not emit a phantom Added for a file that is absent at apply time.");
+        Assert.AreEqual(1, convergence, "a skipped resurrection must request one bounded follow-up to reconcile cleanly.");
+    }
+
     // A fully-reconciled pass (disk == memory, nothing skipped or kept-unparseable)
     // must NOT request a follow-up — otherwise every overflow would re-arm forever.
     [TestMethod]

--- a/tests/Glasswork.Tests/IndexRehydrateTests.cs
+++ b/tests/Glasswork.Tests/IndexRehydrateTests.cs
@@ -194,23 +194,25 @@ public class IndexRehydrateTests
     // OnFileChangedOnDisk path already enforces.
 
     /// <summary>
-    /// Test seam over <see cref="IndexService"/>: returns a caller-supplied disk
-    /// snapshot (parsed task + the mtime "captured at read") instead of the live
-    /// vault, so a test can simulate a snapshot that is already stale relative to
-    /// disk by the time <c>Rehydrate</c> applies it.
+    /// Test seam over <see cref="IndexService"/>: returns a caller-supplied
+    /// <see cref="IndexService.DiskSnapshot"/> (parsed tasks + the store-version
+    /// sequence "captured before the read") instead of the live vault, so a test
+    /// can simulate a snapshot whose captured baseline predates a store mutation
+    /// that lands before <c>Rehydrate</c> applies it.
     /// </summary>
     private sealed class SeamIndex : IndexService
     {
-        private readonly Func<IReadOnlyList<(GlassworkTask, DateTime)>> _snapshot;
-        public SeamIndex(VaultService vault, Func<IReadOnlyList<(GlassworkTask, DateTime)>> snapshot)
+        private readonly Func<DiskSnapshot> _snapshot;
+        public SeamIndex(VaultService vault, Func<DiskSnapshot> snapshot)
             : base(vault) => _snapshot = snapshot;
-        protected override IReadOnlyList<(GlassworkTask Task, DateTime ReadMtimeUtc)> ReadDiskSnapshot()
-            => _snapshot();
+        protected override DiskSnapshot ReadDiskSnapshot() => _snapshot();
     }
 
     // Finding 1 (BLOCKING): a present-but-unparseable file (mid-write / invalid
     // YAML during a bulk import) is silently omitted by LoadAll. It must KEEP its
-    // prior snapshot, NOT be misclassified as a deletion.
+    // prior snapshot, NOT be misclassified as a deletion — and (Finding B) request
+    // exactly one bounded follow-up so a later valid write whose event was also
+    // dropped still converges.
     [TestMethod]
     public void Rehydrate_WhenExistingFileTemporarilyUnparseable_KeepsPriorSnapshot_AndDoesNotEmitRemoved()
     {
@@ -221,35 +223,67 @@ public class IndexRehydrateTests
         // Corrupt frontmatter lands on disk: file is PRESENT but cannot parse.
         File.WriteAllText(Path.Combine(_tempDir, "t.md"), "this file has no frontmatter delimiters and cannot parse");
 
+        int convergence = 0;
+        _index.ConvergencePending += (_, _) => convergence++;
+
         _index.Rehydrate();
 
         Assert.IsNotNull(_index.ById("t"), "an unparseable-but-present file must keep its prior snapshot, not vanish.");
         Assert.AreEqual(DueUrgency.Future, _index.ById("t")!.DueUrgency, "prior (valid) snapshot must be retained intact.");
         Assert.AreEqual(0, _changed.Count, "a present-but-unparseable file must emit no delta (no spurious Removed).");
+        Assert.AreEqual(1, convergence, "a kept present-but-unparseable file must request one bounded follow-up.");
     }
 
-    // Finding 2 (BLOCKING): a slow full-vault read can replay a stale snapshot over
-    // a newer per-file update applied while it was reading. The stale entry's source
-    // file changed since it was read → it must be skipped, not clobber the newer value.
+    // Finding A (BLOCKING, version counter): a write that lands DURING the unlocked
+    // read bumps the entry's per-id version PAST the sequence captured before the
+    // read. Replaying the older parse must be skipped, never clobber the newer store.
+    // This exercises the REAL interleaving (the write happens inside the snapshot
+    // provider, exactly when LoadAll would be reading), not a hand-picked stale value.
+    [TestMethod]
+    public void Rehydrate_ConcurrentWriteDuringRead_VersionGuard_DoesNotOverwriteNewerStore()
+    {
+        var future = DateTime.Today.AddDays(12);
+        var overdue = DateTime.Today.AddDays(-3);
+
+        // The provider stands in for "reading disk": while it runs, a newer per-file
+        // write lands (saved through the vault → bumps the seam's version for "t"),
+        // then it returns an OLDER parse paired with a ReadStartSeq captured BEFORE
+        // that write (0 = nothing observed yet).
+        var seam = new SeamIndex(_vault, () =>
+        {
+            _vault.Save(new GlassworkTask { Id = "t", Title = "Task", Due = future });
+            return new IndexService.DiskSnapshot(
+                new[] { new GlassworkTask { Id = "t", Title = "Task", Due = overdue } },
+                ReadStartSeq: 0);
+        });
+
+        seam.Rehydrate();
+
+        Assert.AreEqual(DueUrgency.Future, seam.ById("t")!.DueUrgency,
+            "a write during the read bumps the version past ReadStartSeq → the older parse must be skipped.");
+        Assert.AreEqual(future.Date, seam.ById("t")!.Due!.Value.Date);
+    }
+
+    // Finding 2 (BLOCKING): a slow full-vault read can replay a stale snapshot over a
+    // newer per-file update applied while it was reading. Under the version counter,
+    // the store entry's version has advanced past the snapshot's captured baseline →
+    // the stale entry is skipped, not clobbering the newer value. (Kept green under
+    // the new signal; the comparison logic still holds for a correctly-stale input.)
     [TestMethod]
     public void Rehydrate_DoesNotOverwriteConcurrentNewerPerFileUpdate()
     {
-        // Current good state: store + disk both hold the NEWER value (future due),
-        // as if a per-file watcher update already landed it.
         var future = DateTime.Today.AddDays(12);
         _vault.Save(new GlassworkTask { Id = "t", Title = "Task", Due = future });
 
-        // A Rehydrate that began BEFORE that update: its unlocked read saw the OLDER
-        // value (overdue) and captured an OLDER mtime. The live file mtime is newer.
-        var staleMtime = File.GetLastWriteTimeUtc(Path.Combine(_tempDir, "t.md")).AddMinutes(-5);
-        var staleSnapshot = new List<(GlassworkTask, DateTime)>
-        {
-            (new GlassworkTask { Id = "t", Title = "Task", Due = DateTime.Today.AddDays(-3) }, staleMtime),
-        };
-        var seam = new SeamIndex(_vault, () => staleSnapshot);
+        // Snapshot's captured baseline is 0 (read began before anything was seen),
+        // but the store already holds the newer value with an advanced version.
+        var snapshot = new IndexService.DiskSnapshot(
+            new[] { new GlassworkTask { Id = "t", Title = "Task", Due = DateTime.Today.AddDays(-3) } },
+            ReadStartSeq: 0);
+        var seam = new SeamIndex(_vault, () => snapshot);
         var seamChanges = new List<TasksChanged>();
         seam.Changed += (_, e) => seamChanges.Add(e);
-        seam.EnsureLoaded(); // hydrate from disk = newer future value
+        seam.EnsureLoaded(); // hydrate from disk = newer future value, version["t"] > 0
         Assert.AreEqual(DueUrgency.Future, seam.ById("t")!.DueUrgency, "precondition: store holds the newer value.");
 
         seam.Rehydrate();
@@ -261,7 +295,8 @@ public class IndexRehydrateTests
 
     // Finding 3 (MEDIUM): TOCTOU. A file written to disk + store AFTER the unlocked
     // read snapshotted disk is absent from the snapshot but PRESENT on disk. It must
-    // NOT be removed — the removal branch re-checks File.Exists.
+    // NOT be removed — the removal branch re-checks File.Exists. ReadStartSeq is set
+    // high so the present entry "a" never version-skips (content-equal => true no-op).
     [TestMethod]
     public void Rehydrate_RemovesOnlyGenuinelyAbsentFiles_NotFilesWrittenDuringSnapshotWindow()
     {
@@ -270,12 +305,10 @@ public class IndexRehydrateTests
 
         // Snapshot reflects disk BEFORE z.md existed (only "a"): a same-process Save
         // wrote z.md and committed _store["z"] after LoadAll ran, before the lock.
-        var aMtime = File.GetLastWriteTimeUtc(Path.Combine(_tempDir, "a.md"));
-        var staleSnapshot = new List<(GlassworkTask, DateTime)>
-        {
-            (new GlassworkTask { Id = "a", Title = "Alpha", Due = DateTime.Today.AddDays(5) }, aMtime),
-        };
-        var seam = new SeamIndex(_vault, () => staleSnapshot);
+        var snapshot = new IndexService.DiskSnapshot(
+            new[] { new GlassworkTask { Id = "a", Title = "Alpha", Due = DateTime.Today.AddDays(5) } },
+            ReadStartSeq: long.MaxValue);
+        var seam = new SeamIndex(_vault, () => snapshot);
         var seamChanges = new List<TasksChanged>();
         seam.Changed += (_, e) => seamChanges.Add(e);
         seam.EnsureLoaded(); // store = {a, z} (both files exist on disk)
@@ -286,5 +319,80 @@ public class IndexRehydrateTests
         Assert.IsNotNull(seam.ById("z"), "a file written during the snapshot window must not be dropped from the index.");
         Assert.AreEqual(2, seam.Count);
         Assert.IsFalse(seamChanges.Any(e => e.Removed.Contains("z")), "must not emit a spurious Removed for a present file.");
+    }
+
+    // ── Finding B: bounded follow-up convergence ────────────────────────────
+
+    // A version-skipped entry must request exactly one follow-up rehydrate — the
+    // per-file watcher event that would otherwise converge it may itself have been
+    // dropped by the same overflow, so convergence cannot depend on another event.
+    [TestMethod]
+    public void Rehydrate_WhenEntrySkippedForConcurrentChange_RaisesConvergencePendingOnce()
+    {
+        var future = DateTime.Today.AddDays(12);
+        _vault.Save(new GlassworkTask { Id = "t", Title = "Task", Due = future });
+
+        var snapshot = new IndexService.DiskSnapshot(
+            new[] { new GlassworkTask { Id = "t", Title = "Task", Due = DateTime.Today.AddDays(-3) } },
+            ReadStartSeq: 0);
+        var seam = new SeamIndex(_vault, () => snapshot);
+        seam.EnsureLoaded(); // version["t"] > 0 → the stale snapshot entry will be skipped
+
+        int convergence = 0;
+        seam.ConvergencePending += (_, _) => convergence++;
+
+        seam.Rehydrate();
+
+        Assert.AreEqual(1, convergence, "a version-skipped entry must request exactly one bounded follow-up.");
+    }
+
+    // A fully-reconciled pass (disk == memory, nothing skipped or kept-unparseable)
+    // must NOT request a follow-up — otherwise every overflow would re-arm forever.
+    [TestMethod]
+    public void Rehydrate_WhenFullyReconciled_DoesNotRaiseConvergencePending()
+    {
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Alpha", Due = DateTime.Today.AddDays(5) });
+        _index.EnsureLoaded();
+
+        int convergence = 0;
+        _index.ConvergencePending += (_, _) => convergence++;
+
+        _index.Rehydrate(); // disk matches memory → no skip, no keep
+
+        Assert.AreEqual(0, convergence, "a fully-reconciled pass must not request a follow-up.");
+    }
+
+    // End-to-end Finding B: the first rehydrate keeps a present-but-unparseable file
+    // and fires ConvergencePending; a single bounded follow-up (the handler unsubscribes
+    // itself) re-reads after the file is repaired by a write whose event was dropped,
+    // and converges to the correct future value. Exactly one follow-up runs.
+    [TestMethod]
+    public void Rehydrate_IncompletePass_OneBoundedFollowUp_Converges()
+    {
+        var future = DateTime.Today.AddDays(12);
+        _vault.Save(new GlassworkTask { Id = "t", Title = "Task", Due = DateTime.Today.AddDays(-3) }); // stale overdue in store
+        _changed.Clear();
+
+        // The file is mid-write / corrupt when the first rehydrate runs.
+        File.WriteAllText(Path.Combine(_tempDir, "t.md"), "this file has no frontmatter delimiters and cannot parse");
+
+        int followUps = 0;
+        EventHandler? handler = null;
+        handler = (_, _) =>
+        {
+            _index.ConvergencePending -= handler;   // bound: at most one follow-up per episode
+            // The final valid write — its watcher event was ALSO dropped (External()
+            // is unobserved by _index), so only the follow-up rehydrate can converge it.
+            External().Save(new GlassworkTask { Id = "t", Title = "Task", Due = future });
+            followUps++;
+            _index.Rehydrate();
+        };
+        _index.ConvergencePending += handler;
+
+        _index.Rehydrate(); // first pass: keeps corrupt file, requests follow-up
+
+        Assert.AreEqual(1, followUps, "exactly one bounded follow-up rehydrate must run.");
+        Assert.AreEqual(DueUrgency.Future, _index.ById("t")!.DueUrgency, "the follow-up must converge the now-valid file.");
+        Assert.AreEqual(future.Date, _index.ById("t")!.Due!.Value.Date);
     }
 }

--- a/tests/Glasswork.Tests/IndexRehydrateTests.cs
+++ b/tests/Glasswork.Tests/IndexRehydrateTests.cs
@@ -184,4 +184,107 @@ public class IndexRehydrateTests
         var delta = _changed.Single();
         CollectionAssert.AreEquivalent(new[] { "x", "y" }, delta.Added.Select(t => t.Id).ToList());
     }
+
+    // ── Reconciliation safety (PR #336 dual-review findings) ────────────────
+    //
+    // Rehydrate reads the whole vault OUTSIDE the lock, then applies under it.
+    // Three races, all triggered by the same bulk-write burst this path targets,
+    // must not let a live task vanish or re-stale — outcomes worse than the
+    // original stale-chip bug. Each mirrors the policy the per-file
+    // OnFileChangedOnDisk path already enforces.
+
+    /// <summary>
+    /// Test seam over <see cref="IndexService"/>: returns a caller-supplied disk
+    /// snapshot (parsed task + the mtime "captured at read") instead of the live
+    /// vault, so a test can simulate a snapshot that is already stale relative to
+    /// disk by the time <c>Rehydrate</c> applies it.
+    /// </summary>
+    private sealed class SeamIndex : IndexService
+    {
+        private readonly Func<IReadOnlyList<(GlassworkTask, DateTime)>> _snapshot;
+        public SeamIndex(VaultService vault, Func<IReadOnlyList<(GlassworkTask, DateTime)>> snapshot)
+            : base(vault) => _snapshot = snapshot;
+        protected override IReadOnlyList<(GlassworkTask Task, DateTime ReadMtimeUtc)> ReadDiskSnapshot()
+            => _snapshot();
+    }
+
+    // Finding 1 (BLOCKING): a present-but-unparseable file (mid-write / invalid
+    // YAML during a bulk import) is silently omitted by LoadAll. It must KEEP its
+    // prior snapshot, NOT be misclassified as a deletion.
+    [TestMethod]
+    public void Rehydrate_WhenExistingFileTemporarilyUnparseable_KeepsPriorSnapshot_AndDoesNotEmitRemoved()
+    {
+        _vault.Save(new GlassworkTask { Id = "t", Title = "Task", Due = DateTime.Today.AddDays(12) });
+        _changed.Clear();
+        Assert.AreEqual(DueUrgency.Future, _index.ById("t")!.DueUrgency, "precondition: index sees the valid future due.");
+
+        // Corrupt frontmatter lands on disk: file is PRESENT but cannot parse.
+        File.WriteAllText(Path.Combine(_tempDir, "t.md"), "this file has no frontmatter delimiters and cannot parse");
+
+        _index.Rehydrate();
+
+        Assert.IsNotNull(_index.ById("t"), "an unparseable-but-present file must keep its prior snapshot, not vanish.");
+        Assert.AreEqual(DueUrgency.Future, _index.ById("t")!.DueUrgency, "prior (valid) snapshot must be retained intact.");
+        Assert.AreEqual(0, _changed.Count, "a present-but-unparseable file must emit no delta (no spurious Removed).");
+    }
+
+    // Finding 2 (BLOCKING): a slow full-vault read can replay a stale snapshot over
+    // a newer per-file update applied while it was reading. The stale entry's source
+    // file changed since it was read → it must be skipped, not clobber the newer value.
+    [TestMethod]
+    public void Rehydrate_DoesNotOverwriteConcurrentNewerPerFileUpdate()
+    {
+        // Current good state: store + disk both hold the NEWER value (future due),
+        // as if a per-file watcher update already landed it.
+        var future = DateTime.Today.AddDays(12);
+        _vault.Save(new GlassworkTask { Id = "t", Title = "Task", Due = future });
+
+        // A Rehydrate that began BEFORE that update: its unlocked read saw the OLDER
+        // value (overdue) and captured an OLDER mtime. The live file mtime is newer.
+        var staleMtime = File.GetLastWriteTimeUtc(Path.Combine(_tempDir, "t.md")).AddMinutes(-5);
+        var staleSnapshot = new List<(GlassworkTask, DateTime)>
+        {
+            (new GlassworkTask { Id = "t", Title = "Task", Due = DateTime.Today.AddDays(-3) }, staleMtime),
+        };
+        var seam = new SeamIndex(_vault, () => staleSnapshot);
+        var seamChanges = new List<TasksChanged>();
+        seam.Changed += (_, e) => seamChanges.Add(e);
+        seam.EnsureLoaded(); // hydrate from disk = newer future value
+        Assert.AreEqual(DueUrgency.Future, seam.ById("t")!.DueUrgency, "precondition: store holds the newer value.");
+
+        seam.Rehydrate();
+
+        Assert.AreEqual(DueUrgency.Future, seam.ById("t")!.DueUrgency, "stale snapshot must not clobber the newer in-memory value.");
+        Assert.AreEqual(future.Date, seam.ById("t")!.Due!.Value.Date);
+        Assert.AreEqual(0, seamChanges.Count, "a skipped stale entry must emit no delta.");
+    }
+
+    // Finding 3 (MEDIUM): TOCTOU. A file written to disk + store AFTER the unlocked
+    // read snapshotted disk is absent from the snapshot but PRESENT on disk. It must
+    // NOT be removed — the removal branch re-checks File.Exists.
+    [TestMethod]
+    public void Rehydrate_RemovesOnlyGenuinelyAbsentFiles_NotFilesWrittenDuringSnapshotWindow()
+    {
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Alpha", Due = DateTime.Today.AddDays(5) });
+        _vault.Save(new GlassworkTask { Id = "z", Title = "Zed", Due = DateTime.Today.AddDays(8) });
+
+        // Snapshot reflects disk BEFORE z.md existed (only "a"): a same-process Save
+        // wrote z.md and committed _store["z"] after LoadAll ran, before the lock.
+        var aMtime = File.GetLastWriteTimeUtc(Path.Combine(_tempDir, "a.md"));
+        var staleSnapshot = new List<(GlassworkTask, DateTime)>
+        {
+            (new GlassworkTask { Id = "a", Title = "Alpha", Due = DateTime.Today.AddDays(5) }, aMtime),
+        };
+        var seam = new SeamIndex(_vault, () => staleSnapshot);
+        var seamChanges = new List<TasksChanged>();
+        seam.Changed += (_, e) => seamChanges.Add(e);
+        seam.EnsureLoaded(); // store = {a, z} (both files exist on disk)
+        Assert.AreEqual(2, seam.Count);
+
+        seam.Rehydrate();
+
+        Assert.IsNotNull(seam.ById("z"), "a file written during the snapshot window must not be dropped from the index.");
+        Assert.AreEqual(2, seam.Count);
+        Assert.IsFalse(seamChanges.Any(e => e.Removed.Contains("z")), "must not emit a spurious Removed for a present file.");
+    }
 }

--- a/tests/Glasswork.Tests/IndexRehydrateTests.cs
+++ b/tests/Glasswork.Tests/IndexRehydrateTests.cs
@@ -1,0 +1,187 @@
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+/// <summary>
+/// Tests for <see cref="IndexService.Rehydrate"/> — the full-reconciliation
+/// recovery path (Option B hardening). When the <see cref="FileSystemWatcher"/>
+/// buffer overflows during a bulk burst of writes (e.g. an ADO sprint import),
+/// per-file change events are silently dropped and the in-memory snapshot goes
+/// stale — chips render the pre-edit <c>Due</c>/<c>DueUrgency</c> until restart.
+/// <c>Rehydrate()</c> re-reads the vault from disk, diffs it against the store,
+/// and emits one batched <see cref="IndexService.Changed"/> delta covering every
+/// added / changed / removed task so subscribed pages catch back up live.
+///
+/// External / dropped edits are simulated with a <b>second, unsubscribed</b>
+/// <see cref="VaultService"/> instance writing the same files: it mutates disk
+/// with parser-valid content but fires its domain events only on itself, so the
+/// index under test never sees them — exactly the "dropped watcher event" shape.
+/// No watcher timing is involved.
+/// </summary>
+[TestClass]
+public class IndexRehydrateTests
+{
+    private string _tempDir = null!;
+    private VaultService _vault = null!;
+    private IndexService _index = null!;
+    private List<TasksChanged> _changed = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "glasswork-rehydrate-" + Guid.NewGuid().ToString("N")[..8]);
+        _vault = new VaultService(_tempDir);
+        _index = new IndexService(_vault);
+        _changed = new List<TasksChanged>();
+        _index.Changed += (_, e) => _changed.Add(e);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    /// <summary>A second vault over the same dir whose writes the index does NOT observe.</summary>
+    private VaultService External() => new(_tempDir);
+
+    // ── No-op ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Rehydrate_WhenDiskMatchesMemory_EmitsNoDelta()
+    {
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Alpha", Due = DateTime.Today.AddDays(5) });
+        _vault.Save(new GlassworkTask { Id = "b", Title = "Beta", Due = DateTime.Today.AddDays(12) });
+        _changed.Clear();
+
+        _index.Rehydrate();
+
+        Assert.AreEqual(0, _changed.Count, "Rehydrate must be a no-op when disk already matches the in-memory store.");
+        Assert.AreEqual(2, _index.Count);
+    }
+
+    // ── Modified (the staleness case) ──────────────────────────────────────
+
+    [TestMethod]
+    public void Rehydrate_WhenDueEditedExternally_EmitsChangedDelta_AndRecomputesDueUrgency()
+    {
+        // Seed a task that is currently Overdue, observed by the index.
+        _vault.Save(new GlassworkTask { Id = "t", Title = "Task", Due = DateTime.Today.AddDays(-3) });
+        _changed.Clear();
+        Assert.AreEqual(DueUrgency.Overdue, _index.ById("t")!.DueUrgency, "precondition: index sees the Overdue due.");
+
+        // Out-of-band edit (dropped watcher event): move due ~2 weeks into the future.
+        var future = DateTime.Today.AddDays(12);
+        External().Save(new GlassworkTask { Id = "t", Title = "Task", Due = future });
+
+        // Without rehydrate, the index is stale.
+        Assert.AreEqual(DueUrgency.Overdue, _index.ById("t")!.DueUrgency, "index should still be stale before Rehydrate.");
+
+        _index.Rehydrate();
+
+        // Store updated + urgency recomputed.
+        Assert.AreEqual(future.Date, _index.ById("t")!.Due!.Value.Date);
+        Assert.AreEqual(DueUrgency.Future, _index.ById("t")!.DueUrgency, "Rehydrate must recompute DueUrgency from the on-disk due.");
+
+        // Exactly one Changed delta, carrying the task in Changed with the fresh due.
+        var delta = _changed.Single();
+        Assert.AreEqual(0, delta.Added.Count);
+        Assert.AreEqual(0, delta.Removed.Count);
+        var changedTask = delta.Changed.Single();
+        Assert.AreEqual("t", changedTask.Id);
+        Assert.AreEqual(future.Date, changedTask.Due!.Value.Date);
+        Assert.AreEqual(DueUrgency.Future, changedTask.DueUrgency);
+    }
+
+    // ── Added ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Rehydrate_WhenFileAddedExternally_EmitsAddedDelta()
+    {
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Alpha" });
+        _changed.Clear();
+
+        External().Save(new GlassworkTask { Id = "new", Title = "Newcomer", Due = DateTime.Today.AddDays(7) });
+
+        _index.Rehydrate();
+
+        Assert.AreEqual(2, _index.Count);
+        Assert.IsNotNull(_index.ById("new"));
+        var delta = _changed.Single();
+        Assert.AreEqual("new", delta.Added.Single().Id);
+        Assert.AreEqual(0, delta.Changed.Count);
+        Assert.AreEqual(0, delta.Removed.Count);
+    }
+
+    // ── Removed ────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Rehydrate_WhenFileRemovedExternally_EmitsRemovedDelta()
+    {
+        _vault.Save(new GlassworkTask { Id = "a", Title = "Alpha" });
+        _vault.Save(new GlassworkTask { Id = "b", Title = "Beta" });
+        _changed.Clear();
+
+        External().Delete("b");
+
+        _index.Rehydrate();
+
+        Assert.AreEqual(1, _index.Count);
+        Assert.IsNull(_index.ById("b"));
+        var delta = _changed.Single();
+        Assert.AreEqual("b", delta.Removed.Single());
+        Assert.AreEqual(0, delta.Added.Count);
+        Assert.AreEqual(0, delta.Changed.Count);
+    }
+
+    // ── Bulk drift (the sprint-import shape) ───────────────────────────────
+
+    [TestMethod]
+    public void Rehydrate_BulkExternalDrift_EmitsAllDeltasInOneBatch()
+    {
+        // Seed three tasks the index observes.
+        _vault.Save(new GlassworkTask { Id = "keep", Title = "Keep", Due = DateTime.Today.AddDays(9) });
+        _vault.Save(new GlassworkTask { Id = "edit", Title = "Edit", Due = DateTime.Today.AddDays(-2) });
+        _vault.Save(new GlassworkTask { Id = "drop", Title = "Drop" });
+        _changed.Clear();
+
+        // A burst of out-of-band writes whose events the index never received.
+        var ext = External();
+        ext.Save(new GlassworkTask { Id = "edit", Title = "Edit", Due = DateTime.Today.AddDays(20) }); // modified
+        ext.Delete("drop");                                                                            // removed
+        ext.Save(new GlassworkTask { Id = "add1", Title = "Add One" });                                // added
+        ext.Save(new GlassworkTask { Id = "add2", Title = "Add Two" });                                // added
+
+        _index.Rehydrate();
+
+        var delta = _changed.Single();
+        CollectionAssert.AreEquivalent(new[] { "add1", "add2" }, delta.Added.Select(t => t.Id).ToList());
+        Assert.AreEqual("edit", delta.Changed.Single().Id);
+        Assert.AreEqual(DueUrgency.Future, delta.Changed.Single().DueUrgency);
+        Assert.AreEqual("drop", delta.Removed.Single());
+
+        // "keep" was untouched on disk → must NOT appear in any bucket.
+        Assert.IsFalse(delta.Changed.Any(t => t.Id == "keep"));
+        Assert.AreEqual(4, _index.Count);
+    }
+
+    // ── Pre-hydrate safety ─────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Rehydrate_BeforeEnsureLoaded_HydratesAndEmitsAddedForEverything()
+    {
+        // Files exist on disk written by a process the index never observed.
+        var ext = External();
+        ext.Save(new GlassworkTask { Id = "x", Title = "Ex" });
+        ext.Save(new GlassworkTask { Id = "y", Title = "Why" });
+
+        // Index has never loaded — Rehydrate must hydrate then surface them as Added.
+        _index.Rehydrate();
+
+        Assert.AreEqual(2, _index.Count);
+        var delta = _changed.Single();
+        CollectionAssert.AreEquivalent(new[] { "x", "y" }, delta.Added.Select(t => t.Id).ToList());
+    }
+}


### PR DESCRIPTION
## Summary

Closes out the "future `due:` shown as overdue" investigation. Root cause was **stale in-memory state after a bulk write burst**, not a parse/urgency-logic bug — current `main` Core code reads a future `due:` correctly. This PR lands a regression guard plus the **Option B hardening** the user approved.

### Root cause
A `FileSystemWatcher` buffer overflow during a bulk write burst (e.g. an ADO sprint import writing many `.md` files at once) silently drops queued change events, leaving in-memory task snapshots — and their rendered due/urgency chips — stale until the next app restart. There was no runtime resync: `EnsureLoaded` is one-shot and the only refresh path was the per-task delta.

## Changes

**Core (TDD)**
- `IndexService.Rehydrate()` — re-loads the store from disk, diffs against the in-memory snapshot, emits Added/Removed/Changed deltas so pages re-bind with freshly recomputed `DueUrgency`. Read-only — **hard rule 5 satisfied** (no `SelfWriteCoordinator` registration needed).
- `FileWatcherService` — raise `InternalBufferSize` to 64 KB, handle the `Error` event, surface a public `Overflowed` event.
- `DueUrgencyTests.cs` (regression guard, `b2f9e68`) — parses the exact newer-schema frontmatter (`links:` array + `my_day:` + future `due:`) and asserts `DueUrgency == Future`, never `Overdue`.

**App (hard rule 7)**
- `App.xaml.cs` — wire `Watcher.Overflowed → Index.Rehydrate()` so a dropped burst triggers a full resync instead of leaving stale chips.

## Tests
- `IndexRehydrateTests.cs` (6) — simulate dropped watcher events via a second out-of-band `VaultService`; assert correct deltas fire and `DueUrgency` recomputes.
- `FileWatcherServiceTests.cs` (+3) — cover the `Overflowed` event.
- Full suite: **893 passed, 0 failed**.

## Visual verification (hard rule 7) — done locally
New scenario `scripts/visual-verification/backlog-due-chips.json` seeds overdue / today / future due dates. PNG inspected: the app launches cleanly with the new wiring (no startup crash / `STOWED_EXCEPTION`), and chips render correctly — red **Overdue** (yesterday), **Today**, and **Jul 11** for the future task, which is **not** flagged overdue. That is the exact bug surface, rendered correct.

> Note: a real watcher overflow is load/timing-dependent and can't be fired deterministically from the scenario harness, so the `Overflowed → Rehydrate → delta` logic is proven by the deterministic Core tests above; the visual check confirms the App wiring didn't regress startup or the due-chip surface.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>