### PR TITLE
Add artifact sharing actions

### DIFF
--- a/scripts/visual-verification/artifacts-share.json
+++ b/scripts/visual-verification/artifacts-share.json
@@ -1,0 +1,32 @@
+{
+  "name": "artifacts-share",
+  "startUri": "glasswork://backlog",
+  "tasks": [
+    {
+      "id": "artifact-share",
+      "title": "Share artifact content",
+      "status": "todo",
+      "artifacts": [
+        {
+          "name": "summary.md",
+          "content": "# Release summary\n\nThis is **markdown** for Teams sharing.\n\n- Copy formatted\n- Copy Markdown\n\n[safe link](https://example.com) and [blocked link](javascript:alert(1)).\n"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    { "type": "select", "automationId": "NavBacklog", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "BacklogHeader", "timeoutMilliseconds": 10000 },
+    { "type": "invoke", "name": "Share artifact content", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "row:Release summary", "timeoutMilliseconds": 15000 },
+    { "type": "expand", "automationId": "row:Release summary", "timeoutMilliseconds": 10000 },
+    { "type": "invoke", "automationId": "share:Release summary", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "ArtifactShareCopyFormatted", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "ArtifactShareCopyMarkdown", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "ArtifactShareSaveCopy", "timeoutMilliseconds": 10000 },
+    { "type": "wait-for", "automationId": "ArtifactShareShowInFolder", "timeoutMilliseconds": 10000 }
+  ],
+  "captures": [
+    { "name": "share-flyout", "waitMilliseconds": 1500 }
+  ]
+}

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml
@@ -490,12 +490,22 @@
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="*" />
                                                 <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="Auto" />
                                             </Grid.ColumnDefinitions>
                                             <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                                                 <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
                                                 <TextBlock Text="{Binding TimeBadge}" Opacity="0.6" FontSize="12" VerticalAlignment="Center" />
                                             </StackPanel>
-                                            <HyperlinkButton Grid.Column="1"
+                                            <Button Grid.Column="1"
+                                                    Content="Share"
+                                                    Tag="{Binding}"
+                                                    Click="ArtifactShare_Click"
+                                                    AutomationProperties.AutomationId="{Binding Title, Converter={StaticResource ArtifactAutoId}, ConverterParameter='share:'}"
+                                                    FontSize="12"
+                                                    Padding="8,2"
+                                                    VerticalAlignment="Center"
+                                                    Margin="8,0,0,0" />
+                                            <HyperlinkButton Grid.Column="2"
                                                              Content="Open in Obsidian"
                                                              Tag="{Binding Path}"
                                                              Click="OpenArtifactInObsidian_Click"

--- a/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
+++ b/src/Glasswork.App/Pages/TaskDetailPage.xaml.cs
@@ -10,6 +10,7 @@ using Glasswork.Core.Services;
 using Glasswork.Services;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media;
@@ -987,6 +988,70 @@ public sealed partial class TaskDetailPage : Page
         var vaultRelative = ToVaultRelativePath(artifactPath);
         if (vaultRelative is null) return;
         await App.ObsidianLauncher.Open(vaultRelative);
+    }
+
+    private void ArtifactShare_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button || button.Tag is not ArtifactRow row)
+        {
+            return;
+        }
+
+        var availability = ArtifactShareFormatter.GetAvailability(row.Artifact);
+        var flyout = new MenuFlyout();
+        flyout.Items.Add(CreateArtifactShareItem(
+            "Copy formatted",
+            "ArtifactShareCopyFormatted",
+            availability.CanCopyFormatted,
+            async () => await ArtifactShareService.CopyToClipboardAsync(row, ArtifactShareClipboardFormat.Formatted)));
+        flyout.Items.Add(CreateArtifactShareItem(
+            "Copy Markdown",
+            "ArtifactShareCopyMarkdown",
+            availability.CanCopyMarkdown,
+            async () => await ArtifactShareService.CopyToClipboardAsync(row, ArtifactShareClipboardFormat.Markdown)));
+        flyout.Items.Add(new MenuFlyoutSeparator());
+        flyout.Items.Add(CreateArtifactShareItem(
+            "Save a copy...",
+            "ArtifactShareSaveCopy",
+            availability.CanSaveCopy,
+            () => ArtifactShareService.SaveCopyAsync(row)));
+        flyout.Items.Add(CreateArtifactShareItem(
+            "Show in folder",
+            "ArtifactShareShowInFolder",
+            availability.CanShowInFolder,
+            () => System.Threading.Tasks.Task.FromResult<string?>(ArtifactShareService.ShowInFolder(row) ?? "Opened artifact folder.")));
+
+        flyout.ShowAt(button);
+    }
+
+    private MenuFlyoutItem CreateArtifactShareItem(
+        string text,
+        string automationId,
+        bool isEnabled,
+        Func<System.Threading.Tasks.Task<string?>> action)
+    {
+        var item = new MenuFlyoutItem
+        {
+            Text = text,
+            IsEnabled = isEnabled,
+        };
+        AutomationProperties.SetAutomationId(item, automationId);
+        item.Click += async (_, _) =>
+        {
+            var message = await action();
+            ShowArtifactShareStatus(message);
+        };
+        return item;
+    }
+
+    private void ShowArtifactShareStatus(string? message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return;
+        }
+
+        ClipboardHint.Text = message;
     }
 
     private static string? ToVaultRelativePath(string absolutePath)

--- a/src/Glasswork.App/Services/ArtifactShareService.cs
+++ b/src/Glasswork.App/Services/ArtifactShareService.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage.Pickers;
+using WinRT.Interop;
+
+namespace Glasswork.Services;
+
+public static class ArtifactShareService
+{
+    public static async Task<string> CopyToClipboardAsync(ArtifactRow row, ArtifactShareClipboardFormat format)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+
+        var availability = ArtifactShareFormatter.GetAvailability(row.Artifact);
+        var canCopy = format == ArtifactShareClipboardFormat.Formatted
+            ? availability.CanCopyFormatted
+            : availability.CanCopyMarkdown;
+        if (!canCopy)
+        {
+            return availability.ContentUnavailableReason ?? "This artifact cannot be copied.";
+        }
+
+        try
+        {
+            var sourceText = await ReadSourceTextAsync(row);
+            var payload = ArtifactShareFormatter.BuildClipboardPayload(row.Artifact, format, sourceText);
+            var package = new DataPackage();
+            package.SetText(payload.PlainText);
+            if (!string.IsNullOrEmpty(payload.HtmlFragment))
+            {
+                package.SetHtmlFormat(HtmlFormatHelper.CreateHtmlFormat(payload.HtmlFragment));
+            }
+
+            Clipboard.SetContent(package);
+            return format == ArtifactShareClipboardFormat.Formatted
+                ? "Copied formatted artifact."
+                : "Copied artifact Markdown.";
+        }
+        catch (Exception ex)
+        {
+            return $"Couldn't copy artifact: {ex.Message}";
+        }
+    }
+
+    public static async Task<string?> SaveCopyAsync(ArtifactRow row)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+
+        if (string.IsNullOrWhiteSpace(row.Path))
+        {
+            return "No file path.";
+        }
+
+        try
+        {
+            var picker = new FileSavePicker
+            {
+                SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
+            };
+
+            var fileName = Path.GetFileName(row.Path);
+            var extension = Path.GetExtension(fileName);
+            if (string.IsNullOrWhiteSpace(extension))
+            {
+                extension = ".artifact";
+                picker.SuggestedFileName = string.IsNullOrWhiteSpace(fileName) ? row.Title : fileName;
+            }
+            else
+            {
+                picker.SuggestedFileName = Path.GetFileNameWithoutExtension(fileName);
+            }
+
+            picker.FileTypeChoices.Add($"{extension.TrimStart('.').ToUpperInvariant()} file", new List<string> { extension });
+
+            var hwnd = WindowNative.GetWindowHandle(App.MainWindow);
+            InitializeWithWindow.Initialize(picker, hwnd);
+
+            var destination = await picker.PickSaveFileAsync();
+            if (destination is null)
+            {
+                return null;
+            }
+
+            await ArtifactShareFileCopier.CopyFileAsync(row.Path, destination.Path);
+            return $"Saved copy to {destination.Path}";
+        }
+        catch (Exception ex)
+        {
+            return $"Couldn't save copy: {ex.Message}";
+        }
+    }
+
+    public static string? ShowInFolder(ArtifactRow row)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+        return ArtifactExternalOpener.ShowInFolder(row.Path);
+    }
+
+    private static async Task<string?> ReadSourceTextAsync(ArtifactRow row)
+    {
+        if (row.Artifact.Body is not null)
+        {
+            return row.Artifact.Body;
+        }
+
+        if (row.Kind == ArtifactKind.Html && row.SizeBytes <= ArtifactCaps.InlineTextBytes)
+        {
+            return await File.ReadAllTextAsync(row.Path);
+        }
+
+        return null;
+    }
+}

--- a/src/Glasswork.Core/Services/ArtifactShareFileCopier.cs
+++ b/src/Glasswork.Core/Services/ArtifactShareFileCopier.cs
@@ -1,0 +1,31 @@
+namespace Glasswork.Core.Services;
+
+public static class ArtifactShareFileCopier
+{
+    public static async Task CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(sourcePath))
+        {
+            throw new ArgumentException("Source path is required.", nameof(sourcePath));
+        }
+
+        if (string.IsNullOrWhiteSpace(destinationPath))
+        {
+            throw new ArgumentException("Destination path is required.", nameof(destinationPath));
+        }
+
+        var resolvedSource = Path.GetFullPath(sourcePath);
+        var resolvedDestination = Path.GetFullPath(destinationPath);
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        if (string.Equals(resolvedSource, resolvedDestination, comparison))
+        {
+            throw new InvalidOperationException("Save copy destination must be different from the source artifact.");
+        }
+
+        await using var source = File.OpenRead(resolvedSource);
+        await using var destination = File.Create(resolvedDestination);
+        await source.CopyToAsync(destination, cancellationToken);
+    }
+}

--- a/src/Glasswork.Core/Services/ArtifactShareFormatter.cs
+++ b/src/Glasswork.Core/Services/ArtifactShareFormatter.cs
@@ -1,0 +1,290 @@
+using System.Net;
+using System.Text;
+using Glasswork.Core.Markdown;
+using Glasswork.Core.Models;
+
+namespace Glasswork.Core.Services;
+
+public enum ArtifactShareClipboardFormat
+{
+    Formatted,
+    Markdown,
+}
+
+public sealed record ArtifactSharePayload(
+    string PlainText,
+    string? HtmlFragment,
+    string SuggestedFileName);
+
+public sealed record ArtifactShareAvailability(
+    bool CanCopyFormatted,
+    bool CanCopyMarkdown,
+    bool CanSaveCopy,
+    bool CanShowInFolder,
+    string? ContentUnavailableReason);
+
+public static class ArtifactShareFormatter
+{
+    public static ArtifactShareAvailability GetAvailability(Artifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var hasPath = !string.IsNullOrWhiteSpace(artifact.Path);
+        var canSaveOrReveal = hasPath;
+
+        if (artifact.LoadError is not null)
+        {
+            return new ArtifactShareAvailability(
+                CanCopyFormatted: false,
+                CanCopyMarkdown: false,
+                CanSaveCopy: canSaveOrReveal,
+                CanShowInFolder: canSaveOrReveal,
+                ContentUnavailableReason: $"Artifact content could not be read: {artifact.LoadError}");
+        }
+
+        return artifact.Kind switch
+        {
+            ArtifactKind.Markdown or ArtifactKind.Text => TextBackedAvailability(artifact, canSaveOrReveal),
+            ArtifactKind.Html => new ArtifactShareAvailability(
+                CanCopyFormatted: artifact.SizeBytes <= ArtifactCaps.InlineTextBytes,
+                CanCopyMarkdown: false,
+                CanSaveCopy: canSaveOrReveal,
+                CanShowInFolder: canSaveOrReveal,
+                ContentUnavailableReason: artifact.SizeBytes > ArtifactCaps.InlineTextBytes
+                    ? "Artifact content is too large to copy."
+                    : null),
+            _ => new ArtifactShareAvailability(
+                CanCopyFormatted: false,
+                CanCopyMarkdown: false,
+                CanSaveCopy: canSaveOrReveal,
+                CanShowInFolder: canSaveOrReveal,
+                ContentUnavailableReason: "This artifact kind has no text content to copy."),
+        };
+    }
+
+    public static ArtifactSharePayload BuildClipboardPayload(
+        Artifact artifact,
+        ArtifactShareClipboardFormat format,
+        string? sourceText = null)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var text = sourceText ?? artifact.Body;
+        if (text is null)
+        {
+            throw new InvalidOperationException("Artifact has no copyable text content.");
+        }
+
+        var html = format switch
+        {
+            ArtifactShareClipboardFormat.Formatted => BuildFormattedHtml(artifact, text),
+            ArtifactShareClipboardFormat.Markdown => null,
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, null),
+        };
+
+        return new ArtifactSharePayload(text, html, GetSuggestedFileName(artifact));
+    }
+
+    private static ArtifactShareAvailability TextBackedAvailability(Artifact artifact, bool canSaveOrReveal)
+    {
+        var hasInlineBody = artifact.Body is not null;
+        return new ArtifactShareAvailability(
+            CanCopyFormatted: hasInlineBody,
+            CanCopyMarkdown: hasInlineBody,
+            CanSaveCopy: canSaveOrReveal,
+            CanShowInFolder: canSaveOrReveal,
+            ContentUnavailableReason: hasInlineBody
+                ? null
+                : artifact.SizeBytes > ArtifactCaps.InlineTextBytes
+                    ? "Artifact content is too large to copy."
+                    : "Artifact content is not available to copy.");
+    }
+
+    private static string BuildFormattedHtml(Artifact artifact, string text)
+    {
+        return artifact.Kind switch
+        {
+            ArtifactKind.Markdown => RenderMarkdown(text),
+            ArtifactKind.Text or ArtifactKind.Html => RenderPreformatted(text),
+            _ => throw new InvalidOperationException("Artifact kind has no formatted text representation."),
+        };
+    }
+
+    private static string RenderMarkdown(string markdown)
+    {
+        var blocks = new VaultMarkdownParser().Parse(markdown);
+        var sb = new StringBuilder();
+        foreach (var block in blocks)
+        {
+            RenderBlock(sb, block);
+        }
+
+        return sb.ToString();
+    }
+
+    private static void RenderBlock(StringBuilder sb, MarkdownBlock block)
+    {
+        switch (block)
+        {
+            case HeadingBlock h:
+                var level = Math.Clamp(h.Level, 1, 6);
+                sb.Append("<h").Append(level).Append('>');
+                RenderInlines(sb, h.Inlines);
+                sb.Append("</h").Append(level).Append('>');
+                break;
+            case ParagraphBlock p:
+                sb.Append("<p>");
+                RenderInlines(sb, p.Inlines);
+                sb.Append("</p>");
+                break;
+            case ListBlock list:
+                sb.Append(list.Ordered ? "<ol>" : "<ul>");
+                foreach (var item in list.Items)
+                {
+                    sb.Append("<li>");
+                    RenderInlines(sb, item.Inlines);
+                    sb.Append("</li>");
+                }
+                sb.Append(list.Ordered ? "</ol>" : "</ul>");
+                break;
+            case CodeBlockNode code:
+                sb.Append("<pre><code");
+                if (!string.IsNullOrWhiteSpace(code.Language))
+                {
+                    sb.Append(" class=\"language-").Append(Html(code.Language)).Append('"');
+                }
+                sb.Append('>').Append(Html(code.Text)).Append("</code></pre>");
+                break;
+            case QuoteBlockNode quote:
+                sb.Append("<blockquote>");
+                foreach (var child in quote.Children)
+                {
+                    RenderBlock(sb, child);
+                }
+                sb.Append("</blockquote>");
+                break;
+            case ThematicBreakNode:
+                sb.Append("<hr>");
+                break;
+            case TableBlock table:
+                RenderTable(sb, table);
+                break;
+            case CalloutBlock callout:
+                sb.Append("<blockquote><p><strong>")
+                    .Append(Html(callout.Title ?? callout.Type.ToString()))
+                    .Append("</strong></p>");
+                foreach (var child in callout.Body)
+                {
+                    RenderBlock(sb, child);
+                }
+                sb.Append("</blockquote>");
+                break;
+            case FallbackPlainTextNode fallback:
+                sb.Append(RenderPreformatted(fallback.Text));
+                break;
+        }
+    }
+
+    private static void RenderTable(StringBuilder sb, TableBlock table)
+    {
+        sb.Append("<table>");
+        sb.Append("<thead><tr>");
+        foreach (var cell in table.Header.Cells)
+        {
+            sb.Append("<th>");
+            RenderInlines(sb, cell.Inlines);
+            sb.Append("</th>");
+        }
+        sb.Append("</tr></thead>");
+
+        if (table.Body.Count > 0)
+        {
+            sb.Append("<tbody>");
+            foreach (var row in table.Body)
+            {
+                sb.Append("<tr>");
+                foreach (var cell in row.Cells)
+                {
+                    sb.Append("<td>");
+                    RenderInlines(sb, cell.Inlines);
+                    sb.Append("</td>");
+                }
+                sb.Append("</tr>");
+            }
+            sb.Append("</tbody>");
+        }
+
+        sb.Append("</table>");
+    }
+
+    private static void RenderInlines(StringBuilder sb, IReadOnlyList<InlineSpan> inlines)
+    {
+        foreach (var inline in inlines)
+        {
+            switch (inline)
+            {
+                case TextSpan text:
+                    sb.Append(Html(text.Text));
+                    break;
+                case BoldSpan bold:
+                    sb.Append("<strong>");
+                    RenderInlines(sb, bold.Inlines);
+                    sb.Append("</strong>");
+                    break;
+                case ItalicSpan italic:
+                    sb.Append("<em>");
+                    RenderInlines(sb, italic.Inlines);
+                    sb.Append("</em>");
+                    break;
+                case CodeSpan code:
+                    sb.Append("<code>").Append(Html(code.Text)).Append("</code>");
+                    break;
+                case LinkSpan link:
+                    RenderLink(sb, link);
+                    break;
+                case ImagePlaceholderSpan image:
+                    sb.Append("<em>[image: ").Append(Html(image.Alt)).Append("]</em>");
+                    break;
+                case HardLineBreakSpan:
+                    sb.Append("<br>");
+                    break;
+                case SoftLineBreakSpan:
+                    sb.Append('\n');
+                    break;
+                case StrikethroughSpan strike:
+                    sb.Append("<s>");
+                    RenderInlines(sb, strike.Inlines);
+                    sb.Append("</s>");
+                    break;
+                case WikiLinkSpan wiki:
+                    sb.Append(Html(wiki.Display ?? wiki.Stem));
+                    break;
+            }
+        }
+    }
+
+    private static void RenderLink(StringBuilder sb, LinkSpan link)
+    {
+        if (ArtifactLinkPolicy.Decide(link.Href) != ArtifactLinkPolicy.Decision.Allow)
+        {
+            RenderInlines(sb, link.Inlines);
+            return;
+        }
+
+        sb.Append("<a href=\"").Append(Html(link.Href)).Append("\">");
+        RenderInlines(sb, link.Inlines);
+        sb.Append("</a>");
+    }
+
+    private static string RenderPreformatted(string text)
+        => "<pre><code>" + Html(text) + "</code></pre>";
+
+    private static string Html(string text)
+        => WebUtility.HtmlEncode(text);
+
+    private static string GetSuggestedFileName(Artifact artifact)
+    {
+        var fileName = Path.GetFileName(artifact.Path);
+        return string.IsNullOrWhiteSpace(fileName) ? artifact.Title : fileName;
+    }
+}

--- a/tests/Glasswork.Tests/ArtifactShareFormatterTests.cs
+++ b/tests/Glasswork.Tests/ArtifactShareFormatterTests.cs
@@ -1,0 +1,212 @@
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+
+namespace Glasswork.Tests;
+
+[TestClass]
+public class ArtifactShareFormatterTests
+{
+    [TestMethod]
+    public void BuildClipboardPayload_MarkdownFormatted_ProducesPlainTextAndHtml()
+    {
+        var markdown = "# Release summary\n\nThis is **ready**.\n\n- Copy\n- Paste";
+        var artifact = new Artifact(
+            Path: @"C:\vault\wiki\todo\task.artifacts\summary.md",
+            Title: "Release summary",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: markdown)
+        {
+            Kind = ArtifactKind.Markdown,
+            SizeBytes = markdown.Length,
+        };
+
+        var payload = ArtifactShareFormatter.BuildClipboardPayload(
+            artifact,
+            ArtifactShareClipboardFormat.Formatted);
+
+        Assert.AreEqual(markdown, payload.PlainText);
+        Assert.IsNotNull(payload.HtmlFragment);
+        StringAssert.Contains(payload.HtmlFragment, "<h1>Release summary</h1>");
+        StringAssert.Contains(payload.HtmlFragment, "<strong>ready</strong>");
+        StringAssert.Contains(payload.HtmlFragment, "<ul>");
+        StringAssert.Contains(payload.HtmlFragment, "<li>Copy</li>");
+        Assert.AreEqual("summary.md", payload.SuggestedFileName);
+    }
+
+    [TestMethod]
+    public void BuildClipboardPayload_MarkdownSource_ProducesPlainTextOnly()
+    {
+        var markdown = "# Release summary\n\nThis is **ready**.";
+        var artifact = new Artifact(
+            Path: @"C:\vault\wiki\todo\task.artifacts\summary.md",
+            Title: "Release summary",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: markdown)
+        {
+            Kind = ArtifactKind.Markdown,
+            SizeBytes = markdown.Length,
+        };
+
+        var payload = ArtifactShareFormatter.BuildClipboardPayload(
+            artifact,
+            ArtifactShareClipboardFormat.Markdown);
+
+        Assert.AreEqual(markdown, payload.PlainText);
+        Assert.IsNull(payload.HtmlFragment);
+    }
+
+    [TestMethod]
+    public void BuildClipboardPayload_MarkdownFormatted_EscapesRawHtmlAndUnsafeLinks()
+    {
+        var markdown = "Before <script>alert(1)</script> [run](javascript:alert(1)) [safe](https://example.com)";
+        var artifact = new Artifact(
+            Path: @"C:\vault\wiki\todo\task.artifacts\unsafe.md",
+            Title: "Unsafe",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: markdown)
+        {
+            Kind = ArtifactKind.Markdown,
+            SizeBytes = markdown.Length,
+        };
+
+        var payload = ArtifactShareFormatter.BuildClipboardPayload(
+            artifact,
+            ArtifactShareClipboardFormat.Formatted);
+
+        StringAssert.Contains(payload.HtmlFragment!, "alert(1)");
+        Assert.IsFalse(payload.HtmlFragment!.Contains("<script>", StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(payload.HtmlFragment.Contains("href=\"javascript:", StringComparison.OrdinalIgnoreCase));
+        StringAssert.Contains(payload.HtmlFragment, " run ");
+        StringAssert.Contains(payload.HtmlFragment, "<a href=\"https://example.com\">safe</a>");
+    }
+
+    [TestMethod]
+    public void BuildClipboardPayload_TextFormatted_ProducesEscapedPreformattedHtml()
+    {
+        var text = "line 1\n<script>alert(1)</script>";
+        var artifact = new Artifact(
+            Path: @"C:\vault\wiki\todo\task.artifacts\notes.log",
+            Title: "notes.log",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: text)
+        {
+            Kind = ArtifactKind.Text,
+            SizeBytes = text.Length,
+        };
+
+        var payload = ArtifactShareFormatter.BuildClipboardPayload(
+            artifact,
+            ArtifactShareClipboardFormat.Formatted);
+
+        Assert.AreEqual(text, payload.PlainText);
+        Assert.AreEqual("<pre><code>line 1\n&lt;script&gt;alert(1)&lt;/script&gt;</code></pre>", payload.HtmlFragment);
+    }
+
+    [TestMethod]
+    public void BuildClipboardPayload_HtmlFormatted_EscapesSourceInsteadOfCopyingExecutableHtml()
+    {
+        var html = "<h1 onclick=\"alert(1)\">Release</h1><script>alert(1)</script>";
+        var artifact = new Artifact(
+            Path: @"C:\vault\wiki\todo\task.artifacts\summary.html",
+            Title: "summary.html",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: null)
+        {
+            Kind = ArtifactKind.Html,
+            SizeBytes = html.Length,
+        };
+
+        var payload = ArtifactShareFormatter.BuildClipboardPayload(
+            artifact,
+            ArtifactShareClipboardFormat.Formatted,
+            html);
+
+        Assert.AreEqual(html, payload.PlainText);
+        Assert.AreEqual("<pre><code>&lt;h1 onclick=&quot;alert(1)&quot;&gt;Release&lt;/h1&gt;&lt;script&gt;alert(1)&lt;/script&gt;</code></pre>", payload.HtmlFragment);
+    }
+
+    [TestMethod]
+    public void GetAvailability_ImageAndOverCapText_DoNotAllowContentCopy()
+    {
+        var image = new Artifact(
+            Path: @"C:\vault\wiki\todo\task.artifacts\screenshot.png",
+            Title: "screenshot.png",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: null)
+        {
+            Kind = ArtifactKind.Image,
+            SizeBytes = 1024,
+        };
+        var overCapText = new Artifact(
+            Path: @"C:\vault\wiki\todo\task.artifacts\huge.log",
+            Title: "huge.log",
+            ModifiedUtc: DateTime.UtcNow,
+            Body: null)
+        {
+            Kind = ArtifactKind.Text,
+            SizeBytes = ArtifactCaps.InlineTextBytes + 1,
+        };
+
+        var imageAvailability = ArtifactShareFormatter.GetAvailability(image);
+        var textAvailability = ArtifactShareFormatter.GetAvailability(overCapText);
+
+        Assert.IsFalse(imageAvailability.CanCopyFormatted);
+        Assert.IsFalse(imageAvailability.CanCopyMarkdown);
+        Assert.IsTrue(imageAvailability.CanSaveCopy);
+        Assert.IsTrue(imageAvailability.CanShowInFolder);
+        Assert.IsFalse(textAvailability.CanCopyFormatted);
+        Assert.IsFalse(textAvailability.CanCopyMarkdown);
+        StringAssert.Contains(textAvailability.ContentUnavailableReason!, "too large");
+    }
+
+    [TestMethod]
+    public async Task CopyFileAsync_PreservesArtifactBytes()
+    {
+        var source = Path.Combine(Path.GetTempPath(), "glasswork-share-source-" + Path.GetRandomFileName());
+        var destination = Path.Combine(Path.GetTempPath(), "glasswork-share-destination-" + Path.GetRandomFileName());
+        var bytes = new byte[] { 0, 1, 2, 3, 254, 255 };
+
+        try
+        {
+            await File.WriteAllBytesAsync(source, bytes);
+
+            await ArtifactShareFileCopier.CopyFileAsync(source, destination);
+
+            CollectionAssert.AreEqual(bytes, await File.ReadAllBytesAsync(destination));
+        }
+        finally
+        {
+            if (File.Exists(source)) File.Delete(source);
+            if (File.Exists(destination)) File.Delete(destination);
+        }
+    }
+
+    [TestMethod]
+    public async Task CopyFileAsync_RejectsSameSourceAndDestinationWithoutTruncatingArtifact()
+    {
+        var source = Path.Combine(Path.GetTempPath(), "glasswork-share-source-" + Path.GetRandomFileName());
+        var bytes = new byte[] { 0, 1, 2, 3, 254, 255 };
+
+        try
+        {
+            await File.WriteAllBytesAsync(source, bytes);
+
+            InvalidOperationException? exception = null;
+            try
+            {
+                await ArtifactShareFileCopier.CopyFileAsync(source, source);
+            }
+            catch (InvalidOperationException ex)
+            {
+                exception = ex;
+            }
+
+            Assert.IsNotNull(exception);
+            CollectionAssert.AreEqual(bytes, await File.ReadAllBytesAsync(source));
+        }
+        finally
+        {
+            if (File.Exists(source)) File.Delete(source);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a compact Share flyout to artifact rows with Copy formatted, Copy Markdown, Save a copy..., and Show in folder.
- Adds a Core artifact share formatter that produces plain-text and sanitized HTML clipboard payloads without allowing artifact editing.
- Adds a WinUI share adapter for Clipboard, FileSavePicker save-copy flow, and Explorer reveal, plus byte-preserving copy safeguards.

## Validation
- `dotnet test tests\Glasswork.Tests\Glasswork.Tests.csproj --filter ArtifactShare --no-restore --nologo --logger "console;verbosity=minimal"`
- `dotnet test tests\Glasswork.Tests\Glasswork.Tests.csproj --no-restore --nologo --logger "console;verbosity=minimal"`
- `dotnet test tests\Glasswork.Mcp.Tests\Glasswork.Mcp.Tests.csproj --no-restore --nologo --logger "console;verbosity=minimal"`
- `dotnet build src\Glasswork.App\Glasswork.csproj -p:Platform=x64 --no-restore --nologo -v minimal -tl:off`
- `pwsh -File scripts\invoke-visual-verification.ps1 -Scenario scripts\visual-verification\artifacts-share.json -NoBuild`
- `pwsh -File scripts\invoke-visual-verification.ps1 -Scenario scripts\visual-verification\artifacts-markdown.json -NoBuild`
- `pwsh -File scripts\invoke-visual-verification.ps1 -Scenario scripts\visual-verification\artifacts-reference.json -NoBuild`

## Visual verification caveat
The visual verification commands completed, and UI Automation found the expected controls including the Share button and flyout entries. However, PNG captures were blank for both the new share scenario and pre-existing artifact scenarios in this environment, suggesting an issue with the screenshot capture path rather than the artifact-sharing UI.