### PR TITLE
feat: add delete_subtask MCP tool

### DIFF
--- a/src/Glasswork.Mcp/Tools/GlassworkTools.cs
+++ b/src/Glasswork.Mcp/Tools/GlassworkTools.cs
@@ -2581,4 +2581,64 @@ public sealed class GlassworkTools
     private sealed record PromoteSubtaskResult(
         [property: JsonPropertyName("task_id")] string TaskId,
         [property: JsonPropertyName("path")] string Path);
+
+    /// <summary>
+    /// Deletes an in-file checklist subtask from a parent task.
+    /// </summary>
+    [McpServerTool(Name = "delete_subtask")]
+    [ToolPrecondition(VaultPathReadablePrecondition.PreconditionName)]
+    [Description("Remove a checklist subtask from a parent task. Returns the updated subtask list.")]
+    public string DeleteSubtask(
+        [Description("Task ID containing the subtask to delete.")] string task_id,
+        [Description("Zero-based index of the subtask to delete.")] int subtask_index)
+    {
+        using var scope = _logger?.BeginCall("delete_subtask");
+        try
+        {
+            var safeId = SanitizeId(task_id);
+            if (safeId is null || !_vault.Exists(safeId))
+            {
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("task_not_found", $"Task '{task_id}' not found."));
+            }
+
+            var parent = _vault.Load(safeId);
+            if (parent is null)
+            {
+                scope?.SetResult("not_found");
+                return JsonSerializer.Serialize(new ErrorResult("task_not_found", $"Task '{task_id}' not found."));
+            }
+
+            if (subtask_index < 0 || subtask_index >= parent.Subtasks.Count)
+            {
+                scope?.SetResult("invalid_index");
+                return JsonSerializer.Serialize(new ErrorResult("invalid_subtask_index", 
+                    $"Subtask index {subtask_index} is out of range. Task has {parent.Subtasks.Count} subtasks."));
+            }
+
+            var index = new IndexService(_vault);
+            index.EnsureLoaded();
+            var taskService = new TaskService(_vault, index);
+
+            var writeSw = Stopwatch.StartNew();
+            taskService.DeleteSubtask(parent, subtask_index);
+            scope?.RecordPhase("write", writeSw.ElapsedMilliseconds);
+
+            // Reload to get the updated subtask list
+            var updated = _vault.Load(safeId)!;
+
+            scope?.SetResult("success");
+            return JsonSerializer.Serialize(new
+            {
+                subtasks = updated.Subtasks.Select(s => new { text = s.Text, status = s.Status }).ToArray(),
+                parent_task_id = updated.Id,
+                removed_index = subtask_index
+            });
+        }
+        catch
+        {
+            scope?.SetResult("error");
+            throw;
+        }
+    }
 }

--- a/tests/Glasswork.Mcp.Tests/DeleteSubtaskToolTests.cs
+++ b/tests/Glasswork.Mcp.Tests/DeleteSubtaskToolTests.cs
@@ -1,0 +1,153 @@
+using System.Text.Json;
+using Glasswork.Core.Models;
+using Glasswork.Core.Services;
+using Glasswork.Mcp.Tools;
+
+namespace Glasswork.Mcp.Tests;
+
+/// <summary>
+/// Tests for delete_subtask MCP tool (issue #349).
+/// Wraps TaskService.DeleteSubtask with SelfWriteCoordinator integration.
+/// </summary>
+[TestClass]
+public class DeleteSubtaskToolTests
+{
+    private string _vaultDir = null!;
+    private GlassworkTools _tools = null!;
+    private VaultService _vault = null!;
+
+    private string TasksDir => Path.Combine(_vaultDir, "wiki", "todo");
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _vaultDir = Path.Combine(Path.GetTempPath(), "glasswork-mcp-delete-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_vaultDir);
+        _tools = new GlassworkTools(new VaultContext(_vaultDir));
+        _vault = new VaultService(Path.Combine(_vaultDir, "wiki", "todo"));
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_vaultDir))
+            Directory.Delete(_vaultDir, recursive: true);
+    }
+
+    // RED: Write the first failing test - delete_subtask removes subtask and persists
+    [TestMethod]
+    public void DeleteSubtask_RemovesAndPersists()
+    {
+        // Arrange: Create parent task with subtasks
+        var parent = new GlassworkTask
+        {
+            Id = "parent-del",
+            Title = "Parent Task",
+            Subtasks =
+            {
+                new SubTask { Text = "keep me" },
+                new SubTask { Text = "delete me" },
+                new SubTask { Text = "also keep" },
+            }
+        };
+        _vault.Save(parent);
+
+        // Act: Call delete_subtask MCP tool
+        var json = _tools.DeleteSubtask(parent.Id, subtask_index: 1);
+
+        // Assert: Returns updated subtask list
+        var doc = JsonDocument.Parse(json);
+        var subtasks = doc.RootElement.GetProperty("subtasks").EnumerateArray().ToList();
+        Assert.AreEqual(2, subtasks.Count, "Must return updated subtask list");
+        Assert.AreEqual("keep me", subtasks[0].GetProperty("text").GetString());
+        Assert.AreEqual("also keep", subtasks[1].GetProperty("text").GetString());
+
+        // Assert: Subtask removed from disk
+        var reloaded = _vault.Load("parent-del")!;
+        Assert.AreEqual(2, reloaded.Subtasks.Count, "Subtask must be persisted on disk");
+        Assert.IsFalse(reloaded.Subtasks.Any(s => s.Text == "delete me"), "Deleted subtask must not exist");
+    }
+
+    [TestMethod]
+    public void DeleteSubtask_UnknownTaskId_ReturnsStructuredError()
+    {
+        var json = _tools.DeleteSubtask("nonexistent-task", subtask_index: 0);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.AreEqual("task_not_found", doc.RootElement.GetProperty("error").GetString());
+        Assert.IsTrue(doc.RootElement.TryGetProperty("message", out _), "Error must have message");
+    }
+
+    [TestMethod]
+    public void DeleteSubtask_IndexOutOfRange_ReturnsStructuredError()
+    {
+        var parent = new GlassworkTask
+        {
+            Id = "parent-task",
+            Title = "Parent Task",
+            Subtasks = { new SubTask { Text = "Only subtask" } }
+        };
+        _vault.Save(parent);
+
+        var json = _tools.DeleteSubtask(parent.Id, subtask_index: 5);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.AreEqual("invalid_subtask_index", doc.RootElement.GetProperty("error").GetString());
+        Assert.IsTrue(doc.RootElement.TryGetProperty("message", out _), "Error must have message");
+    }
+
+    [TestMethod]
+    public void DeleteSubtask_NegativeIndex_ReturnsStructuredError()
+    {
+        var parent = new GlassworkTask
+        {
+            Id = "parent-task",
+            Title = "Parent Task",
+            Subtasks = { new SubTask { Text = "Subtask" } }
+        };
+        _vault.Save(parent);
+
+        var json = _tools.DeleteSubtask(parent.Id, subtask_index: -1);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.AreEqual("invalid_subtask_index", doc.RootElement.GetProperty("error").GetString());
+    }
+
+    [TestMethod]
+    public void DeleteSubtask_RegistersWithSelfWriteCoordinator_MarkerFileExists()
+    {
+        var parent = new GlassworkTask
+        {
+            Id = "parent-task",
+            Title = "Parent Task",
+            Subtasks = { new SubTask { Text = "To delete" } }
+        };
+        _vault.Save(parent);
+
+        _tools.DeleteSubtask(parent.Id, subtask_index: 0);
+
+        var markerFile = Path.Combine(TasksDir, ".glasswork", "recent-writes.json");
+        Assert.IsTrue(File.Exists(markerFile),
+            "SelfWriteCoordinator must write marker file during delete_subtask");
+    }
+
+    [TestMethod]
+    public void DeleteSubtask_RegistersWithSelfWriteCoordinator_MarkerContainsParentPath()
+    {
+        var parent = new GlassworkTask
+        {
+            Id = "parent-task",
+            Title = "Parent Task",
+            Subtasks = { new SubTask { Text = "To delete" } }
+        };
+        _vault.Save(parent);
+
+        _tools.DeleteSubtask(parent.Id, subtask_index: 0);
+
+        var markerFile = Path.Combine(TasksDir, ".glasswork", "recent-writes.json");
+        var markerContent = File.ReadAllText(markerFile);
+        
+        StringAssert.Contains(markerContent, "parent-task.md",
+            "Marker must contain parent task (rewrite)");
+    }
+}


### PR DESCRIPTION
# Add delete_subtask MCP Tool

Closes #349

## Summary

Implements the `delete_subtask` MCP tool so agents can remove checklist subtask items from parent tasks. This is a thin wrapper around the existing `TaskService.DeleteSubtask` method, following the same pattern as `promote_subtask`.

## Changes

- **New Tool**: `delete_subtask(task_id, subtask_index)`
  - Validates task existence and subtask index bounds
  - Returns updated subtask list after deletion
  - Structured error responses for invalid inputs (error codes: `task_not_found`, `invalid_subtask_index`)
- **Test Suite**: `DeleteSubtaskToolTests.cs`
  - 6 integration tests covering success path, error cases, and `SelfWriteCoordinator` integration
  - Tests verify JSON response structure and persistence

## Design Decisions

- **Return format**: Anonymous object with `subtasks`, `parent_task_id`, `removed_index` (matches UpdateSubtask pattern of inline serialization rather than named records)
- **Error codes**: Reused standard patterns from other MCP tools (`task_not_found` for missing tasks, `invalid_subtask_index` for out-of-range indices)

## ADR Compliance

- **ADR 0007**: `SelfWriteCoordinator` integration via `TaskService.DeleteSubtask` (marker file created automatically)
- **ADR 0004**: Operates on in-file checklist subtasks only (not subtask relationships, which are tracked via frontmatter `parent_id`)

## Validation

✅ All 6 new tests pass  
✅ Full test suite passes (977 tests)  
✅ Core build clean  

## Review Notes

(To be updated after dual-model code review)
