### PR TITLE
docs(adr): refresh 0007 tool surface; add 0018 task-deletion decision

### DIFF
--- a/docs/adr/0007-mcp-server.md
+++ b/docs/adr/0007-mcp-server.md
@@ -1,6 +1,7 @@
 # ADR 0007: `glasswork-mcp` — standalone MCP server for typed agent vault access
 
 **Status**: Accepted
+**Amended**: 2026-07-06 — the shipped tool surface has grown well beyond the v1 four; see the [2026-07-06 Amendment](#amendment--2026-07-06-shipped-tool-surface).
 **Context slice**: resolves issue #67 (MCP server); depends on a new prerequisite issue (file-based `SelfWriteCoordinator`); loosely related to #84 (vault settings) and #69 (quick-capture).
 
 ## Context
@@ -43,7 +44,7 @@ Ship the minimum that powers use cases #1 and #3:
 | `get_task` | Return full task content (frontmatter + Description + Notes + artifact filenames) for context |
 | `add_artifact` | Create a sibling markdown file under the task's artifact folder |
 
-**Explicitly deferred to a later milestone**: `update_task`, `add_note`, `set_status`, `list_subtasks`, `add_subtask`, `search_tasks`. The Core services for all of these already exist — they're cheap to add when the agent friction surfaces.
+**Explicitly deferred to a later milestone**: `update_task`, `add_note`, `set_status`, `list_subtasks`, `add_subtask`, `search_tasks`. The Core services for all of these already exist — they're cheap to add when the agent friction surfaces. *(Status: most of these shipped post-v1 — see the [2026-07-06 Amendment](#amendment--2026-07-06-shipped-tool-surface).)*
 
 Tool implementations are **thin wrappers over `Glasswork.Core` services** (`TaskService`, `ArtifactPathResolver`, `FileSystemArtifactStore`). MCP is a transport layer, not a domain layer.
 
@@ -108,6 +109,42 @@ New project: `src/Glasswork.Mcp/Glasswork.Mcp.csproj`.
 - References `Glasswork.Core` only — never `Glasswork.App` (Windows-only, would break Linux/Mac builds).
 - Tests in `tests/Glasswork.Mcp.Tests/` (MSTest, separate project).
 - Solution gains a third app project: `Glasswork.Core`, `Glasswork.App`, `Glasswork.Mcp`.
+
+## Amendment — 2026-07-06: shipped tool surface
+
+The v1 four-tool surface (§3) was the *starting* point, not the ceiling. As of
+2026-07-06 `glasswork-mcp` ships **19 tools**; the "deferred" list in §3 has largely
+landed. Current surface, grouped by verb:
+
+- **Create**: `add_task` (full field coverage — description, parent, status, priority,
+  due date, scheduled, my_day, notes — plus `if_exists` idempotency), `add_artifact`,
+  `add_link`
+- **Read**: `list_tasks`, `get_task`, `search_tasks`, `list_subtasks`, `get_my_day`,
+  `get_artifact`, `list_backlinks`, `list_overdue`, `get_activity`,
+  `get_task_context`, `load_context`
+- **Update**: `update_task` (title / status / description / notes [with append] /
+  priority / parent / ado_link / ado_title), `move_task`, `set_my_day`,
+  `toggle_my_day`
+- **Delete**: `remove_link`
+
+### Remaining gaps (tracked as scoped children of umbrella #277)
+
+- **Subtask writes** — `add_subtask`, `update_subtask` (status / title / notes),
+  `promote_subtask`, `delete_subtask`. The Core methods (`VaultService.AddSubtask`,
+  `TaskService.PromoteSubtask` / `DeleteSubtask`, plus the UI's subtask status-toggle
+  path) already exist; only the MCP wrappers are missing. This is the largest gap —
+  agents can read subtasks but not create or check them off.
+- **`update_task` date fields** — `due_date` and `scheduled` are settable at creation
+  (`add_task`) but have no update path, so an agent can't reschedule or clear a date.
+- **`type` on create/update** — the model carries `type` (`task` / `pbi` / `bug`,
+  ADR 0016) and `get_my_day` surfaces it, but `add_task` / `update_task` can't set it,
+  so agents can't create a PBI or convert task↔PBI.
+- **Task deletion** — no delete-a-task tool exists. The soft-vs-hard decision is
+  ADR 0018 (resolving #207); `delete_subtask` (in-file, low-risk) ships independently.
+
+The boundaries in §9 (stdio-only, vault-only writes, path-traversal guard, optimistic
+concurrency via mtime, self-write marker) continue to govern **every** tool added
+above and every tool still to come.
 
 ## Consequences
 

--- a/docs/adr/0018-mcp-task-deletion.md
+++ b/docs/adr/0018-mcp-task-deletion.md
@@ -1,0 +1,106 @@
+# ADR 0018: MCP task deletion is soft-delete-first (`status: cancelled`); hard delete is an explicit, guarded opt-in
+
+**Status**: Proposed
+**Context slice**: resolves #207 (`delete_task`); `VaultService`, `SelfWriteCoordinator`, `IndexService` (backlinks), `TaskService`; new `delete_subtask` MCP tool (tracked separately, *not* governed by this ADR)
+**Relates to**: ADR 0007 (MCP boundaries — stdio, vault-only writes, self-write marker, optimistic concurrency), ADR 0005 (backlinks watcher + index — deletion breaks link targets), ADR 0016 (task `type` / status enum), ADR 0002 (task prose + artifact siblings)
+
+## Context
+
+Agents create tasks during planning sessions — and therefore create duplicates,
+mistakes, and cancelled work. Without a deletion path, the vault accumulates stale
+`.md` files that pollute `list_tasks`, mislead the agent, and never get cleaned up.
+This is the motivation behind #207, which currently sits in `needs-triage` precisely
+because "delete" is not a clean file operation in Glasswork:
+
+- **Backlinks break.** Other tasks and wiki pages may link to the target. Hard
+  removal orphans those links (ADR 0005). The app tolerates unresolved links, but
+  the information is lost.
+- **Artifacts are owned, not referenced.** A task owns a sibling
+  `<id>.artifacts/` folder (ADR 0002). Hard delete must decide whether that folder
+  and its agent-produced work-products die with the task.
+- **Cascade is cross-file.** In-file checklist subtasks travel with the task, but
+  child *tasks* (`parent:` frontmatter) live in separate files. Deleting a parent
+  PBI must decide those children's fate.
+- **Self-write coordination.** Every deletion must register with the
+  `SelfWriteCoordinator` marker or the running app fires a spurious "external
+  change" banner (ADR 0007). A multi-file cascade must hold the coordinator across
+  *all* deletions, not per-file.
+- **Crash safety.** A mid-cascade crash can orphan children. #207 proposes a
+  `_pending_operation.json` recovery log.
+
+There is currently **no delete-a-task method in `Glasswork.Core` at all** — only
+`TaskService.DeleteSubtask` for in-file checklist items. So this is a genuine green
+field, and the safe default matters more than raw parity with other tools.
+
+## Decision (proposed)
+
+### 1. Default is SOFT delete
+
+`delete_task(task_id)` sets `status: cancelled` (a new value on the status enum) and
+does **not** remove the file.
+
+- Preserves backlink targets, keeps the artifact folder, and is trivially
+  reversible (edit status back).
+- Removes the task from default `list_tasks` / My Day / Backlog views, which already
+  filter by status — this satisfies the "don't pollute the agent's list" goal
+  *without destroying data*.
+- Lowest-risk interaction with the self-write marker (single-file write).
+
+### 2. HARD delete is an explicit, guarded opt-in
+
+`delete_task(task_id, hard: true, cascade_subtasks: bool)`:
+
+- If `hard: true` and child **tasks** exist and `cascade_subtasks: false` → **fail**
+  with a structured error listing the child IDs (mirrors the #207 spec).
+- Hard delete removes the `.md` file **and** its `<id>.artifacts/` folder.
+- Returns `{ deleted_id, title, deleted_children: [...], deleted_artifacts: [...] }`.
+- The entire cascade **acquires the `SelfWriteCoordinator` once and holds it** across
+  every file operation, and writes a `_pending_operation.json` before starting
+  (cleared on completion) for crash recovery.
+
+### 3. Dangling backlinks are tolerated by design
+
+Backlinks to a hard-deleted target are left dangling; the app already tolerates
+unresolved links (ADR 0005). A "target missing" affordance may follow but is out of
+scope here.
+
+### 4. `delete_subtask` is a separate, low-risk tool
+
+Removing an **in-file checklist subtask** is backed by the existing
+`TaskService.DeleteSubtask` and is **not** governed by this ADR's soft/hard/cascade
+machinery. It ships on its own track.
+
+## Consequences
+
+### Positive
+- Safe default: reversible, link- and artifact-preserving, and it already reads as
+  "gone" in every status-filtered view.
+- Agents can still hard-delete when they genuinely mean it.
+- Cascade risk (the dangerous part) is contained behind an explicit flag with a
+  guard, a held coordinator, and a recovery log.
+
+### Negative
+- Adds a `cancelled` status value — a small surface change across views, filters,
+  and the status enum/normalizer.
+- Two deletion semantics to document and test.
+
+### Neutral
+- The hard-delete crash-recovery log (`_pending_operation.json`) is new infra,
+  exercised only on the rare hard cascade.
+
+## Open questions (resolve before moving to Accepted)
+
+1. **Archive by MOVE or by STATUS?** Should soft delete *move* the file to a
+   `<vault>/wiki/todo/.archive/` folder, or only flip `status: cancelled` and leave
+   it in place? Move keeps `list_tasks` scans small; status-only is simpler and keeps
+   Obsidian links resolvable.
+2. **Reversal ergonomics.** Is "edit status back" enough, or do we want an explicit
+   `restore_task` / `undelete` tool?
+3. **PBIs.** Does hard-deleting a PBI container ever make sense, or should containers
+   be soft-delete-only?
+
+## Out of scope
+
+- Bulk deletion.
+- A UI affordance for dangling backlinks (ADR 0005 follow-up).
+- Undo history beyond the reversible `cancelled` status.


### PR DESCRIPTION
## What

Two ADR docs from the CLI-vs-MCP spar analysis:

- **ADR 0007 refresh** — dated amendment documenting the real shipped MCP tool surface (19 tools at the time, grouped by verb) vs. the stale "4 tools at v1" the ADR originally described, plus the remaining write gaps (subtask writes, `update_task` date fields, `type` on create/update, deletion). The original v1 decision is preserved as history.
- **ADR 0018 (Proposed)** — soft-delete-first task deletion (`status: cancelled`), with hard delete as an explicit, guarded opt-in (cascade guard, held `SelfWriteCoordinator`, crash-recovery log). Resolves the open question in #207. Ends with three open questions for maintainer review.

## Why

The spar concluded the goal ("agents easily access + update when needed") is served by *completing the MCP tool surface*, not swapping transport. These ADRs capture that reframe and the one genuine open decision (deletion semantics).

Docs-only. No code changes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>