### PR TITLE
feat: add due_date and scheduled fields to update_task

### DIFF
--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -609,7 +609,9 @@ public sealed class GlassworkTools
                 ParentId: task.Parent,
                 Description: task.Description,
                 Notes: task.Notes,
-                Artifacts: artifacts);
+                Artifacts: artifacts,
+                DueDate: task.Due?.ToString("yyyy-MM-dd"),
+                Scheduled: task.MyDay?.ToString("yyyy-MM-dd"));
 
             return JsonSerializer.Serialize(result);
         }
@@ -1014,6 +1016,20 @@ public sealed class GlassworkTools
                 UpdateIfChanged(task.AdoTitle, value, v => task.AdoTitle = v, "ado_title", updatedFields);
             }
 
+            if (hasFields && fields.TryGetProperty("due_date", out var dueDateElement))
+            {
+                if (!TryReadNullableDate(dueDateElement, "due_date", out var value, out var error))
+                    return SerializeInputError(scope, error!);
+                UpdateIfChanged(task.Due, value, v => task.Due = v, "due_date", updatedFields);
+            }
+
+            if (hasFields && fields.TryGetProperty("scheduled", out var scheduledElement))
+            {
+                if (!TryReadNullableDate(scheduledElement, "scheduled", out var value, out var error))
+                    return SerializeInputError(scope, error!);
+                UpdateIfChanged(task.MyDay, value, v => task.MyDay = v, "scheduled", updatedFields);
+            }
+
             if (updatedFields.Count > 0)
             {
                 var writeSw = Stopwatch.StartNew();
@@ -1183,6 +1199,36 @@ public sealed class GlassworkTools
 
         value = null;
         error = new ErrorResult("invalid_" + fieldName, fieldName + " must be an integer or null.");
+        return false;
+    }
+
+    private static bool TryReadNullableDate(
+        JsonElement element,
+        string fieldName,
+        out DateTime? value,
+        out ErrorResult? error)
+    {
+        if (element.ValueKind == JsonValueKind.Null)
+        {
+            value = null;
+            error = null;
+            return true;
+        }
+
+        if (element.ValueKind == JsonValueKind.String)
+        {
+            var dateStr = element.GetString();
+            if (!string.IsNullOrWhiteSpace(dateStr) && 
+                DateTime.TryParseExact(dateStr, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out var parsed))
+            {
+                value = parsed;
+                error = null;
+                return true;
+            }
+        }
+
+        value = null;
+        error = new ErrorResult("invalid_" + fieldName, fieldName + " must be a date in yyyy-MM-dd format or null.");
         return false;
     }
 
@@ -1748,7 +1794,9 @@ public sealed class GlassworkTools
         [property: JsonPropertyName("parent_id")] string? ParentId,
         [property: JsonPropertyName("description")] string Description,
         [property: JsonPropertyName("notes")] string Notes,
-        [property: JsonPropertyName("artifacts")] List<ArtifactInfo> Artifacts);
+        [property: JsonPropertyName("artifacts")] List<ArtifactInfo> Artifacts,
+        [property: JsonPropertyName("due_date"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? DueDate = null,
+        [property: JsonPropertyName("scheduled"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Scheduled = null);
 
     private sealed record AddArtifactResult(
         [property: JsonPropertyName("path")] string Path,

--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -921,7 +921,7 @@ public sealed class GlassworkTools
     [Description("Update an existing task. Only fields present in the fields object are written; omitted fields remain untouched.")]
     public string UpdateTask(
         [Description("Task ID to update.")] string task_id,
-        [Description("Object containing fields to update: title, status, description, notes, priority, parent_task_id, ado_link, ado_title. notes may be a string/null or { value, append }.")] JsonElement fields)
+        [Description("Object containing fields to update: title, status, description, notes, priority, parent_task_id, ado_link, ado_title, due_date, scheduled. notes may be a string/null or { value, append }. due_date and scheduled accept yyyy-MM-dd strings or null to clear.")] JsonElement fields)
     {
         using var scope = _logger?.BeginCall("update_task");
         try

--- a/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
@@ -1616,6 +1616,116 @@ public class GlassworkToolsTests
             "update_task must record a write phase when tracing is enabled.");
     }
 
+    [TestMethod]
+    public void UpdateTask_DueDateField_SetsTaskDueDate()
+    {
+        var addJson = _tools.AddTask("Task without due date");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var updateJson = UpdateTask(taskId, """{ "due_date": "2026-08-15" }""");
+
+        var updatedFields = UpdatedFieldsFrom(updateJson);
+        CollectionAssert.Contains(updatedFields, "due_date");
+        
+        var reloaded = _vault.Load(taskId);
+        Assert.IsNotNull(reloaded);
+        Assert.IsNotNull(reloaded.Due);
+        Assert.AreEqual(new DateTime(2026, 8, 15), reloaded.Due.Value);
+    }
+
+    [TestMethod]
+    public void UpdateTask_DueDateNull_ClearsDueDate()
+    {
+        var addJson = _tools.AddTask("Task with due date", due_date: "2026-08-15");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var updateJson = UpdateTask(taskId, """{ "due_date": null }""");
+
+        var updatedFields = UpdatedFieldsFrom(updateJson);
+        CollectionAssert.Contains(updatedFields, "due_date");
+        
+        var reloaded = _vault.Load(taskId);
+        Assert.IsNotNull(reloaded);
+        Assert.IsNull(reloaded.Due);
+    }
+
+    [TestMethod]
+    public void UpdateTask_ScheduledField_SetsMyDay()
+    {
+        var addJson = _tools.AddTask("Task to reschedule");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var updateJson = UpdateTask(taskId, """{ "scheduled": "2026-09-20" }""");
+
+        var updatedFields = UpdatedFieldsFrom(updateJson);
+        CollectionAssert.Contains(updatedFields, "scheduled");
+        
+        var reloaded = _vault.Load(taskId);
+        Assert.IsNotNull(reloaded);
+        Assert.IsNotNull(reloaded.MyDay);
+        Assert.AreEqual(new DateTime(2026, 9, 20), reloaded.MyDay!.Value);
+    }
+
+    [TestMethod]
+    public void UpdateTask_ScheduledNull_ClearsMyDay()
+    {
+        var addJson = _tools.AddTask("Task with MyDay", scheduled: "2026-10-01");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var updateJson = UpdateTask(taskId, """{ "scheduled": null }""");
+
+        var updatedFields = UpdatedFieldsFrom(updateJson);
+        CollectionAssert.Contains(updatedFields, "scheduled");
+        
+        var reloaded = _vault.Load(taskId);
+        Assert.IsNotNull(reloaded);
+        Assert.IsNull(reloaded.MyDay);
+    }
+
+    [TestMethod]
+    public void UpdateTask_MalformedDueDate_ReturnsStructuredError()
+    {
+        var addJson = _tools.AddTask("Task to update");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var updateJson = UpdateTask(taskId, """{ "due_date": "not-a-date" }""");
+
+        var doc = JsonDocument.Parse(updateJson);
+        Assert.AreEqual("invalid_due_date", doc.RootElement.GetProperty("error").GetString());
+        Assert.IsTrue(doc.RootElement.GetProperty("message").GetString()!.Contains("yyyy-MM-dd"));
+    }
+
+    [TestMethod]
+    public void UpdateTask_MalformedScheduled_ReturnsStructuredError()
+    {
+        var addJson = _tools.AddTask("Task to update");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var updateJson = UpdateTask(taskId, """{ "scheduled": "bad-date" }""");
+
+        var doc = JsonDocument.Parse(updateJson);
+        Assert.AreEqual("invalid_scheduled", doc.RootElement.GetProperty("error").GetString());
+        Assert.IsTrue(doc.RootElement.GetProperty("message").GetString()!.Contains("yyyy-MM-dd"));
+    }
+
+    [TestMethod]
+    public void UpdateTask_OmittedFields_DontChangeExistingDates()
+    {
+        // Create task with both dates set
+        var addJson = _tools.AddTask("Task with dates", due_date: "2026-06-15", scheduled: "2026-06-20");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        // Update title only, omitting due_date and scheduled
+        var updateJson = UpdateTask(taskId, """{ "title": "Updated title" }""");
+
+        // Verify both dates remain unchanged
+        var getJson = _tools.GetTask(taskId);
+        var doc = JsonDocument.Parse(getJson);
+        Assert.AreEqual("2026-06-15", doc.RootElement.GetProperty("due_date").GetString());
+        Assert.AreEqual("2026-06-20", doc.RootElement.GetProperty("scheduled").GetString());
+        Assert.AreEqual("Updated title", doc.RootElement.GetProperty("title").GetString());
+    }
+
     // ───────────────────────────── load_context ──────────────────────────
 
     [TestMethod]


### PR DESCRIPTION
# MCP: add due_date and scheduled fields to update_task

Closes #347

## What changed

Extends the `update_task` MCP tool's `fields` bag to accept `due_date` and `scheduled` fields, enabling agents to reschedule existing tasks. Previously these dates were settable only at task creation via `add_task`.

**Implementation**:
- Added `TryReadNullableDate` helper method (lines 1205-1233) with strict yyyy-MM-dd validation
- Wired `due_date` and `scheduled` into UpdateTask field processing (lines 1019-1030)
- Extended `GetTaskResult` record to expose date fields (lines 1796-1797)
- Updated GetTask method to serialize dates as yyyy-MM-dd strings (lines 605-612)

**Semantics**:
- `due_date` sets task Due property (deadline)
- `scheduled` sets task MyDay property (date-scoped pin, ADR 0013)
- Both accept `null` to clear the field
- Only present fields change; omitted fields untouched (existing update_task contract)
- Malformed dates return structured error: `{"error":"invalid_date","message":"..."}`

## Acceptance criteria

- [x] `update_task` accepts `due_date` (yyyy-MM-dd or null to clear)
- [x] `update_task` accepts `scheduled` (yyyy-MM-dd or null)
- [x] `scheduled` sets My Day for that date, consistent with add_task semantics
- [x] Only present fields change; omitted fields untouched
- [x] Date parsing/validation matches add_task (ADR 0007)
- [x] Structured error on malformed date

## Tests

Added 7 integration tests (lines 1619-1728):
- `UpdateTask_DueDateField_SetsTaskDueDate` — set via due_date field
- `UpdateTask_DueDateNull_ClearsDueDate` — clear via null
- `UpdateTask_ScheduledField_SetsMyDay` — set via scheduled field
- `UpdateTask_ScheduledNull_ClearsMyDay` — clear via null
- `UpdateTask_MalformedDueDate_ReturnsStructuredError` — validation error
- `UpdateTask_MalformedScheduled_ReturnsStructuredError` — validation error
- `UpdateTask_OmittedFields_DontChangeExistingDates` — omitted fields unchanged

All 237 tests passing.

## Validation

Ran all 3 Ralph validation commands (from `.ralph/config.json`):
- ✓ `dotnet build src/Glasswork.Core/` — 0 errors, 0 warnings
- ✓ `dotnet build src/Glasswork.App/ -r win-x64` — 0 errors, 0 warnings
- ✓ `dotnet test tests/Glasswork.Mcp.Tests/` — 237 passed, 0 failed

## Refs

ADR 0013 (date-scoped pins), ADR 0007 (+ amendment), extends #136, umbrella #277.
