### PR TITLE
feat: expose task type in add_task and update_task

### DIFF
--- a/src/Glasswork.Core/Models/GlassworkTask.cs
+++ b/src/Glasswork.Core/Models/GlassworkTask.cs
@@ -110,14 +110,21 @@ public partial class GlassworkTask : ObservableObject
         /// <summary>
         /// Coerces a raw frontmatter value to a known type, defaulting to
         /// <see cref="Task"/> for null/empty/unrecognized input (case-insensitive).
+        /// ADO container work-item types (Product Backlog Item / User Story / Epic / Feature)
+        /// normalize to <see cref="Pbi"/> (ADR 0016).
         /// </summary>
         public static string Normalize(string? raw)
         {
             if (string.IsNullOrWhiteSpace(raw)) return Task;
-            return raw.Trim().ToLowerInvariant() switch
+            var normalized = raw.Trim().ToLowerInvariant();
+            return normalized switch
             {
                 Pbi => Pbi,
                 Bug => Bug,
+                "product backlog item" => Pbi,
+                "user story" => Pbi,
+                "epic" => Pbi,
+                "feature" => Pbi,
                 _ => Task,
             };
         }

--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -51,6 +51,7 @@ public sealed class GlassworkTools
         [Description("Optional scheduled date (yyyy-MM-dd format). Sets my_day to this future date.")] string? scheduled = null,
         [Description("If true, sets my_day to today.")] bool? my_day = null,
         [Description("Optional notes content. Becomes the Notes section (ADR 0002).")] string? notes = null,
+        [Description("Task type: task, pbi, or bug. Accepts broader aliases (Product Backlog Item/User Story/Epic/Feature → pbi). Defaults to task (ADR 0016).")] string? type = null,
         [Description("Idempotency mode: 'error' (default - fail on duplicate title), 'return_existing' (return existing task), or 'update' (update existing task).")] string? if_exists = null)
     {
         using var scope = _logger?.BeginCall("add_task");
@@ -122,6 +123,7 @@ public sealed class GlassworkTools
                 id = $"{baseId}-{counter++}";
 
             var taskPriority = priority ?? GlassworkTask.Priorities.Medium;
+            var taskType = GlassworkTask.Types.Normalize(type);
 
             DateTime? dueDate = null;
             if (!string.IsNullOrWhiteSpace(due_date) && DateTime.TryParseExact(due_date, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out var parsedDue))
@@ -145,6 +147,7 @@ public sealed class GlassworkTools
                 Title = title,
                 Status = internalStatus,
                 Priority = taskPriority,
+                Type = taskType,
                 Created = DateTime.Today,
                 Parent = safeParent,
                 Description = description ?? string.Empty,
@@ -921,7 +924,7 @@ public sealed class GlassworkTools
     [Description("Update an existing task. Only fields present in the fields object are written; omitted fields remain untouched.")]
     public string UpdateTask(
         [Description("Task ID to update.")] string task_id,
-        [Description("Object containing fields to update: title, status, description, notes, priority, parent_task_id, ado_link, ado_title, due_date, scheduled. notes may be a string/null or { value, append }. due_date and scheduled accept yyyy-MM-dd strings or null to clear.")] JsonElement fields)
+        [Description("Object containing fields to update: title, status, description, notes, priority, type, parent_task_id, ado_link, ado_title, due_date, scheduled. notes may be a string/null or { value, append }. due_date and scheduled accept yyyy-MM-dd strings or null to clear.")] JsonElement fields)
     {
         using var scope = _logger?.BeginCall("update_task");
         try
@@ -988,6 +991,14 @@ public sealed class GlassworkTools
                 if (!TryReadNullableString(priorityElement, "priority", out var value, out var error))
                     return SerializeInputError(scope, error!);
                 UpdateIfChanged(task.Priority, value ?? string.Empty, v => task.Priority = v, "priority", updatedFields);
+            }
+
+            if (hasFields && fields.TryGetProperty("type", out var typeElement))
+            {
+                if (!TryReadNullableString(typeElement, "type", out var value, out var error))
+                    return SerializeInputError(scope, error!);
+                var normalizedType = GlassworkTask.Types.Normalize(value);
+                UpdateIfChanged(task.Type, normalizedType, v => task.Type = v, "type", updatedFields);
             }
 
             if (hasFields && fields.TryGetProperty("parent_task_id", out var parentElement))

--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -106,6 +106,7 @@ public sealed class GlassworkTools
                         if (scheduled != null) updateFields["scheduled"] = scheduled;
                         if (my_day.HasValue) updateFields["my_day"] = my_day.Value;
                         if (notes != null) updateFields["notes"] = notes;
+                        if (type != null) updateFields["type"] = type;
 
                         var fieldsJson = JsonSerializer.Serialize(updateFields);
                         var fieldsElement = JsonDocument.Parse(fieldsJson).RootElement;

--- a/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
@@ -285,6 +285,105 @@ public class GlassworkToolsTests
         StringAssert.Contains(content, "Updated description");
     }
 
+    [TestMethod]
+    public void AddTask_TypeTask_DefaultsToTask()
+    {
+        var json = _tools.AddTask("Regular Task", type: "task");
+        var taskId = JsonDocument.Parse(json).RootElement.GetProperty("task_id").GetString()!;
+        var task = _vault.Load(taskId);
+        
+        Assert.IsNotNull(task);
+        Assert.AreEqual("task", task.Type);
+    }
+
+    [TestMethod]
+    public void AddTask_TypePbi_StoresPbi()
+    {
+        var json = _tools.AddTask("Product Backlog Item", type: "pbi");
+        var taskId = JsonDocument.Parse(json).RootElement.GetProperty("task_id").GetString()!;
+        var task = _vault.Load(taskId);
+        
+        Assert.IsNotNull(task);
+        Assert.AreEqual("pbi", task.Type);
+    }
+
+    [TestMethod]
+    public void AddTask_TypeBug_StoresBug()
+    {
+        var json = _tools.AddTask("Fix the crash", type: "bug");
+        var taskId = JsonDocument.Parse(json).RootElement.GetProperty("task_id").GetString()!;
+        var task = _vault.Load(taskId);
+        
+        Assert.IsNotNull(task);
+        Assert.AreEqual("bug", task.Type);
+    }
+
+    [TestMethod]
+    public void AddTask_TypeProductBacklogItem_NormalizesToPbi()
+    {
+        var json = _tools.AddTask("User Story", type: "Product Backlog Item");
+        var taskId = JsonDocument.Parse(json).RootElement.GetProperty("task_id").GetString()!;
+        var task = _vault.Load(taskId);
+        
+        Assert.IsNotNull(task);
+        Assert.AreEqual("pbi", task.Type);
+    }
+
+    [TestMethod]
+    public void AddTask_TypeUserStory_NormalizesToPbi()
+    {
+        var json = _tools.AddTask("User Story", type: "User Story");
+        var taskId = JsonDocument.Parse(json).RootElement.GetProperty("task_id").GetString()!;
+        var task = _vault.Load(taskId);
+        
+        Assert.IsNotNull(task);
+        Assert.AreEqual("pbi", task.Type);
+    }
+
+    [TestMethod]
+    public void AddTask_TypeEpic_NormalizesToPbi()
+    {
+        var json = _tools.AddTask("Epic", type: "Epic");
+        var taskId = JsonDocument.Parse(json).RootElement.GetProperty("task_id").GetString()!;
+        var task = _vault.Load(taskId);
+        
+        Assert.IsNotNull(task);
+        Assert.AreEqual("pbi", task.Type);
+    }
+
+    [TestMethod]
+    public void AddTask_TypeFeature_NormalizesToPbi()
+    {
+        var json = _tools.AddTask("Feature", type: "Feature");
+        var taskId = JsonDocument.Parse(json).RootElement.GetProperty("task_id").GetString()!;
+        var task = _vault.Load(taskId);
+        
+        Assert.IsNotNull(task);
+        Assert.AreEqual("pbi", task.Type);
+    }
+
+    [TestMethod]
+    public void AddTask_TypeNull_DefaultsToTask()
+    {
+        var json = _tools.AddTask("No Type Specified");
+        var taskId = JsonDocument.Parse(json).RootElement.GetProperty("task_id").GetString()!;
+        var task = _vault.Load(taskId);
+        
+        Assert.IsNotNull(task);
+        Assert.AreEqual("task", task.Type);
+    }
+
+    [TestMethod]
+    public void AddTask_TypeInvalid_DefaultsToTask()
+    {
+        var json = _tools.AddTask("Invalid Type", type: "invalid-type");
+        var taskId = JsonDocument.Parse(json).RootElement.GetProperty("task_id").GetString()!;
+        var task = _vault.Load(taskId);
+        
+        Assert.IsNotNull(task);
+        Assert.AreEqual("task", task.Type);
+    }
+
     // ───────────────────────────── list_tasks ───────────────────────────
 
     [TestMethod]
@@ -1724,6 +1823,108 @@ public class GlassworkToolsTests
         Assert.AreEqual("2026-06-15", doc.RootElement.GetProperty("due_date").GetString());
         Assert.AreEqual("2026-06-20", doc.RootElement.GetProperty("scheduled").GetString());
         Assert.AreEqual("Updated title", doc.RootElement.GetProperty("title").GetString());
+    }
+
+    [TestMethod]
+    public void UpdateTask_TypeToPbi_UpdatesType()
+    {
+        var addJson = _tools.AddTask("Regular Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var updateJson = UpdateTask(taskId, """{ "type": "pbi" }""");
+        var updated = UpdatedFieldsFrom(updateJson);
+
+        CollectionAssert.Contains(updated, "type");
+        var task = _vault.Load(taskId);
+        Assert.AreEqual("pbi", task!.Type);
+    }
+
+    [TestMethod]
+    public void UpdateTask_TypeToBug_UpdatesType()
+    {
+        var addJson = _tools.AddTask("Regular Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var updateJson = UpdateTask(taskId, """{ "type": "bug" }""");
+        var updated = UpdatedFieldsFrom(updateJson);
+
+        CollectionAssert.Contains(updated, "type");
+        var task = _vault.Load(taskId);
+        Assert.AreEqual("bug", task!.Type);
+    }
+
+    [TestMethod]
+    public void UpdateTask_TypeProductBacklogItem_NormalizesToPbi()
+    {
+        var addJson = _tools.AddTask("Regular Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var updateJson = UpdateTask(taskId, """{ "type": "Product Backlog Item" }""");
+        
+        var task = _vault.Load(taskId);
+        Assert.AreEqual("pbi", task!.Type);
+    }
+
+    [TestMethod]
+    public void UpdateTask_TypeUserStory_NormalizesToPbi()
+    {
+        var addJson = _tools.AddTask("Regular Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var updateJson = UpdateTask(taskId, """{ "type": "User Story" }""");
+        
+        var task = _vault.Load(taskId);
+        Assert.AreEqual("pbi", task!.Type);
+    }
+
+    [TestMethod]
+    public void UpdateTask_TypeEpic_NormalizesToPbi()
+    {
+        var addJson = _tools.AddTask("Regular Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var updateJson = UpdateTask(taskId, """{ "type": "Epic" }""");
+        
+        var task = _vault.Load(taskId);
+        Assert.AreEqual("pbi", task!.Type);
+    }
+
+    [TestMethod]
+    public void UpdateTask_TypeFeature_NormalizesToPbi()
+    {
+        var addJson = _tools.AddTask("Regular Task");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var updateJson = UpdateTask(taskId, """{ "type": "Feature" }""");
+        
+        var task = _vault.Load(taskId);
+        Assert.AreEqual("pbi", task!.Type);
+    }
+
+    [TestMethod]
+    public void UpdateTask_TypeInvalid_DefaultsToTask()
+    {
+        var addJson = _tools.AddTask("PBI", type: "pbi");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var updateJson = UpdateTask(taskId, """{ "type": "invalid-type" }""");
+        
+        var task = _vault.Load(taskId);
+        Assert.AreEqual("task", task!.Type);
+    }
+
+    [TestMethod]
+    public void UpdateTask_TypeOmitted_PreservesExistingType()
+    {
+        var addJson = _tools.AddTask("Bug Task", type: "bug");
+        var taskId = JsonDocument.Parse(addJson).RootElement.GetProperty("task_id").GetString()!;
+
+        var updateJson = UpdateTask(taskId, """{ "title": "Updated Bug" }""");
+        var updated = UpdatedFieldsFrom(updateJson);
+
+        CollectionAssert.DoesNotContain(updated, "type");
+        var task = _vault.Load(taskId);
+        Assert.AreEqual("bug", task!.Type);
     }
 
     // ───────────────────────────── load_context ──────────────────────────

--- a/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
+++ b/tests/Glasswork.Mcp.Tests/GlassworkToolsTests.cs
@@ -286,6 +286,24 @@ public class GlassworkToolsTests
     }
 
     [TestMethod]
+    public void AddTask_IfExistsUpdate_UpdatesType()
+    {
+        // Create task with default type
+        var json1 = _tools.AddTask("Task Type Update", description: "Original");
+        var id = JsonDocument.Parse(json1).RootElement.GetProperty("task_id").GetString()!;
+        var task1 = _vault.Load(id);
+        Assert.AreEqual(GlassworkTask.Types.Task, task1!.Type);
+        
+        // Update to PBI via add_task if_exists=update
+        var json2 = _tools.AddTask("Task Type Update", type: "Product Backlog Item", if_exists: "update");
+        var id2 = JsonDocument.Parse(json2).RootElement.GetProperty("task_id").GetString()!;
+        Assert.AreEqual(id, id2); // Same task
+        
+        var task2 = _vault.Load(id);
+        Assert.AreEqual(GlassworkTask.Types.Pbi, task2!.Type);
+    }
+
+    [TestMethod]
     public void AddTask_TypeTask_DefaultsToTask()
     {
         var json = _tools.AddTask("Regular Task", type: "task");


### PR DESCRIPTION
# Summary

Expose task type (`task` / `pbi` / `bug`) in `add_task` and `update_task` MCP tools, enabling agents to create PBIs/bugs and convert between task types.

Closes #348

## Implementation

- **add_task**: Added optional `type` parameter (defaults to `task`)
- **update_task**: Added `type` field to the fields bag for updates
- **Types.Normalize**: Enhanced to handle ADR 0016 aliases:
  - "Product Backlog Item", "User Story", "Epic", "Feature" → `pbi`
  - "Bug" → `bug`
  - null/empty/unrecognized → `task` (default)

## Testing

All 18 type-related tests pass:
- 9 tests for add_task: default behavior, explicit types, normalization, invalid inputs
- 1 test for add_task if_exists="update" type handling (identified in code review)
- 8 tests for update_task: field updates, normalization, invalid inputs, preservation

## Validation

✅ Build Core: passed
✅ Build App (win-x64): passed
✅ Test suite: 977/977 tests passed

## ADR Compliance

- ADR 0016: Type normalization and serialization rules implemented correctly
- ADR 0007: MCP tool boundaries respected

## Code Review Findings

Both GPT-5.5 and Claude Opus 4.7 identified the same high-severity bug:

**Issue**: `add_task` with `if_exists="update"` silently dropped the `type` parameter because it wasn't included in the update fields whitelist.

**Resolution**: Added `if (type != null) updateFields["type"] = type;` to the whitelist (line 109) and added test coverage (`AddTask_IfExistsUpdate_UpdatesType`).