### PR TITLE
feat: add promote_subtask MCP tool

### DIFF
--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -2352,4 +2352,63 @@ public sealed class GlassworkTools
         [property: JsonPropertyName("linking_page_path")] string LinkingPagePath,
         [property: JsonPropertyName("linking_page_title")] string LinkingPageTitle,
         [property: JsonPropertyName("page_type")] string PageType);
+
+    // ───────────────────────────── promote_subtask ─────────────────────────────
+
+    [McpServerTool(Name = "promote_subtask")]
+    [ToolPrecondition(VaultPathReadablePrecondition.PreconditionName)]
+    [Description("Promote an in-file subtask to its own task file, parented to the source task.")]
+    public string PromoteSubtask(
+        [Description("Task ID containing the subtask to promote.")] string task_id,
+        [Description("Zero-based index of the subtask to promote.")] int subtask_index)
+    {
+        using var scope = _logger?.BeginCall("promote_subtask");
+        try
+        {
+            var safeId = SanitizeId(task_id);
+            if (safeId is null || !_vault.Exists(safeId))
+            {
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("task_not_found", $"Task '{task_id}' not found."));
+            }
+
+            var parent = _vault.Load(safeId);
+            if (parent is null)
+            {
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("task_not_found", $"Task '{task_id}' not found."));
+            }
+
+            if (subtask_index < 0 || subtask_index >= parent.Subtasks.Count)
+            {
+                scope?.SetResult("invalid_index");
+                return JsonSerializer.Serialize(new ErrorResult("invalid_subtask_index", 
+                    $"Subtask index {subtask_index} is out of range. Task has {parent.Subtasks.Count} subtasks."));
+            }
+
+            var index = new IndexService(_vault);
+            index.EnsureLoaded();
+            var taskService = new TaskService(_vault, index);
+
+            var writeSw = Stopwatch.StartNew();
+            var newTask = taskService.PromoteSubtask(parent, subtask_index);
+            scope?.RecordPhase("write", writeSw.ElapsedMilliseconds);
+
+            var result = new PromoteSubtaskResult(
+                TaskId: newTask.Id,
+                Path: TodoRelativeTaskPath(newTask.Id));
+
+            scope?.SetResult("success");
+            return JsonSerializer.Serialize(result);
+        }
+        catch
+        {
+            scope?.SetResult("error");
+            throw;
+        }
+    }
+
+    private sealed record PromoteSubtaskResult(
+        [property: JsonPropertyName("task_id")] string TaskId,
+        [property: JsonPropertyName("path")] string Path);
 }

--- a/tests/Glasswork.Mcp.Tests/PromoteSubtaskToolTests.cs
+++ b/tests/Glasswork.Mcp.Tests/PromoteSubtaskToolTests.cs
@@ -1,0 +1,161 @@
+using System.Text.Json;
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+using Glasswork.Mcp.Tools;
+
+namespace Glasswork.Mcp.Tests;
+
+/// <summary>
+/// Tests for promote_subtask MCP tool (issue #346).
+/// Wraps TaskService.PromoteSubtask with SelfWriteCoordinator integration.
+/// </summary>
+[TestClass]
+public class PromoteSubtaskToolTests
+{
+    private string _vaultDir = null!;
+    private GlassworkTools _tools = null!;
+    private VaultService _vault = null!;
+
+    private string TasksDir => Path.Combine(_vaultDir, "wiki", "todo");
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _vaultDir = Path.Combine(Path.GetTempPath(), "glasswork-mcp-promote-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_vaultDir);
+        _tools = new GlassworkTools(new VaultContext(_vaultDir));
+        _vault = new VaultService(Path.Combine(_vaultDir, "wiki", "todo"));
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_vaultDir))
+            Directory.Delete(_vaultDir, recursive: true);
+    }
+
+    // RED: Write the first failing test - promote_subtask creates new task with parent link
+    [TestMethod]
+    public void PromoteSubtask_CreatesNewTaskWithParentLink()
+    {
+        // Arrange: Create parent task with a subtask
+        var parent = new GlassworkTask
+        {
+            Id = "parent-task",
+            Title = "Parent Task",
+            Subtasks = { new SubTask { Text = "Do the thing", IsCompleted = false } }
+        };
+        _vault.Save(parent);
+
+        // Act: Call promote_subtask MCP tool
+        var json = _tools.PromoteSubtask(parent.Id, subtask_index: 0);
+
+        // Assert: New task file exists with parent link
+        var doc = JsonDocument.Parse(json);
+        var newTaskId = doc.RootElement.GetProperty("task_id").GetString()!;
+        var newTaskPath = doc.RootElement.GetProperty("path").GetString()!;
+
+        Assert.IsFalse(string.IsNullOrEmpty(newTaskId), "New task must have an ID");
+        Assert.AreEqual($"{newTaskId}.md", newTaskPath, "Path must be todo-relative");
+        
+        var promoted = _vault.Load(newTaskId);
+        Assert.IsNotNull(promoted, "New task must exist on disk");
+        Assert.AreEqual("Do the thing", promoted.Title);
+        Assert.AreEqual("parent-task", promoted.Parent);
+
+        // Assert: Subtask removed from parent
+        var reloadedParent = _vault.Load("parent-task")!;
+        Assert.AreEqual(0, reloadedParent.Subtasks.Count, "Subtask must be removed from parent");
+    }
+
+    [TestMethod]
+    public void PromoteSubtask_UnknownTaskId_ReturnsStructuredError()
+    {
+        var json = _tools.PromoteSubtask("nonexistent-task", subtask_index: 0);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.AreEqual("task_not_found", doc.RootElement.GetProperty("error").GetString());
+        Assert.IsTrue(doc.RootElement.TryGetProperty("message", out _), "Error must have message");
+    }
+
+    [TestMethod]
+    public void PromoteSubtask_IndexOutOfRange_ReturnsStructuredError()
+    {
+        var parent = new GlassworkTask
+        {
+            Id = "parent-task",
+            Title = "Parent Task",
+            Subtasks = { new SubTask { Text = "Only subtask", IsCompleted = false } }
+        };
+        _vault.Save(parent);
+
+        var json = _tools.PromoteSubtask(parent.Id, subtask_index: 5);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.AreEqual("invalid_subtask_index", doc.RootElement.GetProperty("error").GetString());
+        Assert.IsTrue(doc.RootElement.TryGetProperty("message", out _), "Error must have message");
+    }
+
+    [TestMethod]
+    public void PromoteSubtask_CompletedSubtask_NewTaskIsDone()
+    {
+        var parent = new GlassworkTask
+        {
+            Id = "parent-task",
+            Title = "Parent Task",
+            Subtasks = { new SubTask { Text = "Already done", IsCompleted = true } }
+        };
+        _vault.Save(parent);
+
+        var json = _tools.PromoteSubtask(parent.Id, subtask_index: 0);
+
+        var doc = JsonDocument.Parse(json);
+        var newTaskId = doc.RootElement.GetProperty("task_id").GetString()!;
+        
+        var promoted = _vault.Load(newTaskId)!;
+        Assert.AreEqual(GlassworkTask.Statuses.Done, promoted.Status, 
+            "Completed subtask must become a done task");
+    }
+
+    [TestMethod]
+    public void PromoteSubtask_RegistersWithSelfWriteCoordinator_MarkerFileExists()
+    {
+        var parent = new GlassworkTask
+        {
+            Id = "parent-task",
+            Title = "Parent Task",
+            Subtasks = { new SubTask { Text = "Subtask", IsCompleted = false } }
+        };
+        _vault.Save(parent);
+
+        _tools.PromoteSubtask(parent.Id, subtask_index: 0);
+
+        var markerFile = Path.Combine(TasksDir, ".glasswork", "recent-writes.json");
+        Assert.IsTrue(File.Exists(markerFile),
+            "SelfWriteCoordinator must write marker file during promote_subtask");
+    }
+
+    [TestMethod]
+    public void PromoteSubtask_RegistersWithSelfWriteCoordinator_MarkerContainsBothPaths()
+    {
+        var parent = new GlassworkTask
+        {
+            Id = "parent-task",
+            Title = "Parent Task",
+            Subtasks = { new SubTask { Text = "Subtask", IsCompleted = false } }
+        };
+        _vault.Save(parent);
+
+        var json = _tools.PromoteSubtask(parent.Id, subtask_index: 0);
+        var doc = JsonDocument.Parse(json);
+        var newTaskPath = doc.RootElement.GetProperty("path").GetString()!;
+
+        var markerFile = Path.Combine(TasksDir, ".glasswork", "recent-writes.json");
+        var markerContent = File.ReadAllText(markerFile);
+        
+        StringAssert.Contains(markerContent, "parent-task.md",
+            "Marker must contain parent task (source rewrite)");
+        StringAssert.Contains(markerContent, Path.GetFileName(newTaskPath),
+            "Marker must contain new task (creation write)");
+    }
+}


### PR DESCRIPTION
# Add promote_subtask MCP Tool

## Summary

Adds `promote_subtask(task_id, subtask_index)` MCP tool that wraps the existing `TaskService.PromoteSubtask` method, enabling agents to lift in-file checklist subtasks into standalone tasks.

## Implementation

- **New MCP tool**: `PromoteSubtask` in `GlassworkTools.cs` (lines 2357-2402)
  - Parameter validation for `task_id` and `subtask_index`
  - Task existence check with structured `task_not_found` error
  - Subtask index range validation with structured `invalid_subtask_index` error
  - Delegates to `TaskService.PromoteSubtask` for core logic
  - Returns JSON with new task id and path

- **Result type**: `PromoteSubtaskResult` record at line 2404

- **Test coverage**: 6 integration tests in `PromoteSubtaskToolTests.cs`
  - Happy path: creates new task with parent link
  - Error cases: unknown task, out-of-range index
  - Completed subtask preservation
  - SelfWriteCoordinator integration (marker file and path verification)

## Architecture

Follows ADR 0007:
- Thin wrapper over Core service
- SelfWriteCoordinator marker held across both writes (new task + parent update)
- Structured error format: `{"error": "code", "message": "description"}`
- Stateless tool, re-reads vault on every call

## Validation

All commands pass:
- ✅ Core build
- ✅ App build (WinUI/Windows)
- ✅ Full test suite (977 tests, all passing)

## Decisions

- Error handling follows existing GlassworkTools pattern: `catch { scope?.SetResult("error"); throw; }` without explicit exception logging (MCP framework handles this)
- Structured error codes match existing conventions: snake_case with descriptive messages

Closes #346
