### PR TITLE
Surface task `type` in MCP My Day / overdue / list_tasks projections (#339)

### DIFF
--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -172,7 +172,7 @@ public sealed class GlassworkTools
     public string ListTasks(
         [Description("Filter by status: todo, doing, or done.")] string? status = null,
         [Description("Filter by parent task ID.")] string? parent_task_id = null,
-        [Description("Optional field projection. When provided, each summary contains only these fields plus `id`. Allowed values: title, status, parent_id, path, created, priority, due, start, my_day, defer_until, ready, urgency_score, backlink_count, in_my_day_today. Unknown names are silently dropped. Case-insensitive; whitespace trimmed.")] string[]? fields = null)
+        [Description("Optional field projection. When provided, each summary contains only these fields plus `id`. Allowed values: title, status, type, parent_id, path, created, priority, due, start, my_day, defer_until, ready, urgency_score, backlink_count, in_my_day_today. Unknown names are silently dropped. Case-insensitive; whitespace trimmed.")] string[]? fields = null)
     {
         using var scope = _logger?.BeginCall("list_tasks");
         try
@@ -288,6 +288,7 @@ public sealed class GlassworkTools
                     Id: t.Id,
                     Title: t.Title,
                     Status: MapToExternalStatus(t.Status),
+                    Type: GlassworkTask.Types.Normalize(t.Type),
                     Priority: t.Priority,
                     DueDate: t.Due?.ToString("yyyy-MM-dd"),
                     Scheduled: t.MyDay?.ToString("yyyy-MM-dd"),
@@ -1583,7 +1584,7 @@ public sealed class GlassworkTools
 
     private static readonly HashSet<string> AllowedSummaryFields = new(StringComparer.Ordinal)
     {
-        "title", "status", "parent_id", "path", "created", "priority", "due", "start", "my_day", "defer_until",
+        "title", "status", "type", "parent_id", "path", "created", "priority", "due", "start", "my_day", "defer_until",
         "ready", "urgency_score", "backlink_count", "in_my_day_today",
     };
 
@@ -1625,6 +1626,7 @@ public sealed class GlassworkTools
         var signals = SignalsFor(task, backlinkCounts);
         if (fields.Contains("title")) dict["title"] = task.Title;
         if (fields.Contains("status")) dict["status"] = MapToExternalStatus(task.Status);
+        if (fields.Contains("type")) dict["type"] = GlassworkTask.Types.Normalize(task.Type);
         if (fields.Contains("parent_id")) dict["parent_id"] = task.Parent;
         if (fields.Contains("path")) dict["path"] = TodoRelativeTaskPath(task.Id);
         if (fields.Contains("created")) dict["created"] = task.Created.ToString("yyyy-MM-dd");
@@ -2057,6 +2059,7 @@ public sealed class GlassworkTools
                     Id: t.Id,
                     Title: t.Title,
                     Status: MapToExternalStatus(t.Status),
+                    Type: GlassworkTask.Types.Normalize(t.Type),
                     DueDate: t.Due!.Value.ToString("yyyy-MM-dd"),
                     DaysOverdue: (today - t.Due!.Value.Date).Days,
                     Priority: t.Priority,
@@ -2215,6 +2218,7 @@ public sealed class GlassworkTools
         [property: JsonPropertyName("id")] string Id,
         [property: JsonPropertyName("title")] string Title,
         [property: JsonPropertyName("status")] string Status,
+        [property: JsonPropertyName("type")] string Type,
         [property: JsonPropertyName("priority")] string Priority,
         [property: JsonPropertyName("due_date")] string? DueDate,
         [property: JsonPropertyName("scheduled")] string? Scheduled,
@@ -2235,6 +2239,7 @@ public sealed class GlassworkTools
         [property: JsonPropertyName("id")] string Id,
         [property: JsonPropertyName("title")] string Title,
         [property: JsonPropertyName("status")] string Status,
+        [property: JsonPropertyName("type")] string Type,
         [property: JsonPropertyName("due_date")] string DueDate,
         [property: JsonPropertyName("days_overdue")] int DaysOverdue,
         [property: JsonPropertyName("priority")] string Priority,

--- a/tests/Glasswork.Mcp.Tests/GetMyDayToolTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GetMyDayToolTests.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+using Glasswork.Mcp.Tools;
+
+namespace Glasswork.Mcp.Tests;
+
+[TestClass]
+public class GetMyDayToolTests
+{
+    private string _vaultDir = null!;
+    private GlassworkTools _tools = null!;
+    private VaultService _vault = null!;
+
+    private string TasksDir => Path.Combine(_vaultDir, "wiki", "todo");
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _vaultDir = Path.Combine(Path.GetTempPath(), "glasswork-mcp-getmyday-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_vaultDir);
+        _tools = new GlassworkTools(new VaultContext(_vaultDir));
+        _vault = new VaultService(TasksDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_vaultDir))
+            Directory.Delete(_vaultDir, recursive: true);
+    }
+
+    // ───────────────────────────── get_my_day ─────────────────────────────
+
+    [TestMethod]
+    public void GetMyDay_ReturnsTaskType()
+    {
+        // ARRANGE: two tasks pinned to today (direct pin → My Day, ADR 0013), one a
+        // PBI container and one a default leaf. An agent consuming get_my_day must be
+        // able to tell a container apart from an actionable leaf among returned items.
+        _vault.Save(new GlassworkTask
+        {
+            Id = "container-pbi",
+            Title = "Container PBI",
+            Status = GlassworkTask.Statuses.Todo,
+            Type = GlassworkTask.Types.Pbi,
+            MyDay = DateTime.Today
+        });
+        _vault.Save(new GlassworkTask
+        {
+            Id = "leaf-task",
+            Title = "Leaf Task",
+            Status = GlassworkTask.Statuses.Todo,
+            MyDay = DateTime.Today
+        });
+
+        // ACT
+        var json = _tools.GetMyDay();
+
+        // ASSERT: both surface, each carrying its own type (order-independent lookup)
+        using var doc = JsonDocument.Parse(json);
+        var tasks = doc.RootElement.GetProperty("tasks");
+        Assert.AreEqual(2, tasks.GetArrayLength(), "Both pinned tasks should be in My Day.");
+
+        var typesById = new Dictionary<string, string>();
+        foreach (var t in tasks.EnumerateArray())
+        {
+            typesById[t.GetProperty("id").GetString()!] = t.GetProperty("type").GetString()!;
+        }
+
+        Assert.AreEqual("pbi", typesById["container-pbi"], "PBI container must report type 'pbi'.");
+        Assert.AreEqual("task", typesById["leaf-task"], "Default leaf must report type 'task'.");
+    }
+}

--- a/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
@@ -591,6 +591,28 @@ public class GlassworkToolsTests
     }
 
     [TestMethod]
+    public void ListTasks_FieldsType_ReturnsType()
+    {
+        // Opt-in `type` projection: an agent can request the work-item kind on the
+        // list_tasks sibling, mirroring get_my_day / list_overdue. Default shape is
+        // untouched — the field only appears when explicitly requested.
+        _vault.Save(new GlassworkTask
+        {
+            Id = "bug-task",
+            Title = "Bug task",
+            Status = GlassworkTask.Statuses.Todo,
+            Type = GlassworkTask.Types.Bug,
+        });
+
+        var json = _tools.ListTasks(fields: new[] { "type" });
+        var first = JsonDocument.Parse(json).RootElement.GetProperty("tasks")[0];
+
+        var keys = first.EnumerateObject().Select(p => p.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray();
+        CollectionAssert.AreEqual(new[] { "id", "type" }, keys, "Projection must contain exactly id + type.");
+        Assert.AreEqual("bug", first.GetProperty("type").GetString());
+    }
+
+    [TestMethod]
     public void ListTasks_ParentIdInOutput_IsNullWhenNoParent()
     {
         _tools.AddTask("Standalone Task");

--- a/tests/Glasswork.Mcp.Tests/ListOverdueToolTests.cs
+++ b/tests/Glasswork.Mcp.Tests/ListOverdueToolTests.cs
@@ -225,4 +225,30 @@ public class ListOverdueToolTests
         Assert.AreEqual(1, tasks.GetArrayLength());
         Assert.AreEqual("t-overdue-myday", tasks[0].GetProperty("id").GetString());
     }
+
+    [TestMethod]
+    public void ListOverdue_ReturnsTaskType()
+    {
+        // ARRANGE: an overdue PBI. list_overdue is NOT type-gated, so PBIs appear
+        // here; surfacing `type` lets a morning-review agent tell a container from a
+        // leaf among returned items.
+        _vault.Save(new GlassworkTask
+        {
+            Id = "overdue-pbi",
+            Title = "Overdue PBI",
+            Status = GlassworkTask.Statuses.Todo,
+            Type = GlassworkTask.Types.Pbi,
+            Due = DateTime.Today.AddDays(-1),
+            Created = DateTime.Today.AddDays(-7)
+        });
+
+        // ACT
+        var json = _tools.ListOverdue();
+
+        // ASSERT
+        using var doc = JsonDocument.Parse(json);
+        var tasks = doc.RootElement.GetProperty("tasks");
+        Assert.AreEqual(1, tasks.GetArrayLength(), "Overdue PBI should be returned.");
+        Assert.AreEqual("pbi", tasks[0].GetProperty("type").GetString(), "Overdue item must carry its type.");
+    }
 }


### PR DESCRIPTION
## What & why

ADR 0016 added an explicit task `type` (`task` / `pbi` / `bug`) and gated PBIs out of `TaskService.GetMyDay`, but the agent-facing MCP DTOs omitted `type` — so agents consuming `get_my_day` couldn't distinguish a **container** (`pbi`) from an **actionable leaf** among returned items. This is the deferred follow-up from the #335 dual review.

Purely additive: surface `type` on the agent-facing task projections. `GlassworkTask.Type` already exists and is normalized on load, so this is just emitting an existing model property — no behavior change, no contract break.

## Scope (A + B + C)

| Surface | Change |
|---|---|
| **A.** `get_my_day` → `MyDayTask` | new `type` field *(required by #339)* |
| **B.** `list_overdue` → `OverdueTask` | new `type` field *(`list_overdue` is **not** type-gated, so PBIs genuinely appear here — highest value for morning-review agents)* |
| **C.** `list_tasks` projected mode | `type` added to the opt-in `AllowedSummaryFields` allowlist + `ProjectTaskSummary` + the `fields` parameter description |

Each projection emits `GlassworkTask.Types.Normalize(...)` so only `task|pbi|bug` ever leaves the tool (explicit DTO-boundary contract).

### Explicitly out of scope
- `list_tasks` **default** `TaskSummary` shape and the other fixed-shape summaries (`search_tasks`, `list_subtasks`, `load_context`) — adding an always-present field there is a contract change, a separate consistency pass.
- `get_task` full read; no new ADR (ADR 0016's Consequences already anticipated surfacing `type` on the agent path).

## Tests (TDD, RED→GREEN per slice)
- New `GetMyDayToolTests.GetMyDay_ReturnsTaskType` — two tasks pinned today (a `pbi` + a default leaf); asserts `count == 2` then looks up each by `id` (order-independent) and checks `type`.
- `ListOverdueToolTests.ListOverdue_ReturnsTaskType` — overdue `pbi` → `type == "pbi"`.
- `GlassworkToolsTests.ListTasks_FieldsType_ReturnsType` — `fields: ["type"]` on a `bug` task; asserts projected keys are exactly `id` + `type` and `type == "bug"`.

Full suites green locally: **Glasswork.Mcp.Tests 224/224**, **Glasswork.Tests 895/895**, no regressions. Core/MCP only, no XAML → hard rule 7 (visual verification) does not apply.

Closes #339

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>